### PR TITLE
Store multipart encodings on attributes on the request class

### DIFF
--- a/src/Yardarm.Client/Serialization/MultipartEncodingAttribute.cs
+++ b/src/Yardarm.Client/Serialization/MultipartEncodingAttribute.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace RootNamespace.Serialization
+{
+    /// <summary>
+    /// Decorates a multipart encoded request class to provide the media types
+    /// which are acceptable on each property in the request body. One attribute
+    /// should be applied per property.
+    /// </summary>
+    /// <remarks>
+    /// This class is placed on the request class rather than the schema property to
+    /// align with OpenAPI 3. The encoding information is part of the request media
+    /// type, not part of the schema. The same schema could be used with multiple
+    /// requests with different media types.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class MultipartEncodingAttribute : Attribute
+    {
+        /// <summary>
+        /// Name of the property described by this attribute.
+        /// </summary>
+        public string PropertyName { get; set; }
+
+        /// <summary>
+        /// List of acceptable media types.
+        /// </summary>
+        public string[] MediaTypes { get; set; }
+
+        public MultipartEncodingAttribute(string propertyName, params string[] mediaTypes)
+        {
+            PropertyName = propertyName;
+            MediaTypes = mediaTypes;
+        }
+    }
+}

--- a/src/Yardarm/Enrichment/Requests/RequestEnricherServiceCollectionExtensions.cs
+++ b/src/Yardarm/Enrichment/Requests/RequestEnricherServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Yardarm.Enrichment.Requests
             services
                 .AddOpenApiSyntaxNodeEnricher<RequestClassMethodDocumentationEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<RequestInterfaceMethodDocumentationEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<RequestMultipartEncodingEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<RequestParameterDocumentationEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<RequiredBodyRequestEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<RequiredParameterEnricher>();

--- a/src/Yardarm/Enrichment/Requests/RequestMultipartEncodingEnricher.cs
+++ b/src/Yardarm/Enrichment/Requests/RequestMultipartEncodingEnricher.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Generation.MediaType;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Enrichment.Requests
+{
+    public class RequestMultipartEncodingEnricher : IOpenApiSyntaxNodeEnricher<ClassDeclarationSyntax, OpenApiMediaType>
+    {
+        // Default encodings when the spec doesn't specify the encoding
+        private static readonly AttributeArgumentSyntax[] PlainTextEncoding =
+        {
+            AttributeArgument(SyntaxHelpers.StringLiteral("text/plain"))
+        };
+
+        private static readonly AttributeArgumentSyntax[] JsonEncoding =
+        {
+            AttributeArgument(SyntaxHelpers.StringLiteral("application/json"))
+        };
+
+        private static readonly AttributeArgumentSyntax[] OctetStreamEncoding =
+        {
+            AttributeArgument(SyntaxHelpers.StringLiteral("application/octet-stream"))
+        };
+
+        private readonly ISerializationNamespace _serializationNamespace;
+
+        public RequestMultipartEncodingEnricher(ISerializationNamespace serializationNamespace)
+        {
+            _serializationNamespace = serializationNamespace ?? throw new ArgumentNullException(nameof(serializationNamespace));
+        }
+
+        public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiMediaType> context) =>
+            target.GetGeneratorAnnotation() == typeof(RequestMediaTypeGenerator)
+                ? AddEncodingAttributes(target, context.Element)
+                : target;
+
+        private ClassDeclarationSyntax AddEncodingAttributes(ClassDeclarationSyntax target,
+            OpenApiMediaType element) =>
+            target.AddAttributeLists(AttributeList(SeparatedList(
+                GetProperties(element)
+                    .Select(p =>
+                    {
+                        element.Encoding.TryGetValue(p.Key, out OpenApiEncoding? encoding);
+
+                        return CreateAttribute(p.Key, p.Value, encoding);
+                    }))));
+
+        private AttributeSyntax CreateAttribute(string propertyName, OpenApiSchema propertySchema, OpenApiEncoding? encoding)
+        {
+            var mediaTypes = encoding?.ContentType != null
+                ? GetMediaTypes(encoding.ContentType)
+                    .Select(p => AttributeArgument(SyntaxHelpers.StringLiteral(p)))
+                    .ToArray()
+                : null;
+
+            if (mediaTypes == null || mediaTypes.Length == 0)
+            {
+                mediaTypes = SelectDefaultMediaTypes(propertySchema);
+            }
+
+            return Attribute(_serializationNamespace.MultipartEncodingAttribute)
+                .AddArgumentListArguments(AttributeArgument(SyntaxHelpers.StringLiteral(propertyName)))
+                .AddArgumentListArguments(mediaTypes);
+        }
+
+        private static AttributeArgumentSyntax[] SelectDefaultMediaTypes(OpenApiSchema schema) =>
+            schema switch
+            {
+                {Type: "string", Format: "binary" or "base64"} => OctetStreamEncoding,
+                {Type: "object"} or {Type: "array", Items: {Type: "object"}} => JsonEncoding,
+                _ => PlainTextEncoding
+            };
+
+        private static IEnumerable<KeyValuePair<string, OpenApiSchema>> GetProperties(OpenApiMediaType element) =>
+            element.Schema?.Properties ?? Enumerable.Empty<KeyValuePair<string, OpenApiSchema>>();
+
+        private static IEnumerable<string> GetMediaTypes(string contentType) =>
+            contentType.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim());
+    }
+}

