### PR TITLE
Ensure consistent header type names

### DIFF
--- a/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
+++ b/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Internal
@@ -10,18 +11,33 @@ namespace Yardarm.Generation.Internal
     {
         private readonly ITypeGeneratorRegistry _mainRegistry;
         private readonly ITypeGeneratorFactory<TElement> _factory;
+        private readonly OpenApiDocument _document;
 
         private readonly ConcurrentDictionary<ILocatedOpenApiElement<TElement>, ITypeGenerator> _registry =
             new ConcurrentDictionary<ILocatedOpenApiElement<TElement>, ITypeGenerator>(new LocatedElementEqualityComparer<TElement>());
 
-        public TypeGeneratorRegistry(ITypeGeneratorRegistry mainRegistry, ITypeGeneratorFactory<TElement> factory)
+        public TypeGeneratorRegistry(ITypeGeneratorRegistry mainRegistry, ITypeGeneratorFactory<TElement> factory,
+            OpenApiDocument document)
         {
             _mainRegistry = mainRegistry ?? throw new ArgumentNullException(nameof(mainRegistry));
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+            _document = document ?? throw new ArgumentNullException(nameof(document));
         }
 
         public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element) =>
             _registry.GetOrAdd(element, key =>
-                _factory.Create(key, key.Parent != null ? _mainRegistry.Get(key.Parent) : null));
+            {
+                if (LocatedElementEqualityComparer<TElement>.GetIsReferenceEqualDefault() &&
+                    key.Element is IOpenApiReferenceable referenceable && referenceable.Reference != null)
+                {
+                    // When making the new type generator with the factory for a reference, we must ensure
+                    // that we are using the referenced component path for the ILocatedOpenApiElement.
+
+                    var referencedElement = (TElement) _document.ResolveReference(referenceable.Reference);
+                    key = LocatedOpenApiElement.CreateRoot<TElement>(referencedElement, referenceable.Reference.Id);
+                }
+
+                return _factory.Create(key, key.Parent != null ? _mainRegistry.Get(key.Parent) : null);
+            });
     }
 }

--- a/src/Yardarm/Generation/Response/HeaderTypeGenerator.cs
+++ b/src/Yardarm/Generation/Response/HeaderTypeGenerator.cs
@@ -15,7 +15,8 @@ namespace Yardarm.Generation.Response
         {
         }
 
-        protected override YardarmTypeInfo GetTypeInfo() => throw new NotImplementedException();
+        protected override YardarmTypeInfo GetTypeInfo() =>
+            Context.TypeGeneratorRegistry.Get(Element.GetSchemaOrDefault()).TypeInfo;
 
         public override IEnumerable<MemberDeclarationSyntax> Generate() =>
             Context.TypeGeneratorRegistry.Get(Element.GetSchemaOrDefault()).Generate();

--- a/src/Yardarm/Spec/LocatedElementEqualityComparer.cs
+++ b/src/Yardarm/Spec/LocatedElementEqualityComparer.cs
@@ -80,7 +80,7 @@ namespace Yardarm.Spec
 
         // For OpenApiResponse, treat the element in the components section as unequal to an element
         // referencing it in an operation, allowing us to define a separate class for each case.
-        private static bool GetIsReferenceEqualDefault() =>
+        public static bool GetIsReferenceEqualDefault() =>
             typeof(T) != typeof(OpenApiResponse);
     }
 }

--- a/src/Yardarm/Spec/LocatedOpenApiElementExtensions.cs
+++ b/src/Yardarm/Spec/LocatedOpenApiElementExtensions.cs
@@ -16,6 +16,10 @@ namespace Yardarm.Spec
 
         public static bool IsRoot(this ILocatedOpenApiElement element) => element.Parent is null;
 
+        public static bool IsReference<T>(this ILocatedOpenApiElement<T> element)
+            where T : IOpenApiReferenceable =>
+            element.Element.Reference != null;
+
         public static ILocatedOpenApiElement<T> CreateRoot<T>(this T rootItem, string key)
             where T : IOpenApiElement =>
             LocatedOpenApiElement.CreateRoot(rootItem, key);


### PR DESCRIPTION
Motivation
----------
There is a race condition surrounding header references with custom
schemas. If the reference in a response is processed before the header
component then incorrect type names are used.

Modifications
-------------
Add intelligence to the TypeGeneratorRegistry so it always handles
references to components as root elements, even if they are looked up
the first time using a reference to the component.

Rework the ResponseTypeGenerator to get type names from the header type
generator instead of the schema type generator.

Fixes #23