### PR TITLE
Add MultipartPropertyAttribute for property name override

### DIFF
--- a/src/Yardarm.Client/Serialization/MultipartPropertyAttribute.cs
+++ b/src/Yardarm.Client/Serialization/MultipartPropertyAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace RootNamespace.Serialization
+{
+    /// <summary>
+    /// Annotates a property with the name to use when encoded as multipart/form-data.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    internal class MultipartPropertyAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the property when serialized.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Creates a new MultipartPropertyAttribute.
+        /// </summary>
+        /// <param name="name">Name of the property when serialized.</param>
+        public MultipartPropertyAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Yardarm.NewtonsoftJson/JsonPropertyEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonPropertyEnricher.cs
@@ -2,6 +2,8 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.Generation.MediaType;
 using Yardarm.Helpers;
 using Yardarm.NewtonsoftJson.Helpers;
 
@@ -10,10 +12,18 @@ namespace Yardarm.NewtonsoftJson
     public class JsonPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
     {
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax target,
-            OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            target
-                .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
-                    SyntaxFactory.Attribute(NewtonsoftJsonTypes.JsonPropertyAttributeName).AddArgumentListArguments(
-                        SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (target.Parent is ClassDeclarationSyntax classDeclaration &&
+                classDeclaration.GetGeneratorAnnotation() == typeof(RequestMediaTypeGenerator))
+            {
+                // Don't enrich body properties on the request classes
+                return target;
+            }
+
+            return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
+                SyntaxFactory.Attribute(NewtonsoftJsonTypes.JsonPropertyAttributeName).AddArgumentListArguments(
+                    SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+        }
     }
 }

--- a/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Generation.MediaType;
+using Yardarm.Helpers;
+using Yardarm.Names;
+
+namespace Yardarm.Enrichment.Schema
+{
+    /// <summary>
+    /// Enriches schema class properties with the MultipartPropertyAttribute to support multipart encoding. This is currently
+    /// applied to all schemas because there isn't an easy way to recognize schemas which are used for multipart encoding.
+    /// </summary>
+    public class MultipartPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly ISerializationNamespace _serializationNamespace;
+
+        public MultipartPropertyEnricher(ISerializationNamespace serializationNamespace)
+        {
+            _serializationNamespace = serializationNamespace ?? throw new ArgumentNullException(nameof(serializationNamespace));
+        }
+
+        public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (target.Parent is ClassDeclarationSyntax classDeclaration &&
+                classDeclaration.GetGeneratorAnnotation() == typeof(RequestMediaTypeGenerator))
+            {
+                // Don't enrich body properties on the request classes
+                return target;
+            }
+
+            return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
+                SyntaxFactory.Attribute(_serializationNamespace.MultipartFormDataSerializer)
+                    .AddArgumentListArguments(
+                        SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+        }
+    }
+}

--- a/src/Yardarm/Enrichment/Schema/SchemaEnricherServiceCollectionExtensions.cs
+++ b/src/Yardarm/Enrichment/Schema/SchemaEnricherServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace Yardarm.Enrichment.Schema
                 .AddOpenApiSyntaxNodeEnricher<DocumentationPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<BaseTypeEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<AdditionalPropertiesEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<MultipartPropertyEnricher>()
                 .AddSchemaEnrichersCore();
 
         public static IServiceCollection AddSchemaEnrichersCore(this IServiceCollection services)

--- a/src/Yardarm/Generation/MediaType/RequestMediaTypeGenerator.cs
+++ b/src/Yardarm/Generation/MediaType/RequestMediaTypeGenerator.cs
@@ -87,6 +87,7 @@ namespace Yardarm.Generation.MediaType
 
             ClassDeclarationSyntax declaration = ClassDeclaration(className)
                 .AddElementAnnotation(Element, Context.ElementRegistry)
+                .AddGeneratorAnnotation(this)
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddBaseListTypes(SimpleBaseType(RequestTypeGenerator.TypeInfo.Name))
                 .AddMembers(ConstructorDeclaration(className)

--- a/src/Yardarm/Names/ISerializationNamespace.cs
+++ b/src/Yardarm/Names/ISerializationNamespace.cs
@@ -10,6 +10,7 @@ namespace Yardarm.Names
         NameSyntax ITypeSerializer { get; }
         NameSyntax ITypeSerializerRegistry { get; }
         NameSyntax MultipartFormDataSerializer { get; }
+        NameSyntax MultipartPropertyAttribute { get; }
         NameSyntax PathSegmentStyle { get; }
         NameSyntax PathSegmentSerializer { get; }
         ExpressionSyntax PathSegmentSerializerInstance { get; }

--- a/src/Yardarm/Names/Internal/SerializationNamespace.cs
+++ b/src/Yardarm/Names/Internal/SerializationNamespace.cs
@@ -14,6 +14,7 @@ namespace Yardarm.Names.Internal
         public NameSyntax ITypeSerializer { get; }
         public NameSyntax ITypeSerializerRegistry { get; }
         public NameSyntax MultipartFormDataSerializer { get; }
+        public NameSyntax MultipartPropertyAttribute { get; }
         public NameSyntax PathSegmentStyle { get; }
         public NameSyntax PathSegmentSerializer { get; }
         public ExpressionSyntax PathSegmentSerializerInstance { get; }
@@ -48,6 +49,10 @@ namespace Yardarm.Names.Internal
             MultipartFormDataSerializer = QualifiedName(
                 Name,
                 IdentifierName("MultipartFormDataSerializer"));
+
+            MultipartFormDataSerializer = QualifiedName(
+                Name,
+                IdentifierName("MultipartPropertyAttribute"));
 
             PathSegmentStyle = QualifiedName(
                 Name,


### PR DESCRIPTION
Motivation
----------
Much like JsonProperty for Newtonsoft.Json, we need some attribute to
indicate the attribute name (with correct casing) to use when
serializing a schema using multipart/form-data encoding.

Modifications
-------------
Add a new attribute and apply it using an enricher to all schema
properties.

Drop the JsonProperty attribute which was being incorrectly applied to
the body property of Request classes.