### PR TITLE
Don't add authenticators to HttpContentRequest classes

### DIFF
--- a/src/Yardarm/Enrichment/Authentication/SecuritySchemeRequestEnricher.cs
+++ b/src/Yardarm/Enrichment/Authentication/SecuritySchemeRequestEnricher.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Generation.Request;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -23,7 +25,7 @@ namespace Yardarm.Enrichment.Authentication
 
         public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiOperation> context) =>
-            context.Element.Security.Count > 0
+            context.Element.Security.Count > 0 && target.GetGeneratorAnnotation() == typeof(RequestTypeGenerator)
                 ? AddSecuritySchemes(target, context.LocatedElement)
                 : target;
 

--- a/src/Yardarm/Generation/GeneratorSyntaxNodeExtensions.cs
+++ b/src/Yardarm/Generation/GeneratorSyntaxNodeExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Yardarm.Generation
+{
+    public static class GeneratorSyntaxNodeExtensions
+    {
+        public const string GeneratorAnnotationName = "YardarmGenerator";
+
+        public static TSyntaxNode AddGeneratorAnnotation<TSyntaxNode>(this TSyntaxNode node,
+            TypeGeneratorBase generator)
+            where TSyntaxNode : SyntaxNode =>
+            node.AddGeneratorAnnotation(generator.GetType());
+
+        public static TSyntaxNode AddGeneratorAnnotation<TSyntaxNode>(this TSyntaxNode node,
+            Type generatorType)
+            where TSyntaxNode : SyntaxNode =>
+            node.WithAdditionalAnnotations(
+                new SyntaxAnnotation(GeneratorAnnotationName, generatorType.FullName));
+
+        public static Type? GetGeneratorAnnotation(this SyntaxNode node)
+        {
+            string? typeName = node.GetAnnotations(GeneratorAnnotationName).FirstOrDefault()?.Data;
+            if (typeName == null)
+            {
+                return null;
+            }
+
+            return Type.GetType(typeName, false);
+        }
+    }
+}

--- a/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
@@ -44,6 +44,7 @@ namespace Yardarm.Generation.Request.Internal
 
             ClassDeclarationSyntax declaration = ClassDeclaration(className)
                 .AddElementAnnotation(Element, Context.ElementRegistry)
+                .AddGeneratorAnnotation(this)
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddBaseListTypes(SimpleBaseType(RequestTypeGenerator.TypeInfo.Name))
                 .AddMembers(ConstructorDeclaration(className)

--- a/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
@@ -65,6 +65,7 @@ namespace Yardarm.Generation.Request
 
             ClassDeclarationSyntax declaration = ClassDeclaration(className)
                 .AddElementAnnotation(Element, Context.ElementRegistry)
+                .AddGeneratorAnnotation(this)
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddBaseListTypes(SimpleBaseType(RequestsNamespace.OperationRequest));
 


### PR DESCRIPTION
Motivation
----------
HttpContextRequest classes don't need authenticators, they're inherited
from the base Request class.

Modifications
-------------
Add a generator annotation system so enrichers can recognize which
generator created a particular declaration.

Suppress security scheme enrichment on OpenApiOperation elements unless
they're from the RequestTypeGenerator.