### PR TITLE
Move AdditionalProperties to an enricher

### DIFF
--- a/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
@@ -41,7 +41,7 @@ namespace Yardarm.NewtonsoftJson
 
         private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
 
-        public int Priority => 0;
+        public int Priority => 10;
 
         public JsonAdditionalPropertiesEnricher(IJsonSerializationNamespace jsonSerializationNamespace)
         {

--- a/src/Yardarm/Enrichment/Schema/Internal/AdditionalPropertiesEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/AdditionalPropertiesEnricher.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Enrichment.Schema.Internal
+{
+    /// <summary>
+    /// Adds AdditionalProperties to object schemas, but runs after the <see cref="BaseTypeEnricher"/>. This allows
+    /// property shadowing with the new keyword or dropping of unnecessary duplicates.
+    /// </summary>
+    internal class AdditionalPropertiesEnricher : IOpenApiSyntaxNodeEnricher<ClassDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly GenerationContext _context;
+
+        public int Priority => 1;
+
+        public AdditionalPropertiesEnricher(GenerationContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (!context.Element.AdditionalPropertiesAllowed)
+            {
+                return target;
+            }
+
+            (TypeSyntax dictionaryType, TypeSyntax interfaceType) = GetDictionaryType(context);
+
+            string propertyName = _context.NameFormatterSelector.GetFormatter(NameKind.Property)
+                .Format("AdditionalProperties");
+            bool isShadowing = false;
+
+            // Check to see if we're inheriting from a type that already implements AdditionalProperties
+            if (target.BaseList != null)
+            {
+                var semanticModel = context.Compilation.GetSemanticModel(context.SyntaxTree);
+
+                foreach (BaseTypeSyntax baseType in target.BaseList.Types)
+                {
+                    var typeInfo = ModelExtensions.GetTypeInfo(semanticModel, baseType.Type);
+                    if (typeInfo.Type?.TypeKind == TypeKind.Class)
+                    {
+                        if (typeInfo.Type.GetMembers(propertyName)
+                            .OfType<IPropertySymbol>().FirstOrDefault()?
+                            .DeclaringSyntaxReferences.FirstOrDefault()?
+                            .GetSyntax() is PropertyDeclarationSyntax baseMember)
+                        {
+                            if (baseMember.Type.IsEquivalentTo(interfaceType))
+                            {
+                                // The types match, we can just accept the inherited version
+                                return target;
+                            }
+                            else
+                            {
+                                // We must shadow
+                                isShadowing = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return target.AddMembers(GenerateAdditionalPropertiesMembers(dictionaryType, interfaceType,
+                propertyName, isShadowing));
+        }
+
+        private (TypeSyntax dictionartyType, TypeSyntax interfaceType) GetDictionaryType(OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            ILocatedOpenApiElement<OpenApiSchema> additionalProperties =
+                context.LocatedElement.GetAdditionalPropertiesOrDefault();
+            ITypeGenerator schemaGenerator = _context.TypeGeneratorRegistry.Get(additionalProperties);
+
+            TypeSyntax valueType = schemaGenerator.TypeInfo.Name;
+            if (additionalProperties.Element.Nullable)
+            {
+                valueType = NullableType(valueType);
+            }
+
+            var dictionaryType = WellKnownTypes.System.Collections.Generic.DictionaryT.Name(
+                PredefinedType(Token(SyntaxKind.StringKeyword)), valueType);
+
+            var interfaceType = WellKnownTypes.System.Collections.Generic.IDictionaryT.Name(
+                PredefinedType(Token(SyntaxKind.StringKeyword)), valueType);
+
+            return (dictionaryType, interfaceType);
+        }
+
+        private MemberDeclarationSyntax GenerateAdditionalPropertiesMembers(TypeSyntax dictionaryType, TypeSyntax interfaceType,
+            string propertyName, bool isShadowing)
+        {
+            var property = PropertyDeclaration(interfaceType, Identifier(propertyName))
+                .AddSpecialMemberAnnotation(SpecialMembers.AdditionalProperties)
+                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                .AddAccessorListAccessors(
+                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)))
+                .WithInitializer(EqualsValueClause(ObjectCreationExpression(dictionaryType)));
+
+            if (isShadowing)
+            {
+                property = property.AddModifiers(Token(SyntaxKind.NewKeyword));
+            }
+
+            return property;
+        }
+    }
+}

--- a/src/Yardarm/Enrichment/Schema/SchemaEnricherServiceCollectionExtensions.cs
+++ b/src/Yardarm/Enrichment/Schema/SchemaEnricherServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ namespace Yardarm.Enrichment.Schema
                 .AddOpenApiSyntaxNodeEnricher<RequiredPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<DocumentationPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<BaseTypeEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<AdditionalPropertiesEnricher>()
                 .AddSchemaEnrichersCore();
 
         public static IServiceCollection AddSchemaEnrichersCore(this IServiceCollection services)

--- a/src/Yardarm/Generation/Schema/ObjectSchemaGenerator.cs
+++ b/src/Yardarm/Generation/Schema/ObjectSchemaGenerator.cs
@@ -97,27 +97,10 @@ namespace Yardarm.Generation.Schema
         protected virtual IEnumerable<MemberDeclarationSyntax> GenerateAdditionalPropertiesMember(
             ILocatedOpenApiElement<OpenApiSchema> additionalProperties)
         {
+            // The AdditionalProperties element isn't generated here, it's done by the AdditionalPropertiesEnricher
+            // However, we do need to generate the schema now
+
             ITypeGenerator schemaGenerator = Context.TypeGeneratorRegistry.Get(additionalProperties);
-
-            TypeSyntax valueType = schemaGenerator.TypeInfo.Name;
-            if (additionalProperties.Element.Nullable)
-            {
-                valueType = NullableType(valueType);
-            }
-
-            yield return PropertyDeclaration(
-                    WellKnownTypes.System.Collections.Generic.IDictionaryT.Name(
-                        PredefinedType(Token(SyntaxKind.StringKeyword)), valueType),
-                    Identifier(Context.NameFormatterSelector.GetFormatter(NameKind.Property)
-                        .Format("AdditionalProperties")))
-                .AddSpecialMemberAnnotation(SpecialMembers.AdditionalProperties)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)))
-                .WithInitializer(EqualsValueClause(ObjectCreationExpression(
-                    WellKnownTypes.System.Collections.Generic.DictionaryT.Name(
-                        PredefinedType(Token(SyntaxKind.StringKeyword)), valueType))));
 
             if (schemaGenerator.TypeInfo.IsGenerated && additionalProperties.Element.Reference == null)
             {


### PR DESCRIPTION
Motivation
----------
Since enrichers run after all classes are generated, we can look at the
base type (if any) and determine information about its
AdditionalProperties.

Modifications
-------------
Create the enricher and move most of the logic from
ObjectSchemaGenerator to the enricher. Add additional logic to either
specify the shadowing of the base property with a `new` keyword, or
suppress generation altogether.

Tweak the run order of the JsonAddtionalPropertiesEnricher so it runs
afterwards.

Results
-------
If the base class already has AdditionalProperties and the type is the
same (very commonly dynamic), then the child class gets no new
declaration. If the base class uses a different type, then shadow the
declaration in the base class.

Fixes #26