### PR TITLE
Improve command line file path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Yardarm is an OpenAPI 3 SDK Generator for C#. It provides various tools that wil
 ### .NET Core Global Tool
 
 ```sh
-dotnet tool install --global Yardarm.CommandLine --version 0.1.0-alpha003
+dotnet tool install --global Yardarm.CommandLine --version 0.1.0-alpha007
 
 yardarm help generate
 ```
@@ -53,7 +53,7 @@ yardarm help generate
 ### Docker
 
 ```sh
-docker run -it centeredge/yardarm:release-0.1.0-alpha003
+docker run -it centeredge/yardarm:release-0.1.0-alpha007
 
 yardarm help generate
 ```
@@ -62,10 +62,13 @@ yardarm help generate
 
 ```sh
 # Generate a DLL and related files, with Newtonsoft.Json support
-yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -o MySpec.dll --xml MySpec.xml --pdb MySpec.pdb -x Yardarm.NewtonsoftJson.dll
+yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -o output/directory/ -x Yardarm.NewtonsoftJson
 
 # Generate a NuGet package and symbols package, with Newtonsoft.Json support
-yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -nupkg MySpec.nupkg --snupkg MySpec.snupkg -x Yardarm.NewtonsoftJson.dll
+yardarm generate -i my-spec.json -n MySpec -v 1.0.0 --nupkg output/directory/ -x Yardarm.NewtonsoftJson
+
+# Note the trailing slash on the output directory. If there is no trailing slash, it is assumed to be a DLL or nupkg file name.
+# Related files will be output beside that file.
 ```
 
 ## Contributing