--- a/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
@@ -33,7 +33,7 @@ namespace Yardarm.Enrichment.Schema
             }
 
             return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
-                SyntaxFactory.Attribute(_serializationNamespace.MultipartFormDataSerializer)
+                SyntaxFactory.Attribute(_serializationNamespace.MultipartPropertyAttribute)
                     .AddArgumentListArguments(
                         SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
         }

--- a/src/Yardarm/Names/ISerializationNamespace.cs
+++ b/src/Yardarm/Names/ISerializationNamespace.cs
@@ -9,6 +9,7 @@ namespace Yardarm.Names
         ExpressionSyntax HeaderSerializerInstance { get; }
         NameSyntax ITypeSerializer { get; }
         NameSyntax ITypeSerializerRegistry { get; }
+        NameSyntax MultipartEncodingAttribute { get; }
         NameSyntax MultipartFormDataSerializer { get; }
         NameSyntax MultipartPropertyAttribute { get; }
         NameSyntax PathSegmentStyle { get; }

--- a/src/Yardarm/Names/Internal/SerializationNamespace.cs
+++ b/src/Yardarm/Names/Internal/SerializationNamespace.cs
@@ -13,6 +13,7 @@ namespace Yardarm.Names.Internal
         public NameSyntax Name { get; }
         public NameSyntax ITypeSerializer { get; }
         public NameSyntax ITypeSerializerRegistry { get; }
+        public NameSyntax MultipartEncodingAttribute { get; }
         public NameSyntax MultipartFormDataSerializer { get; }
         public NameSyntax MultipartPropertyAttribute { get; }
         public NameSyntax PathSegmentStyle { get; }
@@ -46,11 +47,15 @@ namespace Yardarm.Names.Internal
                 Name,
                 IdentifierName("ITypeSerializerRegistry"));
 
+            MultipartEncodingAttribute = QualifiedName(
+                Name,
+                IdentifierName("MultipartEncodingAttribute"));
+
             MultipartFormDataSerializer = QualifiedName(
                 Name,
                 IdentifierName("MultipartFormDataSerializer"));
 
-            MultipartFormDataSerializer = QualifiedName(
+            MultipartPropertyAttribute = QualifiedName(
                 Name,
                 IdentifierName("MultipartPropertyAttribute"));
 


### PR DESCRIPTION
Motivation
----------
We need to know what the expected encoding type is when formatting a
property on a multipart encoding.

Modifications
-------------
Encode multipart information as attributes on the request class.