### PR TITLE
Upgrade to C# 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0
+        dotnet-version: '5.0.x'
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.401
+        dotnet-version: 5.0
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG VERSION=0.1.0-local
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 ARG VERSION
 WORKDIR /app
 
@@ -17,7 +17,7 @@ RUN dotnet restore Yardarm.sln
 COPY ./src ./
 RUN dotnet pack -c Release -p:VERSION=${VERSION} ./Yardarm.CommandLine/Yardarm.CommandLine.csproj
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 ARG VERSION
 WORKDIR /app
 

--- a/src/Yardarm.Client.UnitTests/Serialization/TypeSerializerRegistryTests.cs
+++ b/src/Yardarm.Client.UnitTests/Serialization/TypeSerializerRegistryTests.cs
@@ -50,11 +50,11 @@ namespace Yardarm.Client.UnitTests.Serialization
 
         public class DefaultConstructorSerializer : ITypeSerializer
         {
-            public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
+            public HttpContent Serialize<T>(T value, string mediaType, ISerializationData serializationData = null) =>
                 throw new NotImplementedException();
 
             public ValueTask<T>
-                DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null) =>
+                DeserializeAsync<T>(HttpContent content, ISerializationData serializationData = null) =>
                 throw new NotImplementedException();
         }
 
@@ -72,11 +72,11 @@ namespace Yardarm.Client.UnitTests.Serialization
                 Registry = registry;
             }
 
-            public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
+            public HttpContent Serialize<T>(T value, string mediaType, ISerializationData serializationData = null) =>
                 throw new NotImplementedException();
 
             public ValueTask<T>
-                DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null) =>
+                DeserializeAsync<T>(HttpContent content, ISerializationData serializationData = null) =>
                 throw new NotImplementedException();
         }
 

--- a/src/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
+++ b/src/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/src/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
+++ b/src/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -28,7 +28,7 @@ namespace RootNamespace.Serialization
                 }
                 : "";
 
-        [return: MaybeNull]
+        [return: NotNullIfNotNull("value")]
         public T Deserialize<T>(string? value) =>
             value != null
                 ? (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value)!

--- a/src/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/Yardarm.Client/Yardarm.Client.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>RootNamespace</RootNamespace>
 
     <Nullable>enable</Nullable>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>
   </PropertyGroup>

--- a/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -15,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <Nullable>enable</Nullable>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <Nullable>enable</Nullable>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Yardarm.UnitTests/Yardarm.UnitTests.csproj
+++ b/src/Yardarm.UnitTests/Yardarm.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9</LangVersion>
 
     <IsPackable>false</IsPackable>

--- a/src/Yardarm.UnitTests/Yardarm.UnitTests.csproj
+++ b/src/Yardarm.UnitTests/Yardarm.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9</LangVersion>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -38,7 +38,7 @@ namespace Yardarm.Generation
 
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(rawText),
                 CSharpParseOptions.Default
-                    .WithLanguageVersion(LanguageVersion.CSharp8)
+                    .WithLanguageVersion(LanguageVersion.CSharp9)
                     .WithPreprocessorSymbols("NETSTANDARD2_0"));
 
             // Annotate the compilation root so we know which resource file it came from

--- a/src/Yardarm/Yardarm.csproj
+++ b/src/Yardarm/Yardarm.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- We must also target netcoreapp3.0 to avoid binding issues with Microsoft.Bcl.AsyncInterfaces when consumed by netcoreapp3.0 and later -->
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <!-- We must also target netcoreapp3.1 to avoid binding issues with Microsoft.Bcl.AsyncInterfaces when consumed by netcoreapp3.1 and later -->
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
 
     <Nullable>enable</Nullable>
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -14,21 +14,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Commands" Version="5.6.0" />
-    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
Get access to new language features.

Modifications
-------------
Change projects and build environment to use C# 9.

Upgrade NuGet packages to latest versions, include latest Roslyn so we
have access to C# 9 when building Yardarm client SDKs.