### PR TITLE
Add support for multiple categories of type generators

### DIFF
--- a/src/Yardarm/Generation/ITypeGeneratorFactory`1.cs
+++ b/src/Yardarm/Generation/ITypeGeneratorFactory`1.cs
@@ -2,7 +2,7 @@
 
 namespace Yardarm.Generation
 {
-    public interface ITypeGeneratorRegistry<in TElement> : ITypeGeneratorRegistry<TElement, PrimaryGeneratorCategory>
+    public interface ITypeGeneratorFactory<in TElement> : ITypeGeneratorFactory<TElement, PrimaryGeneratorCategory>
         where TElement : IOpenApiElement
     {
     }

--- a/src/Yardarm/Generation/ITypeGeneratorFactory`2.cs
+++ b/src/Yardarm/Generation/ITypeGeneratorFactory`2.cs
@@ -3,7 +3,8 @@ using Yardarm.Spec;
 
 namespace Yardarm.Generation
 {
-    public interface ITypeGeneratorFactory<in TElement>
+    // ReSharper disable once UnusedTypeParameter
+    public interface ITypeGeneratorFactory<in TElement, TGeneratorCategory>
         where TElement : IOpenApiElement
     {
         ITypeGenerator Create(ILocatedOpenApiElement<TElement> element, ITypeGenerator? parent);

--- a/src/Yardarm/Generation/ITypeGeneratorRegistry.cs
+++ b/src/Yardarm/Generation/ITypeGeneratorRegistry.cs
@@ -1,13 +1,18 @@
-﻿using Microsoft.OpenApi.Interfaces;
+﻿using System;
+using Microsoft.OpenApi.Interfaces;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation
 {
     public interface ITypeGeneratorRegistry
     {
-        ITypeGenerator Get(ILocatedOpenApiElement element);
+        ITypeGenerator Get(ILocatedOpenApiElement element, Type generatorCategory);
 
-        ITypeGenerator Get<T>(ILocatedOpenApiElement<T> element)
+        public ITypeGenerator Get<T>(ILocatedOpenApiElement<T> element)
+            where T : IOpenApiElement =>
+            Get<T, PrimaryGeneratorCategory>(element);
+
+        ITypeGenerator Get<T, TGeneratorCategory>(ILocatedOpenApiElement<T> element)
             where T : IOpenApiElement;
     }
 }

--- a/src/Yardarm/Generation/ITypeGeneratorRegistry`2.cs
+++ b/src/Yardarm/Generation/ITypeGeneratorRegistry`2.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.OpenApi.Interfaces;
+using Yardarm.Spec;
+
+namespace Yardarm.Generation
+{
+    // ReSharper disable once UnusedTypeParameter
+    public interface ITypeGeneratorRegistry<in TElement, TGeneratorCategory>
+        where TElement : IOpenApiElement
+    {
+        public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element);
+    }
+}

--- a/src/Yardarm/Generation/Internal/TypeGeneratorRegistry.cs
+++ b/src/Yardarm/Generation/Internal/TypeGeneratorRegistry.cs
@@ -20,21 +20,21 @@ namespace Yardarm.Generation.Internal
             _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
-        public ITypeGenerator Get(ILocatedOpenApiElement element)
+        public ITypeGenerator Get(ILocatedOpenApiElement element, Type generatorCategory)
         {
             if (element == null)
             {
                 throw new ArgumentNullException(nameof(element));
             }
 
-            return (ITypeGenerator)_getTypedMethod.MakeGenericMethod(element.ElementType)
+            return (ITypeGenerator)_getTypedMethod.MakeGenericMethod(element.ElementType, generatorCategory)
                 .Invoke(this, new object[] {element})!;
         }
 
-        public ITypeGenerator Get<T>(ILocatedOpenApiElement<T> element)
+        public ITypeGenerator Get<T, TGeneratorCategory>(ILocatedOpenApiElement<T> element)
             where T : IOpenApiElement
         {
-            return _serviceProvider.GetRequiredService<ITypeGeneratorRegistry<T>>().Get(element);
+            return _serviceProvider.GetRequiredService<ITypeGeneratorRegistry<T, TGeneratorCategory>>().Get(element);
         }
     }
 }

