### PR TITLE
Don't include MultipartEncodingAttribute on non-multipart requests

### DIFF
--- a/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -32,7 +32,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="centeredge-cardsystemapi.yaml">
+    <None Update="*.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Motivation
----------
We're adding bloat by incorrectly placing these attributes on things
like JSON requests.

Modifications
-------------
Filter based on content types.