### PR TITLE
Correct various problems with Docker builds

### DIFF
--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -134,13 +134,26 @@ namespace Yardarm.CommandLine
             {
                 try
                 {
-                    string fullPath = !Path.IsPathFullyQualified(extensionFile)
-                        ? Path.Combine(Directory.GetCurrentDirectory(), extensionFile)
-                        : extensionFile;
+                    if (extensionFile.EndsWith(".dll"))
+                    {
+                        // Appears to be a file reference
 
-                    Assembly assembly = Assembly.LoadFile(fullPath);
+                        string fullPath = !Path.IsPathFullyQualified(extensionFile)
+                            ? Path.Combine(Directory.GetCurrentDirectory(), extensionFile)
+                            : extensionFile;
 
-                    settings.AddExtension(assembly);
+                        Assembly assembly = Assembly.LoadFile(fullPath);
+
+                        settings.AddExtension(assembly);
+                    }
+                    else
+                    {
+                        // Appears to be an assembly name
+
+                        Assembly assembly = Assembly.Load(extensionFile);
+
+                        settings.AddExtension(assembly);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
@@ -104,7 +104,7 @@ namespace Yardarm.Packaging.Internal
                 .SelectMany(
                     _ => lockFile.PackageFolders.Select(p => p.Path),
                     (dependency, folder) =>
-                        Path.Combine(folder, dependency.Library.Name, dependency.Library.Version.ToString(), dependency.Path)
+                        Path.Combine(folder, dependency.Library.Name.ToLowerInvariant(), dependency.Library.Version.ToString(), dependency.Path)
                 )
                 .Where(File.Exists)
                 .ToList();
@@ -115,9 +115,9 @@ namespace Yardarm.Packaging.Internal
             LockFileTargetLibrary netstandardLibrary = netstandardTarget.Libraries.First(p => p.Name == NetStandardLibrary);
 
             string refDirectory = lockFile.PackageFolders.Select(p => p.Path)
-                .Select(p => Path.Combine(p, netstandardLibrary.Name, netstandardLibrary.Version.ToString()))
+                .Select(p => Path.Combine(p, netstandardLibrary.Name.ToLowerInvariant(), netstandardLibrary.Version.ToString()))
                 .First(Directory.Exists);
-            refDirectory = Path.Combine(refDirectory, @"build\netstandard2.0\ref");
+            refDirectory = Path.Combine(refDirectory, "build", "netstandard2.0", "ref");
 
             dependencies.AddRange(Directory.EnumerateFiles(refDirectory, "*.dll"));
 


### PR DESCRIPTION
- Use correct directory separators for Linux. Addresses problems loading
  NetStandard.Library.
- Use lowercase NuGet package names to find files. Addresses issues
  finding package DLLs on Linux, which is case sensitive
- Allow loading extensions by assembly name instead of file path.
  Addresses inability to find the extensions packaged with the .NET
  global tool.