### PR TITLE
Remove leading slash for paths

### DIFF
--- a/src/Yardarm.UnitTests/Spec/Path/PathParserTests.cs
+++ b/src/Yardarm.UnitTests/Spec/Path/PathParserTests.cs
@@ -39,7 +39,7 @@ namespace Yardarm.UnitTests.Spec.Path
 
             result.Should().BeEquivalentTo(new[]
             {
-                new PathSegment("/some/path", PathSegmentType.Text)
+                new PathSegment("some/path", PathSegmentType.Text)
             });
         }
 
@@ -54,7 +54,7 @@ namespace Yardarm.UnitTests.Spec.Path
 
             result.Should().BeEquivalentTo(new[]
             {
-                new PathSegment("/some/", PathSegmentType.Text),
+                new PathSegment("some/", PathSegmentType.Text),
                 new PathSegment("path", PathSegmentType.Parameter)
             });
         }
@@ -70,7 +70,7 @@ namespace Yardarm.UnitTests.Spec.Path
 
             result.Should().BeEquivalentTo(new[]
             {
-                new PathSegment("/some/", PathSegmentType.Text),
+                new PathSegment("some/", PathSegmentType.Text),
                 new PathSegment("path", PathSegmentType.Parameter),
                 new PathSegment("/withtrailer", PathSegmentType.Text),
             });
@@ -103,7 +103,7 @@ namespace Yardarm.UnitTests.Spec.Path
 
             result.Should().BeEquivalentTo(new[]
             {
-                new PathSegment("/some/", PathSegmentType.Text),
+                new PathSegment("some/", PathSegmentType.Text),
                 new PathSegment("path", PathSegmentType.Parameter),
                 new PathSegment("/and/", PathSegmentType.Text),
                 new PathSegment("someotherpath", PathSegmentType.Parameter),

--- a/src/Yardarm/Spec/Path/PathParser.cs
+++ b/src/Yardarm/Spec/Path/PathParser.cs
@@ -21,12 +21,13 @@ namespace Yardarm.Spec.Path
 
         private static IEnumerable<PathSegment> ParseInternal(string path)
         {
+            int index = 0;
+
             if (path.StartsWith("/"))
             {
-                path = path.Substring(1);
+                index = 1;
             }
 
-            int index = 0;
             while (index < path.Length)
             {
                 int nextParameter = path.IndexOf('{', index);

--- a/src/Yardarm/Spec/Path/PathParser.cs
+++ b/src/Yardarm/Spec/Path/PathParser.cs
@@ -21,6 +21,11 @@ namespace Yardarm.Spec.Path
 
         private static IEnumerable<PathSegment> ParseInternal(string path)
         {
+            if (path.StartsWith("/"))
+            {
+                path = path.Substring(1);
+            }
+
             int index = 0;
             while (index < path.Length)
             {


### PR DESCRIPTION
Motivation
------------
Do to the specifications defined at the link below, if a leading slash is present for a path any path that was attached to the base URI is removed. This causes issues when trying to use embeded paths.

Modification
-------------
 - Added check for leading slash in schema