### PR TITLE
Add discriminator support to System.Text.Json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,13 @@ WORKDIR /app
 
 COPY src/*.sln ./
 COPY src/Yardarm/*.csproj ./Yardarm/
-COPY src/Yardarm.UnitTests/*.csproj ./Yardarm.UnitTests/
 COPY src/Yardarm.Client/*.csproj ./Yardarm.Client/
-COPY src/Yardarm.Client.UnitTests/*.csproj ./Yardarm.Client.UnitTests/
 COPY src/Yardarm.CommandLine/*.csproj ./Yardarm.CommandLine/
 COPY src/Yardarm.NewtonsoftJson/*.csproj ./Yardarm.NewtonsoftJson/
 COPY src/Yardarm.NewtonsoftJson.Client/*.csproj ./Yardarm.NewtonsoftJson.Client/
 COPY src/Yardarm.SystemTextJson/*.csproj ./Yardarm.SystemTextJson/
 COPY src/Yardarm.SystemTextJson.Client/*.csproj ./Yardarm.SystemTextJson.Client/
-RUN dotnet restore Yardarm.sln
+RUN dotnet restore ./Yardarm.CommandLine/Yardarm.CommandLine.csproj
 
 COPY ./src ./
 RUN dotnet pack -c Release -p:VERSION=${VERSION} ./Yardarm.CommandLine/Yardarm.CommandLine.csproj

--- a/src/Yardarm.SystemTextJson.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/Yardarm.SystemTextJson.Client/Properties/ClientAssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Runtime.CompilerServices;
+
+#if FORTESTS
+[assembly: InternalsVisibleTo("Yardarm.SystemTextJson.UnitTests")]
+#endif

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+
+namespace RootNamespace.Serialization.Json
+{
+    internal static class JsonHelpers
+    {
+        public static string? GetDiscriminator(ref Utf8JsonReader reader, ReadOnlySpan<byte> utf8PropertyName)
+        {
+            // Clone the reader so we don't mutate the original
+            Utf8JsonReader readerClone = reader;
+
+            if (readerClone.TokenType != JsonTokenType.StartObject)
+            {
+                throw new JsonException();
+            }
+
+            // Read the property name
+            if (!readerClone.Read())
+            {
+                ThrowJsonException();
+            }
+            while (readerClone.TokenType != JsonTokenType.EndObject)
+            {
+                if (readerClone.TokenType != JsonTokenType.PropertyName)
+                {
+                    ThrowJsonException();
+                }
+
+                if (readerClone.ValueTextEquals(utf8PropertyName))
+                {
+                    // Read the value
+                    if (!readerClone.Read())
+                    {
+                        readerClone.Read();
+                    }
+
+                    return readerClone.GetString();
+                }
+
+                // Read the value
+                if (!readerClone.Read())
+                {
+                    ThrowJsonException();
+                }
+
+                if (readerClone.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+                {
+                    // Skip the array or object to the next property name or end of the object
+                    // This leaves us on the end of the object or array
+                    if (!readerClone.TrySkip())
+                    {
+                        ThrowJsonException();
+                    }
+                }
+
+                // Skip the value to the next property name or end of the object
+                if (!readerClone.Read())
+                {
+                    ThrowJsonException();
+                }
+            }
+
+            return null;
+        }
+
+        [DoesNotReturn]
+        private static void ThrowJsonException()
+        {
+            throw new JsonException();
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
@@ -15,7 +15,7 @@ namespace RootNamespace.Serialization.Json
 
             if (readerClone.TokenType != JsonTokenType.StartObject)
             {
-                throw new JsonException();
+                ThrowJsonException();
             }
 
             // Read the property name

--- a/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
+
+    <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Yardarm.SystemTextJson.UnitTests/Client/JsonHelpersTests.cs
+++ b/src/Yardarm.SystemTextJson.UnitTests/Client/JsonHelpersTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Text;
+using System.Text.Json;
+using RootNamespace.Serialization.Json;
+using Xunit;
+
+namespace Yardarm.SystemTextJson.UnitTests.Client
+{
+    public class JsonHelpersTests
+    {
+        private static UTF8Encoding Utf8Encoding { get; } = new(encoderShouldEmitUTF8Identifier: false);
+        private static byte[] PropertyName { get; } = Utf8Encoding.GetBytes("type");
+
+        #region GetDiscriminator
+
+        [Fact]
+        public void GetDiscriminator_NotPresent_Null()
+        {
+            // Arrange
+
+            const string json = "{\"amount\":{\"bonusPoints\":100}}";
+
+            var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+            reader.Read();
+
+            // Act
+
+            string result = JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+
+            // Assert
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetDiscriminator_TypeAtFront_Returns()
+        {
+            // Arrange
+
+            const string json = "{\"type\":\"addValue\",\"amount\":{\"bonusPoints\":100}}";
+
+            var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+            reader.Read();
+
+            // Act
+
+            string result = JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+
+            // Assert
+
+            Assert.Equal("addValue", result);
+        }
+
+        [Fact]
+        public void GetDiscriminator_TypeAtRear_Returns()
+        {
+            // Arrange
+
+            const string json = "{\"amount\":100,\"type\":\"addValue\"}";
+
+            var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+            reader.Read();
+
+            // Act
+
+            string result = JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+
+            // Assert
+
+            Assert.Equal("addValue", result);
+        }
+
+        [Fact]
+        public void GetDiscriminator_TypeAtRearWithObject_Returns()
+        {
+            // Arrange
+
+            const string json = "{\"amount\":{\"bonusPoints\":100},\"type\":\"addValue\"}";
+
+            var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+            reader.Read();
+
+            // Act
+
+            string result = JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+
+            // Assert
+
+            Assert.Equal("addValue", result);
+        }
+
+        [Fact]
+        public void GetDiscriminator_TypeAtRearWithArray_Returns()
+        {
+            // Arrange
+
+            const string json = "{\"amount\":[100],\"type\":\"addValue\"}";
+
+            var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+            reader.Read();
+
+            // Act
+
+            string result = JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+
+            // Assert
+
+            Assert.Equal("addValue", result);
+        }
+
+        [Fact]
+        public void GetDiscriminator_NotAnObject_JsonException()
+        {
+            // Arrange
+
+            const string json = "100";
+
+            // Act/Assert
+
+            Assert.Throws<JsonException>(() =>
+            {
+                var reader = new Utf8JsonReader(Utf8Encoding.GetBytes(json));
+                reader.Read();
+
+                return JsonHelpers.GetDiscriminator(ref reader, PropertyName);
+            });
+        }
+
+        #endregion
+    }
+}

--- a/src/Yardarm.SystemTextJson.UnitTests/Yardarm.SystemTextJson.UnitTests.csproj
+++ b/src/Yardarm.SystemTextJson.UnitTests/Yardarm.SystemTextJson.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj" />
+    <ProjectReference Include="..\Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson.Helpers
@@ -11,16 +12,65 @@ namespace Yardarm.SystemTextJson.Helpers
                 IdentifierName("Text")),
             IdentifierName("Json"));
 
-        public static NameSyntax Serialization { get; } = QualifiedName(
+        public static NameSyntax JsonSerializer { get; } = QualifiedName(
             SystemTextJson,
-            IdentifierName("Serialization"));
+            IdentifierName("JsonSerializer"));
 
-        public static NameSyntax JsonPropertyNameAttributeName { get; } = QualifiedName(
-            Serialization,
-            IdentifierName("JsonPropertyName"));
+        public static NameSyntax JsonSerializerOptions { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("JsonSerializerOptions"));
 
-        public static NameSyntax JsonConverterAttributeName { get; } = QualifiedName(
-            Serialization,
-            IdentifierName("JsonConverterAttribute"));
+        public static NameSyntax JsonException { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("JsonException"));
+
+        public static class JsonTokenType
+        {
+            public static NameSyntax Name { get; } = QualifiedName(
+                SystemTextJson,
+                IdentifierName("JsonTokenType"));
+
+            public static MemberAccessExpressionSyntax Null { get; } = MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                Name,
+                IdentifierName("Null"));
+
+            public static MemberAccessExpressionSyntax PropertyName { get; } = MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                Name,
+                IdentifierName("PropertyName"));
+
+            public static MemberAccessExpressionSyntax StartObject { get; } = MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                Name,
+                IdentifierName("StartObject"));
+        }
+
+        public static class Serialization
+        {
+            public static NameSyntax Name { get; } = QualifiedName(
+                SystemTextJson,
+                IdentifierName("Serialization"));
+
+            public static NameSyntax JsonPropertyNameAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonPropertyName"));
+
+            public static NameSyntax JsonConverterAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonConverterAttribute"));
+
+            public static TypeSyntax JsonConverterName(TypeSyntax t) =>
+                QualifiedName(Name, GenericName(Identifier("JsonConverter"),
+                    TypeArgumentList(SingletonSeparatedList(t))));
+        }
+
+        public static NameSyntax Utf8JsonReader { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("Utf8JsonReader"));
+
+        public static NameSyntax Utf8JsonWriter { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("Utf8JsonWriter"));
     }
 }

--- a/src/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
+++ b/src/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
@@ -8,5 +8,7 @@ namespace Yardarm.SystemTextJson
         NameSyntax JsonTypeSerializer { get; }
 
         TypeSyntax JsonStringEnumConverter(TypeSyntax valueType);
+
+        InvocationExpressionSyntax GetDiscriminator(ExpressionSyntax reader, ExpressionSyntax utf8PropertyName);
     }
 }

--- a/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
+++ b/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Spec;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal class DiscriminatorConverterGenerator : ISyntaxTreeGenerator
+    {
+        private readonly OpenApiDocument _document;
+        private readonly ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> _typeGeneratorRegistry;
+
+        public DiscriminatorConverterGenerator(OpenApiDocument document, ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> typeGeneratorRegistry)
+        {
+            _document = document ?? throw new ArgumentNullException(nameof(document));
+            _typeGeneratorRegistry = typeGeneratorRegistry ?? throw new ArgumentNullException(nameof(typeGeneratorRegistry));
+        }
+
+        public IEnumerable<SyntaxTree> Generate()
+        {
+            foreach (var schema in _document.Components.Schemas
+                         .Where(schema => schema.Value.Discriminator?.PropertyName != null))
+            {
+                var element = schema.Value.CreateRoot(schema.Key);
+
+                var generator = _typeGeneratorRegistry.Get(element);
+
+                var syntaxTree = generator.GenerateSyntaxTree();
+                if (syntaxTree != null)
+                {
+                    yield return syntaxTree;
+                }
+            }
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGenerator.cs
+++ b/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGenerator.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.Spec;
+using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal class DiscriminatorConverterTypeGenerator : TypeGeneratorBase<OpenApiSchema>
+    {
+        public static ReadOnlySpan<byte> X => new byte[] {1, 2};
+
+        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+
+        public DiscriminatorConverterTypeGenerator(ILocatedOpenApiElement<OpenApiSchema> element,
+            GenerationContext context, ITypeGenerator? parent, IJsonSerializationNamespace jsonSerializationNamespace)
+            : base(element, context, parent)
+        {
+            _jsonSerializationNamespace = jsonSerializationNamespace ?? throw new ArgumentNullException(nameof(jsonSerializationNamespace));
+        }
+
+        protected override YardarmTypeInfo GetTypeInfo()
+        {
+            var schema = Element.Element;
+
+            if (schema.Reference != null)
+            {
+                NameSyntax ns = _jsonSerializationNamespace.Name;
+
+                var formatter = Context.NameFormatterSelector.GetFormatter(NameKind.Class);
+
+                return new YardarmTypeInfo(
+                    QualifiedName(ns, IdentifierName(formatter.Format(schema.Reference.Id + "-JsonConverter"))),
+                    NameKind.Class);
+            }
+
+            if (Parent == null)
+            {
+                throw new InvalidOperationException(
+                    $"Unable to generate schema for '{Element.Key}', it has no parent is not a component.");
+            }
+
+            QualifiedNameSyntax? name = Parent.GetChildName(Element, NameKind.Class);
+            if (name == null)
+            {
+                throw new InvalidOperationException($"Unable to generate schema for '{Element.Key}', parent did not provide a name.");
+            }
+
+            return new YardarmTypeInfo(name, NameKind.Class);
+        }
+
+        public override IEnumerable<MemberDeclarationSyntax> Generate()
+        {
+            var classNameAndNamespace = (QualifiedNameSyntax)TypeInfo.Name;
+
+            string className = classNameAndNamespace.Right.Identifier.Text;
+
+            var schemaType = Context.TypeGeneratorRegistry.Get(Element).TypeInfo.Name;
+            var baseType = SystemTextJsonTypes.Serialization.JsonConverterName(schemaType);
+
+            var declaration = ClassDeclaration(
+                    default,
+                    TokenList(Token(SyntaxKind.InternalKeyword)),
+                    Identifier(className),
+                    null,
+                    BaseList(SingletonSeparatedList<BaseTypeSyntax>(SimpleBaseType(baseType))),
+                    default,
+                    new SyntaxList<MemberDeclarationSyntax>(GenerateMethods(schemaType)));
+
+            yield return declaration;
+        }
+
+        private IEnumerable<MemberDeclarationSyntax> GenerateMethods(TypeSyntax schemaType)
+        {
+            yield return GeneratePropertyNameProperty();
+            yield return GenerateCanConvert(schemaType);
+            yield return GenerateRead(schemaType);
+            yield return GenerateWrite(schemaType);
+        }
+
+        private PropertyDeclarationSyntax GeneratePropertyNameProperty()
+        {
+            byte[] propertyName = Encoding.UTF8.GetBytes(Element.Element.Discriminator.PropertyName);
+
+            return PropertyDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)),
+                WellKnownTypes.System.ReadOnlySpan(PredefinedType(Token(SyntaxKind.ByteKeyword))),
+                default,
+                Identifier("PropertyName"),
+                null,
+                ArrowExpressionClause(ArrayCreationExpression(
+                    ArrayType(
+                        PredefinedType(Token(SyntaxKind.ByteKeyword)), new SyntaxList<ArrayRankSpecifierSyntax>(
+                            ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression())))),
+                    InitializerExpression(SyntaxKind.ArrayInitializerExpression,
+                        SeparatedList(propertyName.Select(p =>
+                            (ExpressionSyntax)LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(p))))))),
+                null);
+        }
+
+        private MethodDeclarationSyntax GenerateCanConvert(TypeSyntax schemaType)
+        {
+            var expressionBody = ArrowExpressionClause(
+                InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        TypeOfExpression(schemaType),
+                        IdentifierName("IsAssignableFrom")),
+                    ArgumentList(SingletonSeparatedList(Argument(IdentifierName("typeToConvert"))))));
+
+            return MethodDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)),
+                PredefinedType(Token(SyntaxKind.BoolKeyword)),
+                default,
+                Identifier("CanConvert"),
+                default,
+                ParameterList(SingletonSeparatedList(
+                    Parameter(
+                        default,
+                        TokenList(),
+                        WellKnownTypes.System.Type,
+                        Identifier("typeToConvert"),
+                        null))),
+                default,
+                null,
+                expressionBody);
+        }
+
+        private MethodDeclarationSyntax GenerateRead(TypeSyntax schemaType)
+        {
+            OpenApiSchema schema = Element.Element;
+
+            var mappings = schema.Discriminator.Mapping
+                .Select(mapping =>
+                {
+                    var referencedSchema = schema.OneOf
+                        .FirstOrDefault(p => p.Reference?.ReferenceV3 == mapping.Value);
+
+                    var locatedReferencedSchema = referencedSchema?.CreateRoot(referencedSchema.Reference.Id);
+
+                    TypeSyntax? typeName = null;
+                    if (locatedReferencedSchema != null)
+                    {
+                        typeName = Context.TypeGeneratorRegistry.Get(locatedReferencedSchema).TypeInfo.Name;
+                    }
+
+                    return (key: mapping.Key, typeName);
+                })
+                .Where(p => p.typeName != null)
+                .Select(mapping =>
+                    SwitchExpressionArm(
+                        ConstantPattern(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(mapping.key))),
+                        PostfixUnaryExpression(SyntaxKind.SuppressNullableWarningExpression, InvocationExpression(
+                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                SystemTextJsonTypes.JsonSerializer,
+                                GenericName(Identifier("Deserialize"),
+                                    TypeArgumentList(SingletonSeparatedList(mapping.typeName!)))),
+                            ArgumentList(SeparatedList(new[]
+                            {
+                                Argument(null, Token(SyntaxKind.RefKeyword), IdentifierName("reader")),
+                                Argument(IdentifierName("options"))
+                            }))))))
+                .Concat(new[]
+                {
+                    SwitchExpressionArm(DiscardPattern(),
+                        ThrowExpression(ObjectCreationExpression(SystemTextJsonTypes.JsonException)))
+                });
+
+            var body = Block(default, new SyntaxList<StatementSyntax>(new StatementSyntax[] {
+                LocalDeclarationStatement(VariableDeclaration(
+                    NullableType(PredefinedType(Token(SyntaxKind.StringKeyword))),
+                    SingletonSeparatedList(VariableDeclarator(
+                        Identifier("discriminator"),
+                        null,
+                        EqualsValueClause(_jsonSerializationNamespace.GetDiscriminator(
+                            IdentifierName("reader"),
+                            IdentifierName("PropertyName"))))))),
+
+                ReturnStatement(SwitchExpression(IdentifierName("discriminator"), SeparatedList(mappings)))
+            }));
+
+            return MethodDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)),
+                schemaType,
+                default,
+                Identifier("Read"),
+                default,
+                ParameterList(SeparatedList<ParameterSyntax>(new [] {
+                    Parameter(
+                        default,
+                        TokenList(Token(SyntaxKind.RefKeyword)),
+                        SystemTextJsonTypes.Utf8JsonReader,
+                        Identifier("reader"),
+                        null),
+                    Parameter(
+                        default,
+                        TokenList(),
+                        WellKnownTypes.System.Type,
+                        Identifier("typeToConvert"),
+                        null),
+                    Parameter(
+                        default,
+                        TokenList(),
+                        SystemTextJsonTypes.JsonSerializerOptions,
+                        Identifier("options"),
+                        null)
+                })),
+                default,
+                body,
+                null);
+        }
+
+        private MethodDeclarationSyntax GenerateWrite(TypeSyntax schemaType)
+        {
+            var expressionBody = InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    SystemTextJsonTypes.JsonSerializer,
+                    IdentifierName("Serialize")),
+                ArgumentList(SeparatedList(new[]
+                {
+                    Argument(IdentifierName("writer")),
+                    Argument(IdentifierName("value")),
+                    Argument(InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName("value"),
+                        IdentifierName("GetType")))),
+                    Argument(IdentifierName("options"))
+                })));
+
+            return MethodDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)),
+                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                default,
+                Identifier("Write"),
+                default,
+                ParameterList(SeparatedList<ParameterSyntax>(new [] {
+                    Parameter(
+                        default,
+                        TokenList(),
+                        SystemTextJsonTypes.Utf8JsonWriter,
+                        Identifier("writer"),
+                        null),
+                    Parameter(
+                        default,
+                        TokenList(),
+                        schemaType,
+                        Identifier("value"),
+                        null),
+                    Parameter(
+                        default,
+                        TokenList(),
+                        SystemTextJsonTypes.JsonSerializerOptions,
+                        Identifier("options"),
+                        null)
+                })),
+                default,
+                null,
+                ArrowExpressionClause(expressionBody));
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGeneratorFactory.cs
+++ b/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGeneratorFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation;
+using Yardarm.Spec;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal class DiscriminatorConverterTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiSchema, SystemTextJsonGeneratorCategory>
+    {
+        private readonly GenerationContext _context;
+        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+
+        public DiscriminatorConverterTypeGeneratorFactory(GenerationContext context, IJsonSerializationNamespace jsonSerializationNamespace)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _jsonSerializationNamespace = jsonSerializationNamespace ?? throw new ArgumentNullException(nameof(jsonSerializationNamespace));
+        }
+
+        public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiSchema> element, ITypeGenerator? parent) =>
+            new DiscriminatorConverterTypeGenerator(element, _context, parent, _jsonSerializationNamespace);
+    }
+}

--- a/src/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
+++ b/src/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Names;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -9,6 +10,7 @@ namespace Yardarm.SystemTextJson.Internal
     {
         public NameSyntax Name { get; }
         public NameSyntax JsonTypeSerializer { get; }
+        public NameSyntax JsonHelpers { get; }
 
         public JsonSerializationNamespace(ISerializationNamespace serializationNamespace)
         {
@@ -24,6 +26,10 @@ namespace Yardarm.SystemTextJson.Internal
             JsonTypeSerializer = QualifiedName(
                 Name,
                 IdentifierName("JsonTypeSerializer"));
+
+            JsonHelpers = QualifiedName(
+                Name,
+                IdentifierName("JsonHelpers"));
         }
 
         public TypeSyntax JsonStringEnumConverter(TypeSyntax valueType) =>
@@ -32,5 +38,14 @@ namespace Yardarm.SystemTextJson.Internal
                 GenericName(
                     Identifier("JsonStringEnumConverter"),
                     TypeArgumentList(SingletonSeparatedList(valueType))));
+
+        public InvocationExpressionSyntax GetDiscriminator(ExpressionSyntax reader, ExpressionSyntax utf8PropertyName) =>
+            InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    JsonHelpers,
+                    IdentifierName("GetDiscriminator")),
+                ArgumentList(SeparatedList<ArgumentSyntax>(new[] {
+                    Argument(null, Token(SyntaxKind.RefKeyword), reader),
+                    Argument(utf8PropertyName) })));
     }
 }

--- a/src/Yardarm.SystemTextJson/Internal/SystemTextJsonGeneratorCategory.cs
+++ b/src/Yardarm.SystemTextJson/Internal/SystemTextJsonGeneratorCategory.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    public class SystemTextJsonGeneratorCategory
+    {
+        private SystemTextJsonGeneratorCategory()
+        {
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonDiscriminatorEnricher : IOpenApiSyntaxNodeEnricher<InterfaceDeclarationSyntax, OpenApiSchema>
+    {
+        protected GenerationContext Context { get; }
+        protected ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> TypeGeneratorRegistry { get; }
+
+        public JsonDiscriminatorEnricher(GenerationContext context,
+            ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> typeGeneratorRegistry)
+        {
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+            TypeGeneratorRegistry = typeGeneratorRegistry ?? throw new ArgumentNullException(nameof(typeGeneratorRegistry));
+        }
+
+        public InterfaceDeclarationSyntax Enrich(InterfaceDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context) =>
+            context.Element.Discriminator?.PropertyName != null
+                ? AddJsonConverter(target, context)
+                : target;
+
+        protected virtual InterfaceDeclarationSyntax AddJsonConverter(InterfaceDeclarationSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            var converter = TypeGeneratorRegistry.Get(context.LocatedElement);
+
+            var attribute = Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName,
+                AttributeArgumentList(SingletonSeparatedList(AttributeArgument(TypeOfExpression(converter.TypeInfo.Name)))));
+
+            return target.AddAttributeLists(AttributeList(SingletonSeparatedList(attribute)));
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
@@ -21,7 +21,7 @@ namespace Yardarm.SystemTextJson
             context.Element.Type == "string"
                 ? target
                     .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
-                        SyntaxFactory.Attribute(SystemTextJsonTypes.JsonConverterAttributeName).AddArgumentListArguments(
+                        SyntaxFactory.Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName).AddArgumentListArguments(
                             SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(
                                 _jsonSerializationNamespace.JsonStringEnumConverter(SyntaxFactory.IdentifierName(target.Identifier)))))))
                 : target;

--- a/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
@@ -22,7 +22,7 @@ namespace Yardarm.SystemTextJson
             }
 
             return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
-                SyntaxFactory.Attribute(SystemTextJsonTypes.JsonPropertyNameAttributeName).AddArgumentListArguments(
+                SyntaxFactory.Attribute(SystemTextJsonTypes.Serialization.JsonPropertyNameAttributeName).AddArgumentListArguments(
                     SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
         }
     }

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Generation;
 using Yardarm.Packaging;
@@ -17,8 +18,11 @@ namespace Yardarm.SystemTextJson
                 .AddCreateDefaultRegistryEnricher<JsonCreateDefaultRegistryEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
-                .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
+                .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
+                .AddSingleton<ISyntaxTreeGenerator, DiscriminatorConverterGenerator>()
+                .TryAddTypeGeneratorFactory<OpenApiSchema, SystemTextJsonGeneratorCategory, DiscriminatorConverterTypeGeneratorFactory>();
 
             services
                 .TryAddSingleton<IJsonSerializationNamespace, JsonSerializationNamespace>();

--- a/src/Yardarm.sln
+++ b/src/Yardarm.sln
@@ -17,9 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.NewtonsoftJson.Clie
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.Client.UnitTests", "Yardarm.Client.UnitTests\Yardarm.Client.UnitTests.csproj", "{764A21AF-D4BB-40FD-859C-59679AB7E4FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.SystemTextJson", "Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj", "{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.SystemTextJson", "Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj", "{B8E31BC7-0232-43F7-9327-EF2BBDC14D8D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.SystemTextJson.Client", "Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj", "{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.SystemTextJson.Client", "Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj", "{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.SystemTextJson.UnitTests", "Yardarm.SystemTextJson.UnitTests\Yardarm.SystemTextJson.UnitTests.csproj", "{D69528D7-7308-4E44-A00C-3E95A6BC1F7B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F80C514-3A76-4EBD-8D19-98B4C7D6E2D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D69528D7-7308-4E44-A00C-3E95A6BC1F7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D69528D7-7308-4E44-A00C-3E95A6BC1F7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D69528D7-7308-4E44-A00C-3E95A6BC1F7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D69528D7-7308-4E44-A00C-3E95A6BC1F7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/Yardarm/Helpers/WellKnownTypes.cs
@@ -153,6 +153,13 @@ namespace Yardarm.Helpers
                     IdentifierName("ObsoleteAttribute"));
             }
 
+            public static NameSyntax ReadOnlySpan(TypeSyntax elementType) =>
+                QualifiedName(
+                    Name,
+                    GenericName(
+                        Identifier("ReadOnlySpan"),
+                        TypeArgumentList(SingletonSeparatedList(elementType))));
+
             public static class Text
             {
                 public static NameSyntax Name { get; } = QualifiedName(
@@ -236,6 +243,10 @@ namespace Yardarm.Helpers
                     }
                 }
             }
+
+            public static NameSyntax Type { get; } = QualifiedName(
+                System.Name,
+                IdentifierName("Type"));
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
System.Text.Json doesn't support polymorphic deserialization out of the
box, but discriminators are a common pattern in OpenAPI specs.

Modifications
-------------
Implement a code generator to create a custom deserializer for each
schema with a discriminator, and register this on the base interface
with an attribute.

Add a unit test project to test some of the details.