### PR TITLE
Fix Duplicate Interface List Bug (15)

### DIFF
--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using Yardarm.Helpers;
 
 namespace Yardarm.Enrichment.Schema.Internal
 {
@@ -14,7 +15,7 @@ namespace Yardarm.Enrichment.Schema.Internal
 
         public BaseTypeEnricher(GenerationContext context)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _context = context ?? throw new WellKnownTypes.System.ArgumentNullException(nameof(context));
         }
 
         public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
@@ -27,6 +28,12 @@ namespace Yardarm.Enrichment.Schema.Internal
             }
 
             BaseTypeSyntax[] additionalBaseTypes = feature.GetBaseTypes(context.LocatedElement).ToArray();
+
+            if (target.AddBaseListTypes( != null))
+            {
+                additionalBaseTypes = additionalBaseTypes.Where(additionalBaseType =>
+                    !target.BaseList.Types.Any(currentType => additionalBaseType.ToString() == currentType.ToString()));
+            }
 
             return additionalBaseTypes.Length > 0
                 ? target.AddBaseListTypes(additionalBaseTypes)

--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -14,7 +14,7 @@ namespace Yardarm.Enrichment.Schema.Internal
 
         public BaseTypeEnricher(GenerationContext context)
         {
-            _context = context ?? throw new System.ArgumentNullException(nameof(context));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,

--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -31,7 +31,8 @@ namespace Yardarm.Enrichment.Schema.Internal
             if (target.BaseList != null)
             {
                 additionalBaseTypes = additionalBaseTypes.Where(additionalBaseType =>
-                    !target.BaseList.Types.Any(currentType => additionalBaseType.ToString() == currentType.ToString()));
+                    !target.BaseList.Types.Any(currentType => additionalBaseType.ToString() == currentType.ToString()))
+                    .ToArray();
             }
 
             return additionalBaseTypes.Length > 0

--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Yardarm.Helpers;
 
 namespace Yardarm.Enrichment.Schema.Internal
 {
@@ -15,7 +14,7 @@ namespace Yardarm.Enrichment.Schema.Internal
 
         public BaseTypeEnricher(GenerationContext context)
         {
-            _context = context ?? throw new WellKnownTypes.System.ArgumentNullException(nameof(context));
+            _context = context ?? throw new System.ArgumentNullException(nameof(context));
         }
 
         public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
@@ -29,7 +28,7 @@ namespace Yardarm.Enrichment.Schema.Internal
 
             BaseTypeSyntax[] additionalBaseTypes = feature.GetBaseTypes(context.LocatedElement).ToArray();
 
-            if (target.AddBaseListTypes( != null))
+            if (target.BaseList != null)
             {
                 additionalBaseTypes = additionalBaseTypes.Where(additionalBaseType =>
                     !target.BaseList.Types.Any(currentType => additionalBaseType.ToString() == currentType.ToString()));

--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -26,17 +26,17 @@ namespace Yardarm.Enrichment.Schema.Internal
                 return target;
             }
 
-            BaseTypeSyntax[] additionalBaseTypes = feature.GetBaseTypes(context.LocatedElement).ToArray();
+            var additionalBaseTypes = feature.GetBaseTypes(context.LocatedElement);
 
             if (target.BaseList != null)
             {
                 additionalBaseTypes = additionalBaseTypes.Where(additionalBaseType =>
-                    !target.BaseList.Types.Any(currentType => additionalBaseType.ToString() == currentType.ToString()))
-                    .ToArray();
+                    target.BaseList.Types.Any(currentType => !currentType.IsEquivalentTo(additionalBaseType)));
             }
 
-            return additionalBaseTypes.Length > 0
-                ? target.AddBaseListTypes(additionalBaseTypes)
+            var typesToAdd = additionalBaseTypes.ToArray();
+            return typesToAdd.Length > 0
+                ? target.AddBaseListTypes(typesToAdd)
                 : target;
         }
     }

--- a/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/BaseTypeEnricher.cs
@@ -34,10 +34,7 @@ namespace Yardarm.Enrichment.Schema.Internal
                     target.BaseList.Types.Any(currentType => !currentType.IsEquivalentTo(additionalBaseType)));
             }
 
-            var typesToAdd = additionalBaseTypes.ToArray();
-            return typesToAdd.Length > 0
-                ? target.AddBaseListTypes(typesToAdd)
-                : target;
+            return target.AddBaseListTypes(additionalBaseTypes.ToArray());
         }
     }
 }


### PR DESCRIPTION
Motivation
----
Current Yardarm SDK generation crashes when using discriminators and one of tags due to a Duplicate interface name being added to the syntax list for a given class.

Modifications
----
* Updated BaseTypeEnricher to check if a given interface name exists in the syntax list before blindingly adding it

Result
----
Yardarm should no longer crash when generating sdks with discriminators and one of tags

Fixes #15