### PR TITLE
Basic System.Text.Json support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY src/Yardarm.Client.UnitTests/*.csproj ./Yardarm.Client.UnitTests/
 COPY src/Yardarm.CommandLine/*.csproj ./Yardarm.CommandLine/
 COPY src/Yardarm.NewtonsoftJson/*.csproj ./Yardarm.NewtonsoftJson/
 COPY src/Yardarm.NewtonsoftJson.Client/*.csproj ./Yardarm.NewtonsoftJson.Client/
+COPY src/Yardarm.SystemTextJson/*.csproj ./Yardarm.SystemTextJson/
+COPY src/Yardarm.SystemTextJson.Client/*.csproj ./Yardarm.SystemTextJson.Client/
 RUN dotnet restore Yardarm.sln
 
 COPY ./src ./

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Yardarm is an OpenAPI 3 SDK Generator for C#. It provides various tools that wil
 - Highly extensible SDK generation
   - Built around plugable extensions that add additional features or modify the C# code used for compilation
   - Will include some out-of-the-box plugins for common scenarios
-    - `Newtonsoft.Json` serialization/deserialization
+    - `Newtonsoft.Json` serialization/deserialization (done)
+    - `System.Text.Json` serialization/deserialization (in progress)
     - `NodaTime` date/time properties
 - Highly extensible SDK
   - Will allow the SDK consumer to extend the behaviors on the client side
@@ -65,6 +66,12 @@ yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -o output/directory/ -x Yard
 
 # Generate a NuGet package and symbols package, with Newtonsoft.Json support
 yardarm generate -i my-spec.json -n MySpec -v 1.0.0 --nupkg output/directory/ -x Yardarm.NewtonsoftJson
+
+# Generate a DLL and related files, with System.Text.Json support
+yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -o output/directory/ -x Yardarm.SystemTextJson
+
+# Generate a NuGet package and symbols package, with System.Text.Json support
+yardarm generate -i my-spec.json -n MySpec -v 1.0.0 --nupkg output/directory/ -x Yardarm.SystemTextJson
 
 # Note the trailing slash on the output directory. If there is no trailing slash, it is assumed to be a DLL or nupkg file name.
 # Related files will be output beside that file.

--- a/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Yardarm.NewtonsoftJson\Yardarm.NewtonsoftJson.csproj" />
+    <ProjectReference Include="..\Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj" />
     <ProjectReference Include="..\Yardarm\Yardarm.csproj" />
   </ItemGroup>
 

--- a/src/Yardarm.SystemTextJson.Client/README.md
+++ b/src/Yardarm.SystemTextJson.Client/README.md
@@ -1,0 +1,13 @@
+# Yardarm.SystemTextJson.Client
+
+This project is a "fake" project to hold C# files which will be added to SDK projects. The compiled
+output of this project is never referenced or distributed, instead the C# files are stored as
+resources in Yardarm.SystemTextJson.dll.
+
+Placing these C# files in a separate project allows us to validate the files by building the project,
+ensuring that the C# code compiles. We can also run unit tests against the classes to ensure
+correct behavior.
+
+All members in this project **must** be `internal` members or be in `RootNamespace`. This avoids naming conflicts
+if a consumer is using more than one generated SDK in their project. `RootNamespace` will be rewritten
+to the namespace of the generated SDK.

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RootNamespace.Serialization.Json
+{
+    internal class JsonStringEnumConverter<T> : JsonConverter<T>
+        where T : Enum
+    {
+        private static readonly TypeCode _enumTypeCode = Type.GetTypeCode(typeof(T));
+
+        private static readonly Dictionary<T, JsonEncodedText> _enumToString = new();
+        private static readonly Dictionary<string, T> _stringToEnum = new();
+
+        static JsonStringEnumConverter()
+        {
+            var type = typeof(T);
+
+            foreach (string name in Enum.GetNames(type))
+            {
+                var enumMember = type.GetField(name);
+                T enumValue = (T) enumMember.GetValue(null);
+
+                var attribute = (EnumMemberAttribute?) enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false).FirstOrDefault();
+                var stringValue = attribute is not null ? attribute.Value : name;
+
+                _stringToEnum.Add(stringValue, enumValue);
+                _enumToString.Add(enumValue, JsonEncodedText.Encode(stringValue));
+            }
+        }
+
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    var strValue = reader.GetString()!;
+                    if (_stringToEnum.TryGetValue(strValue, out var enumValue))
+                    {
+                        return enumValue;
+                    }
+                    break;
+
+                case JsonTokenType.Number:
+                    switch (_enumTypeCode)
+                    {
+                        case TypeCode.Int32:
+                            if (reader.TryGetInt32(out int int32))
+                            {
+                                return Unsafe.As<int, T>(ref int32);
+                            }
+                            break;
+                        case TypeCode.UInt32:
+                            if (reader.TryGetUInt32(out uint uint32))
+                            {
+                                return Unsafe.As<uint, T>(ref uint32);
+                            }
+                            break;
+                        case TypeCode.UInt64:
+                            if (reader.TryGetUInt64(out ulong uint64))
+                            {
+                                return Unsafe.As<ulong, T>(ref uint64);
+                            }
+                            break;
+                        case TypeCode.Int64:
+                            if (reader.TryGetInt64(out long int64))
+                            {
+                                return Unsafe.As<long, T>(ref int64);
+                            }
+                            break;
+                        case TypeCode.SByte:
+                            if (reader.TryGetSByte(out sbyte byte8))
+                            {
+                                return Unsafe.As<sbyte, T>(ref byte8);
+                            }
+                            break;
+                        case TypeCode.Byte:
+                            if (reader.TryGetByte(out byte ubyte8))
+                            {
+                                return Unsafe.As<byte, T>(ref ubyte8);
+                            }
+                            break;
+                        case TypeCode.Int16:
+                            if (reader.TryGetInt16(out short int16))
+                            {
+                                return Unsafe.As<short, T>(ref int16);
+                            }
+                            break;
+                        case TypeCode.UInt16:
+                            if (reader.TryGetUInt16(out ushort uint16))
+                            {
+                                return Unsafe.As<ushort, T>(ref uint16);
+                            }
+                            break;
+                    }
+
+                    throw new JsonException();
+            }
+
+            return default;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            if (_enumToString.TryGetValue(value, out JsonEncodedText str))
+            {
+                writer.WriteStringValue(str);
+                return;
+            }
+
+            switch (_enumTypeCode)
+            {
+                case TypeCode.Int32:
+                    writer.WriteNumberValue(Unsafe.As<T, int>(ref value));
+                    break;
+                case TypeCode.UInt32:
+                    writer.WriteNumberValue(Unsafe.As<T, uint>(ref value));
+                    break;
+                case TypeCode.UInt64:
+                    writer.WriteNumberValue(Unsafe.As<T, ulong>(ref value));
+                    break;
+                case TypeCode.Int64:
+                    writer.WriteNumberValue(Unsafe.As<T, long>(ref value));
+                    break;
+                case TypeCode.Int16:
+                    writer.WriteNumberValue(Unsafe.As<T, short>(ref value));
+                    break;
+                case TypeCode.UInt16:
+                    writer.WriteNumberValue(Unsafe.As<T, ushort>(ref value));
+                    break;
+                case TypeCode.Byte:
+                    writer.WriteNumberValue(Unsafe.As<T, byte>(ref value));
+                    break;
+                case TypeCode.SByte:
+                    writer.WriteNumberValue(Unsafe.As<T, sbyte>(ref value));
+                    break;
+                default:
+                    throw new JsonException();
+            }
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace RootNamespace.Serialization.Json
+{
+    public class JsonTypeSerializer : ITypeSerializer
+    {
+        public static string[] SupportedMediaTypes => new [] { "application/json" };
+
+        private readonly JsonSerializerOptions _options;
+
+        public JsonTypeSerializer()
+            : this(new JsonSerializerOptions())
+        {
+        }
+
+        public JsonTypeSerializer(JsonSerializerOptions options)
+        {
+            _options = options;
+        }
+
+        public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
+            JsonContent.Create(value, new MediaTypeHeaderValue("application/json"), _options);
+
+        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null)
+        {
+            return new ValueTask<T>(content.ReadFromJsonAsync<T>(_options)!);
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yardarm.Client\Yardarm.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+    We need access to these attributes to compile for testing, but we don't want them included
+    in the SDK because they would be included multiple times. Yardarm.Client should have the only
+    copy that's embedded.
+    -->
+    <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson.Helpers
+{
+    internal static class SystemTextJsonTypes
+    {
+        public static NameSyntax SystemTextJson { get; } = QualifiedName(
+            QualifiedName(
+                IdentifierName("System"),
+                IdentifierName("Text")),
+            IdentifierName("Json"));
+
+        public static NameSyntax Serialization { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("Serialization"));
+
+        public static NameSyntax JsonPropertyNameAttributeName { get; } = QualifiedName(
+            Serialization,
+            IdentifierName("JsonPropertyName"));
+
+        public static NameSyntax JsonConverterAttributeName { get; } = QualifiedName(
+            Serialization,
+            IdentifierName("JsonConverterAttribute"));
+    }
+}

--- a/src/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
+++ b/src/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Yardarm.SystemTextJson
+{
+    public interface IJsonSerializationNamespace
+    {
+        NameSyntax Name { get; }
+        NameSyntax JsonTypeSerializer { get; }
+
+        TypeSyntax JsonStringEnumConverter(TypeSyntax valueType);
+    }
+}

--- a/src/Yardarm.SystemTextJson/Internal/ClientGenerator.cs
+++ b/src/Yardarm.SystemTextJson/Internal/ClientGenerator.cs
@@ -1,0 +1,15 @@
+﻿using Yardarm.Generation;
+using Yardarm.Names;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal class ClientGenerator : ResourceSyntaxTreeGenerator
+    {
+        protected override string ResourcePrefix => "Yardarm.SystemTextJson.Client.";
+
+        public ClientGenerator(IRootNamespace rootNamespace)
+            : base(rootNamespace)
+        {
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
+++ b/src/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Yardarm.Names;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationNamespace
+    {
+        public NameSyntax Name { get; }
+        public NameSyntax JsonTypeSerializer { get; }
+
+        public JsonSerializationNamespace(ISerializationNamespace serializationNamespace)
+        {
+            if (serializationNamespace == null)
+            {
+                throw new ArgumentNullException(nameof(serializationNamespace));
+            }
+
+            Name = QualifiedName(
+                serializationNamespace.Name,
+                IdentifierName("Json"));
+
+            JsonTypeSerializer = QualifiedName(
+                Name,
+                IdentifierName("JsonTypeSerializer"));
+        }
+
+        public TypeSyntax JsonStringEnumConverter(TypeSyntax valueType) =>
+            QualifiedName(
+                Name,
+                GenericName(
+                    Identifier("JsonStringEnumConverter"),
+                    TypeArgumentList(SingletonSeparatedList(valueType))));
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Yardarm.Enrichment;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonCreateDefaultRegistryEnricher : ICreateDefaultRegistryEnricher
+    {
+        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+
+        public JsonCreateDefaultRegistryEnricher(IJsonSerializationNamespace jsonSerializationNamespace)
+        {
+            _jsonSerializationNamespace = jsonSerializationNamespace ??
+                                          throw new ArgumentNullException(nameof(jsonSerializationNamespace));
+        }
+
+        public ExpressionSyntax Enrich(ExpressionSyntax target) =>
+            InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    target,
+                    GenericName(
+                        Identifier("Add"),
+                        TypeArgumentList(SingletonSeparatedList<TypeSyntax>(_jsonSerializationNamespace.JsonTypeSerializer)))))
+                .AddArgumentListArguments(
+                    Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        _jsonSerializationNamespace.JsonTypeSerializer,
+                        IdentifierName("SupportedMediaTypes"))));
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+using Yardarm.Packaging;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonDependencyGenerator : IDependencyGenerator
+    {
+        public IEnumerable<LibraryDependency> GetDependencies()
+        {
+            yield return new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "System.Text.Json",
+                    TypeConstraint = LibraryDependencyTarget.Package,
+                    VersionRange = VersionRange.Parse("6.0.0")
+                }
+            };
+
+            yield return new LibraryDependency
+            {
+                LibraryRange = new LibraryRange
+                {
+                    Name = "System.Net.Http.Json",
+                    TypeConstraint = LibraryDependencyTarget.Package,
+                    VersionRange = VersionRange.Parse("6.0.0")
+                }
+            };
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.SystemTextJson.Helpers;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonEnumEnricher : IOpenApiSyntaxNodeEnricher<EnumDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+
+        public JsonEnumEnricher(IJsonSerializationNamespace jsonSerializationNamespace)
+        {
+            _jsonSerializationNamespace = jsonSerializationNamespace ?? throw new ArgumentNullException(nameof(jsonSerializationNamespace));
+        }
+
+        public EnumDeclarationSyntax Enrich(EnumDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context) =>
+            context.Element.Type == "string"
+                ? target
+                    .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
+                        SyntaxFactory.Attribute(SystemTextJsonTypes.JsonConverterAttributeName).AddArgumentListArguments(
+                            SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(
+                                _jsonSerializationNamespace.JsonStringEnumConverter(SyntaxFactory.IdentifierName(target.Identifier)))))))
+                : target;
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.Generation.MediaType;
+using Yardarm.Helpers;
+using Yardarm.SystemTextJson.Helpers;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
+    {
+        public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (target.Parent is ClassDeclarationSyntax classDeclaration &&
+                classDeclaration.GetGeneratorAnnotation() == typeof(RequestMediaTypeGenerator))
+            {
+                // Don't enrich body properties on the request classes
+                return target;
+            }
+
+            return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
+                SyntaxFactory.Attribute(SystemTextJsonTypes.JsonPropertyNameAttributeName).AddArgumentListArguments(
+                    SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Immutable;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.Packaging;
+using Yardarm.Serialization;
+using Yardarm.SystemTextJson.Internal;
+
+namespace Yardarm.SystemTextJson
+{
+    public class SystemTextJsonExtension : YardarmExtension
+    {
+        public override IServiceCollection ConfigureServices(IServiceCollection services)
+        {
+            services
+                .AddCreateDefaultRegistryEnricher<JsonCreateDefaultRegistryEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
+                .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
+                .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
+
+            services
+                .TryAddSingleton<IJsonSerializationNamespace, JsonSerializationNamespace>();
+
+            services.AddSerializerDescriptor(serviceProvider => new SerializerDescriptor(
+                ImmutableHashSet.Create(new SerializerMediaType("application/json", 1.0)),
+                "Json",
+                serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
+            ));
+
+            return services;
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+
+    <Nullable>enable</Nullable>
+    <LangVersion>10</LangVersion>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Description>Extension for Yardarm to generate SDKs that use System.Text.Json for JSON serialization.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yardarm\Yardarm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Collect cs files from Yardarm.SystemTextJson.Client as resources so we can compile them into generated SDKs -->
+    <EmbeddedResource Include="../Yardarm.SystemTextJson.Client/**/*.cs" Exclude="../Yardarm.SystemTextJson.Client/bin/**;../Yardarm.SystemTextJson.Client/obj/**">
+      <Visible>False</Visible>
+      <LogicalName>$([System.String]::Copy('%(RelativeDir)').Substring(3).Replace('/', '.').Replace('\', '.'))%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/src/Yardarm.sln
+++ b/src/Yardarm.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30204.135
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.CommandLine", "Yardarm.CommandLine\Yardarm.CommandLine.csproj", "{527F5AF0-1F33-4F07-A6D6-E411CCA5B0AB}"
 EndProject
@@ -15,7 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.Client", "Yardarm.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.NewtonsoftJson.Client", "Yardarm.NewtonsoftJson.Client\Yardarm.NewtonsoftJson.Client.csproj", "{F9BF417C-669B-43B4-BAB7-836E4E01EE74}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.Client.UnitTests", "Yardarm.Client.UnitTests\Yardarm.Client.UnitTests.csproj", "{764A21AF-D4BB-40FD-859C-59679AB7E4FF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.Client.UnitTests", "Yardarm.Client.UnitTests\Yardarm.Client.UnitTests.csproj", "{764A21AF-D4BB-40FD-859C-59679AB7E4FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.SystemTextJson", "Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj", "{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.SystemTextJson.Client", "Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj", "{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +55,14 @@ Global
 		{764A21AF-D4BB-40FD-859C-59679AB7E4FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{764A21AF-D4BB-40FD-859C-59679AB7E4FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{764A21AF-D4BB-40FD-859C-59679AB7E4FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds an alternative extension, Yardarm.SystemTextJson, which uses
System.Text.Json serialization instead of Newtonsoft.Json.

Note that this support is not 100% complete yet, but does support basic
operations including enumerations. Further work will add support for
things like discriminators.