### PR TITLE
Support missing properties in System.Text.Json

### DIFF
--- a/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -60,6 +60,38 @@ namespace Yardarm.SystemTextJson.Helpers
                 Name,
                 IdentifierName("JsonExtensionDataAttribute"));
 
+            public static NameSyntax JsonIgnoreAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonIgnoreAttribute"));
+
+            public static class JsonIgnoreCondition
+            {
+                // ReSharper disable once MemberHidesStaticFromOuterClass
+                public static NameSyntax Name { get; } = QualifiedName(
+                    Serialization.Name,
+                    IdentifierName("JsonIgnoreCondition"));
+
+                public static MemberAccessExpressionSyntax Always { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("Always"));
+
+                public static MemberAccessExpressionSyntax Never { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("Never"));
+
+                public static MemberAccessExpressionSyntax WhenWritingDefault { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("WhenWritingDefault"));
+
+                public static MemberAccessExpressionSyntax WhenWritingNull { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("WhenWritingNull"));
+            }
+
             public static NameSyntax JsonPropertyNameAttributeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonPropertyName"));

--- a/src/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Spec;
+using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonOptionalPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly IOpenApiElementRegistry _elementRegistry;
+
+        public JsonOptionalPropertyEnricher(IOpenApiElementRegistry elementRegistry)
+        {
+            _elementRegistry = elementRegistry ?? throw new ArgumentNullException(nameof(elementRegistry));
+        }
+
+        public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (syntax.Parent?.GetElementAnnotation<OpenApiSchema>(_elementRegistry) is null)
+            {
+                // We don't need to apply this to properties of request classes, only schemas
+                return syntax;
+            }
+
+            bool isRequired =
+                context.LocatedElement.Parent is LocatedOpenApiElement<OpenApiSchema> parentSchema &&
+                parentSchema.Element.Required.Contains(context.LocatedElement.Key);
+
+            bool isNullable = context.LocatedElement.Element.Nullable;
+
+            // We prefer not to send null values if the property is not required.
+            // However, for nullable properties, prefer to send the null explicitly.
+            // This is a compromise due to .NET not supporting a concept of null vs missing.
+            return !isRequired && !isNullable
+                ? AddJsonIgnoreAttribute(syntax)
+                : syntax;
+        }
+
+        private PropertyDeclarationSyntax AddJsonIgnoreAttribute(PropertyDeclarationSyntax syntax) =>
+            syntax
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                    Attribute(SystemTextJsonTypes.Serialization.JsonIgnoreAttributeName,
+                        AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
+                            NameEquals(IdentifierName("Condition")),
+                            null,
+                            SystemTextJsonTypes.Serialization.JsonIgnoreCondition.WhenWritingNull)))))));
+    }
+}

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -20,6 +20,7 @@ namespace Yardarm.SystemTextJson
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, DiscriminatorConverterGenerator>()


### PR DESCRIPTION
Motivation
----------
When a property isn't required we shouldn't send null for it unless null
is expected.

Modifications
-------------
Add the JsonIgnore attribute with WhenWritingNull where applicable.