--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -169,18 +169,57 @@ namespace Yardarm.CommandLine
             {
                 if (!string.IsNullOrEmpty(_options.OutputFile))
                 {
+                    bool isDirectory = Path.EndsInDirectorySeparator(_options.OutputFile);
+                    if (isDirectory)
+                    {
+                        string directory = _options.OutputFile;
+                        if (!Directory.Exists(directory))
+                        {
+                            Directory.CreateDirectory(directory);
+                        }
+
+                        _options.OutputFile = Path.Combine(directory, $"{_options.AssemblyName}.dll");
+
+                        if (string.IsNullOrEmpty(_options.OutputXmlFile))
+                        {
+                            _options.OutputXmlFile = Path.Combine(directory, $"{_options.AssemblyName}.xml");
+                        }
+
+                        if (string.IsNullOrEmpty(_options.OutputDebugSymbols))
+                        {
+                            _options.OutputDebugSymbols = Path.Combine(directory, $"{_options.AssemblyName}.pdb");
+                        }
+                    }
+                    else
+                    {
+                        var directory = Path.GetDirectoryName(_options.OutputPackageFile) ??
+                                        Directory.GetCurrentDirectory();
+
+                        if (string.IsNullOrEmpty(_options.OutputXmlFile))
+                        {
+                            _options.OutputXmlFile = Path.Combine(directory,
+                                $"{Path.GetFileNameWithoutExtension(_options.OutputFile)}.xml");
+                        }
+
+                        if (string.IsNullOrEmpty(_options.OutputDebugSymbols))
+                        {
+                            _options.OutputDebugSymbols = Path.Combine(directory,
+                                $"{Path.GetFileNameWithoutExtension(_options.OutputFile)}.pdb");
+                        }
+                    }
+
                     var dllStream = File.Create(_options.OutputFile);
                     streams.Add(dllStream);
                     settings.DllOutput = dllStream;
 
-                    if (!string.IsNullOrEmpty(_options.OutputXmlFile))
+                    if (!_options.NoXmlFile && !string.IsNullOrEmpty(_options.OutputXmlFile))
                     {
                         var xmlStream = File.Create(_options.OutputXmlFile);
                         streams.Add(xmlStream);
                         settings.XmlDocumentationOutput = xmlStream;
                     }
 
-                    if (!string.IsNullOrEmpty(_options.OutputDebugSymbols))
+                    if (!_options.NoDebugSymbols && !string.IsNullOrEmpty(_options.OutputDebugSymbols))
                     {
                         var pdbStream = File.Create(_options.OutputDebugSymbols);
                         streams.Add(pdbStream);
@@ -189,11 +228,36 @@ namespace Yardarm.CommandLine
                 }
                 else if (!string.IsNullOrEmpty(_options.OutputPackageFile))
                 {
+                    bool isDirectory = Path.EndsInDirectorySeparator(_options.OutputPackageFile);
+                    if (isDirectory)
+                    {
+                        string directory = _options.OutputPackageFile;
+                        if (!Directory.Exists(directory))
+                        {
+                            Directory.CreateDirectory(directory);
+                        }
+
+                        _options.OutputPackageFile =
+                            Path.Combine(directory, $"{_options.AssemblyName}.{_options.Version}.nupkg");
+
+                        if (string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
+                        {
+                            _options.OutputSymbolsPackageFile = Path.Combine(directory,
+                                $"{_options.AssemblyName}.{_options.Version}.snupkg");
+                        }
+                    }
+                    else if (string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
+                    {
+                        _options.OutputSymbolsPackageFile = Path.Combine(
+                            Path.GetDirectoryName(_options.OutputPackageFile) ?? Directory.GetCurrentDirectory(),
+                            $"{Path.GetFileNameWithoutExtension(_options.OutputSymbolsPackageFile)}.snupkg");
+                    }
+
                     var nupkgStream = File.Create(_options.OutputPackageFile);
                     streams.Add(nupkgStream);
                     settings.NuGetOutput = nupkgStream;
 
-                    if (!string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
+                    if (!_options.NoSymbolsPackageFile && !string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
                     {
                         var snupkgStream = File.Create(_options.OutputSymbolsPackageFile);
                         streams.Add(snupkgStream);

--- a/src/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/Yardarm.CommandLine/GenerateOptions.cs
@@ -22,24 +22,33 @@ namespace Yardarm.CommandLine
 
         #region DLL
 
-        [Option('o', "output", HelpText = "Output .dll file", SetName = "dll")]
+        [Option('o', "output", HelpText = "Output directory or .dll file. Indicate a directory with a trailing slash.", SetName = "dll")]
         public string OutputFile { get; set; }
 
         [Option("xml", HelpText = "Output .xml documentation file", SetName = "dll")]
         public string OutputXmlFile { get; set; }
 
+        [Option("no-xml", HelpText = "Suppress output of .xml documentation", SetName = "dll")]
+        public bool NoXmlFile { get; set; }
+
         [Option("pdb", HelpText = "Output .pdb debug symbols files", SetName = "dll")]
         public string OutputDebugSymbols { get; set; }
+
+        [Option("no-pdb", HelpText = "Suppress output of .pdb debug symbols", SetName = "dll")]
+        public bool NoDebugSymbols { get; set; }
 
         #endregion
 
         #region NuGet
 
-        [Option("nupkg", HelpText = "Output .nupkg package file", SetName = "nuget")]
+        [Option("nupkg", HelpText = "Output directory or .nupkg package file. Indicate a directory with a trailing slash.", SetName = "nuget")]
         public string OutputPackageFile { get; set; }
 
         [Option("snupkg", HelpText = "Output .snupkg symbols package file", SetName = "nuget")]
         public string OutputSymbolsPackageFile { get; set; }
+
+        [Option("no-snupkg", HelpText = "Suppress output of .snupkg symbols package file", SetName = "nuget")]
+        public bool NoSymbolsPackageFile { get; set; }
 
         #endregion
 

--- a/src/Yardarm.CommandLine/Properties/launchSettings.json
+++ b/src/Yardarm.CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Yardarm.CommandLine": {
       "commandName": "Project",
-      "commandLineArgs": "generate -x Yardarm.NewtonsoftJson.dll -o Test.dll --xml Test.xml --pdb Test.pdb -i centeredge-cardsystemapi.yaml -n Test"
+      "commandLineArgs": "generate -n Test -x Yardarm.NewtonsoftJson.dll -o output/ -i centeredge-cardsystemapi.yaml"
     }
   }
 }

--- a/src/Yardarm/Packaging/StreamPackageFile.cs
+++ b/src/Yardarm/Packaging/StreamPackageFile.cs
@@ -26,7 +26,7 @@ namespace Yardarm.Packaging
 
         public string Path { get; }
         public string EffectivePath => Path;
-        public FrameworkName TargetFramework => null;
+        public FrameworkName? TargetFramework => null;
         public NuGetFramework NuGetFramework { get; }
         public DateTimeOffset LastWriteTime { get; }
 


### PR DESCRIPTION
Motivation
----------
The current commandline for output of files and packages is a bit
cumbersome, requiring lots of file paths.

Modifications
-------------
Allow the main output parameters to be a directory (indicated by a
trailing slash). This then outputs all of the files to that directory,
named based on the assembly name. For NuGet packages, include the
version number in the file name.

If the main output parameter is a file, then by default output the
other supporting files to the same directory with the same name, just
changing the extension. This is overridden if a particular path is
provided for that file instead.

Add additional parameters which can suppress the output of unwanted
files.

Fixes #5