--- a/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
+++ b/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
@@ -6,38 +6,44 @@ using Yardarm.Spec;
 
 namespace Yardarm.Generation.Internal
 {
-    internal class TypeGeneratorRegistry<TElement> : ITypeGeneratorRegistry<TElement>
+    internal class TypeGeneratorRegistry<TElement, TGeneratorCategory> : ITypeGeneratorRegistry<TElement, TGeneratorCategory>
         where TElement : IOpenApiElement
     {
         private readonly ITypeGeneratorRegistry _mainRegistry;
-        private readonly ITypeGeneratorFactory<TElement> _factory;
+        private readonly ITypeGeneratorFactory<TElement, TGeneratorCategory> _factory;
         private readonly OpenApiDocument _document;
 
         private readonly ConcurrentDictionary<ILocatedOpenApiElement<TElement>, ITypeGenerator> _registry =
-            new ConcurrentDictionary<ILocatedOpenApiElement<TElement>, ITypeGenerator>(new LocatedElementEqualityComparer<TElement>());
+            new(new LocatedElementEqualityComparer<TElement>());
+        private readonly Func<ILocatedOpenApiElement<TElement>, ITypeGenerator> _createTypeGenerator;
 
-        public TypeGeneratorRegistry(ITypeGeneratorRegistry mainRegistry, ITypeGeneratorFactory<TElement> factory,
+        public TypeGeneratorRegistry(ITypeGeneratorRegistry mainRegistry, ITypeGeneratorFactory<TElement, TGeneratorCategory> factory,
             OpenApiDocument document)
         {
             _mainRegistry = mainRegistry ?? throw new ArgumentNullException(nameof(mainRegistry));
             _factory = factory ?? throw new ArgumentNullException(nameof(factory));
             _document = document ?? throw new ArgumentNullException(nameof(document));
+
+            _createTypeGenerator = CreateTypeGenerator;
         }
 
         public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element) =>
-            _registry.GetOrAdd(element, key =>
+            _registry
+                .GetOrAdd(element, _createTypeGenerator);
+
+        private ITypeGenerator CreateTypeGenerator(ILocatedOpenApiElement<TElement> element)
+        {
+            if (LocatedElementEqualityComparer<TElement>.GetIsReferenceEqualDefault() &&
+                element.Element is IOpenApiReferenceable referenceable && referenceable.Reference != null)
             {
-                if (LocatedElementEqualityComparer<TElement>.GetIsReferenceEqualDefault() &&
-                    key.Element is IOpenApiReferenceable referenceable && referenceable.Reference != null)
-                {
-                    // When making the new type generator with the factory for a reference, we must ensure
-                    // that we are using the referenced component path for the ILocatedOpenApiElement.
+                // When making the new type generator with the factory for a reference, we must ensure
+                // that we are using the referenced component path for the ILocatedOpenApiElement.
 
-                    var referencedElement = (TElement) _document.ResolveReference(referenceable.Reference);
-                    key = LocatedOpenApiElement.CreateRoot<TElement>(referencedElement, referenceable.Reference.Id);
-                }
+                var referencedElement = (TElement)_document.ResolveReference(referenceable.Reference);
+                element = LocatedOpenApiElement.CreateRoot<TElement>(referencedElement, referenceable.Reference.Id);
+            }
 
-                return _factory.Create(key, key.Parent != null ? _mainRegistry.Get(key.Parent) : null);
-            });
+            return _factory.Create(element, element.Parent != null ? _mainRegistry.Get(element.Parent, typeof(TGeneratorCategory)) : null);
+        }
     }
 }

--- a/src/Yardarm/Generation/NoopTypeGeneratorFactory.cs
+++ b/src/Yardarm/Generation/NoopTypeGeneratorFactory.cs
@@ -3,7 +3,7 @@ using Yardarm.Spec;
 
 namespace Yardarm.Generation
 {
-    public class NoopTypeGeneratorFactory<T> : ITypeGeneratorFactory<T>
+    public class NoopTypeGeneratorFactory<T, TGeneratorCategory> : ITypeGeneratorFactory<T, TGeneratorCategory>
         where T : IOpenApiElement
     {
         public ITypeGenerator Create(ILocatedOpenApiElement<T> element, ITypeGenerator? parent) =>

--- a/src/Yardarm/Generation/PrimaryGeneratorCategory.cs
+++ b/src/Yardarm/Generation/PrimaryGeneratorCategory.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.OpenApi.Interfaces;
+using Yardarm.Spec;
+
+namespace Yardarm.Generation
+{
+    /// <summary>
+    /// Used as a key for TGeneratorCategory on <see cref="ITypeGeneratorFactory{TElement,TGeneratorCategory}"/>.
+    /// Represents the primary types generated for an element.
+    /// </summary>
+    public class PrimaryGeneratorCategory
+    {
+        private PrimaryGeneratorCategory()
+        {
+        }
+
+        /// <summary>
+        /// Supports DI injection of <see cref="ITypeGeneratorRegistry{TElement}"/> wrapping a
+        /// <see cref="ITypeGeneratorRegistry{TElement,TGeneratorCategory}"/>.
+        /// </summary>
+        /// <typeparam name="TElement"></typeparam>
+        internal class TypeGeneratorRegistryWrapper<TElement> : ITypeGeneratorRegistry<TElement>
+            where TElement : IOpenApiElement
+        {
+            private readonly ITypeGeneratorRegistry<TElement, PrimaryGeneratorCategory> _innerRegistry;
+
+            public TypeGeneratorRegistryWrapper(ITypeGeneratorRegistry<TElement, PrimaryGeneratorCategory> innerRegistry)
+            {
+                _innerRegistry = innerRegistry;
+            }
+
+            public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element) => _innerRegistry.Get(element);
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
For System.Text.Json support we want to also generate types and be able
to access their names from ITypeGeneratorRegistry. This is primarily to
create custom converters for discriminated schemas.

Modifications
-------------
Expand the TypeGeneratorRegistry system to work on an additional generic
type key. This type is not used/instantiated, and is purely present to
act as a DI key for lookup.

For compatibility, leave the existing interfaces which accept a single
type as inherited from the new interfaces using the new
PrimaryGeneratorCategory used for our existing generators.

Results
-------
Extensions may now register their own generator types using alternative
TGeneratorCategory key classes.