### PR TITLE
Support dynamic assembly loading

### DIFF
--- a/src/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/src/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/src/Yardarm/Internal/YardarmAssemblyLoadContext.cs
+++ b/src/Yardarm/Internal/YardarmAssemblyLoadContext.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace Yardarm.Internal
+{
+    /// <summary>
+    /// Provides a mechanism for loading assemblies temporarily during a Yardarm execution and
+    /// unloading them afterwards.
+    /// </summary>
+    internal class YardarmAssemblyLoadContext : AssemblyLoadContext
+    {
+        public YardarmAssemblyLoadContext() : base(isCollectible: true)
+        {
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName) => null;
+    }
+}

--- a/src/Yardarm/Yardarm.csproj
+++ b/src/Yardarm/Yardarm.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>


### PR DESCRIPTION
Motivation
----------
Upcoming work to support source generators will require loading
assemblies from NuGet packages. This could cause conflicts across
multiple runs when imported as a library.

Modifications
-------------
Provide an internal YardarmAssemblyLoadContext which may be used for
loading assemblies dynamically during a build.