### PR TITLE
Support nullable property schemas

### DIFF
--- a/src/Yardarm/Enrichment/Schema/RequiredPropertyEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/RequiredPropertyEnricher.cs
@@ -20,10 +20,17 @@ namespace Yardarm.Enrichment.Schema
         }
 
         private PropertyDeclarationSyntax AddRequiredAttribute(PropertyDeclarationSyntax syntax,
-            OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            syntax
-                .MakeNullableOrInitializeIfReferenceType(context.Compilation)
-                .AddAttributeLists(AttributeList().AddAttributes(
-                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name)));
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            var newSyntax = context.Element.Nullable
+                // If the schema is nullable the property should be nullable
+                ? syntax.MakeNullable()
+                // If the schema is not nullable we should try to initialize it, fallback to making it nullable if we can't
+                : syntax.MakeNullableOrInitializeIfReferenceType(context.Compilation);
+
+            return newSyntax
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name))));
+        }
     }
 }


### PR DESCRIPTION
Motivation
----------
Required properties aren't the only kind of nullable, they may also
be marked as nullable (even if required).

Modifications
-------------
Always allow nullable schemas to be nullable properties. Still mark them
with the Required attribute if they're also required.