### PR TITLE
Make internal request methods protected

### DIFF
--- a/src/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -40,7 +40,7 @@ namespace Yardarm.Generation.Request
         public MethodDeclarationSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
             ILocatedOpenApiElement<OpenApiMediaType>? mediaType) =>
             GenerateHeader(operation)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                 .WithBody(Block(GenerateStatements(operation)));
 
         protected virtual IEnumerable<StatementSyntax> GenerateStatements(

--- a/src/Yardarm/Generation/Request/BuildContentMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildContentMethodGenerator.cs
@@ -45,7 +45,7 @@ namespace Yardarm.Generation.Request
             {
                 // In the base request class which has no body
                 methodDeclaration = methodDeclaration
-                    .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.VirtualKeyword))
+                    .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                     .WithExpressionBody(ArrowExpressionClause(
                         LiteralExpression(SyntaxKind.NullLiteralExpression)));
             }
@@ -53,7 +53,7 @@ namespace Yardarm.Generation.Request
             {
                 // In an inherited request class which adds a body
                 methodDeclaration = methodDeclaration
-                    .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword))
+                    .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword))
                     .WithBody(Block(GenerateStatements(operation, mediaType)));
             }
 

--- a/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -83,7 +83,7 @@ namespace Yardarm.Generation.Request
             }
 
             return GenerateHeader(operation)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                 .WithExpressionBody(ArrowExpressionClause(
                     pathExpression));
         }

--- a/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
@@ -54,7 +54,7 @@ namespace Yardarm.Generation.Request.Internal
             {
                 CreateBodyPropertyDeclaration(),
                 _buildContentMethodGenerator.GenerateHeader(RequestTypeGenerator.Element)
-                    .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)))
+                    .WithModifiers(TokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)))
                     .WithExpressionBody(ArrowExpressionClause(
                         IdentifierName(RequestMediaTypeGenerator.BodyPropertyName)))
             });


### PR DESCRIPTION
Motivation
----------
Reduce consumer confusion on the API surface.

Modifications
-------------
Make the methods only used by BuildRequest protected instead of public,
and make them virtual as well.

Results
-------
Methods a consumer shouldn't generally need are now hidden, but can
still be accessed and can now be overriden in derived classes.