### PR TITLE
Allow additional properties on nested classes

### DIFF
--- a/src/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
@@ -79,12 +79,12 @@ namespace Yardarm.Enrichment.Compilation
 
             var newRootNode = rootNode.ReplaceNodes(
                 rootNode.GetAnnotatedNodes(typeof(TElement).Name).OfType<TSyntaxNode>(),
-                (_, node) =>
+                (originalNode, node) =>
                 {
                     var schema = node.GetElementAnnotation<TElement>(_elementRegistry);
 
                     return schema != null
-                        ? enricher.Enrich(node, new OpenApiEnrichmentContext<TElement>(compilation, syntaxTree, schema))
+                        ? enricher.Enrich(node, new OpenApiEnrichmentContext<TElement>(compilation, syntaxTree, schema, originalNode))
                         : node;
                 });
 

--- a/src/Yardarm/Enrichment/OpenApiEnrichmentContext.cs
+++ b/src/Yardarm/Enrichment/OpenApiEnrichmentContext.cs
@@ -13,16 +13,25 @@ namespace Yardarm.Enrichment
 
         public SyntaxTree SyntaxTree { get; }
 
+        /// <summary>
+        /// The original node before any enrichments in the current set. This must be used to access the
+        /// semantic model, as any mutations to the target won't belong on the syntax tree until all
+        /// enrichments to that syntax tree are completed.
+        /// </summary>
+        public SyntaxNode OriginalNode { get; }
+
         public ILocatedOpenApiElement<TElement> LocatedElement { get; }
 
         public TElement Element => LocatedElement.Element;
 
+
         public OpenApiEnrichmentContext(CSharpCompilation compilation, SyntaxTree syntaxTree,
-            ILocatedOpenApiElement<TElement> locatedElement)
+            ILocatedOpenApiElement<TElement> locatedElement, SyntaxNode originalNode)
         {
             Compilation = compilation ?? throw new ArgumentNullException(nameof(compilation));
             SyntaxTree = syntaxTree ?? throw new ArgumentNullException(nameof(syntaxTree));
             LocatedElement = locatedElement ?? throw new ArgumentNullException(nameof(locatedElement));
+            OriginalNode = originalNode ?? throw new ArgumentNullException(nameof(originalNode));
         }
     }
 }

--- a/src/Yardarm/Enrichment/Schema/AdditionalPropertiesEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/AdditionalPropertiesEnricher.cs
@@ -44,12 +44,14 @@ namespace Yardarm.Enrichment.Schema
                 .Format("AdditionalProperties");
             bool isShadowing = false;
 
+            var originalNode = context.OriginalNode as ClassDeclarationSyntax;
+
             // Check to see if we're inheriting from a type that already implements AdditionalProperties
-            if (target.BaseList != null)
+            if (originalNode?.BaseList is {Types.Count: > 0})
             {
                 var semanticModel = context.Compilation.GetSemanticModel(context.SyntaxTree);
 
-                foreach (BaseTypeSyntax baseType in target.BaseList.Types)
+                foreach (BaseTypeSyntax baseType in originalNode.BaseList.Types)
                 {
                     var typeInfo = ModelExtensions.GetTypeInfo(semanticModel, baseType.Type);
                     if (typeInfo.Type?.TypeKind == TypeKind.Class)


### PR DESCRIPTION
Motivation
----------
If a schema has additionalProperties set to true and also has a nested
schema, and the outer class is an allOf inherited from a parent schema,
we fail with the semantic model.

Modifications
-------------
When enriching a class with AdditionalProperties, check the base type
on the semantic model using the original node rather than the node which
was mutated by enriching the child class.