### PR TITLE
Execute source generators against the generated code

### DIFF
--- a/src/Yardarm/GenerationContext.cs
+++ b/src/Yardarm/GenerationContext.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Yardarm.Generation;
 using Yardarm.Names;
+using Yardarm.Packaging;
 using Yardarm.Spec;
 
 namespace Yardarm
@@ -20,6 +21,12 @@ namespace Yardarm
         public IServiceProvider GenerationServices { get; }
         public INamespaceProvider NamespaceProvider => _namespaceProvider.Value;
         public INameFormatterSelector NameFormatterSelector => _nameFormatterSelector.Value;
+
+        /// <summary>
+        /// Details about the NuGet restore operation, once it is completed.
+        /// </summary>
+        public NuGetRestoreInfo? NuGetRestoreInfo { get; set; }
+
         public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
 
         public GenerationContext(IServiceProvider serviceProvider)

--- a/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using NuGet.Commands;
+using NuGet.Configuration;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using Yardarm.Generation.Internal;
+using Yardarm.Internal;
+
+namespace Yardarm.Packaging.Internal
+{
+    internal class NuGetRestoreProcessor
+    {
+        public const string NetStandardFramework = ".NETStandard";
+        public static readonly Version NetStandard20 = new(2, 0, 0, 0);
+
+        private readonly PackageSpec _packageSpec;
+        private readonly YardarmAssemblyLoadContext _assemblyLoadContext;
+        private readonly ILogger<NuGetReferenceGenerator> _logger;
+
+        public NuGetRestoreProcessor(PackageSpec packageSpec, YardarmAssemblyLoadContext assemblyLoadContext,
+            ILogger<NuGetReferenceGenerator> logger)
+        {
+            _packageSpec = packageSpec ?? throw new ArgumentNullException(nameof(packageSpec));
+            _assemblyLoadContext = assemblyLoadContext ?? throw new ArgumentNullException(nameof(assemblyLoadContext));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<NuGetRestoreInfo> ExecuteAsync(CancellationToken cancellationToken = default)
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempPath);
+            try
+            {
+                using var cacheContext = new SourceCacheContext();
+
+                _packageSpec.RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    OutputPath = tempPath,
+                    ProjectName = _packageSpec.Name,
+                    ProjectStyle = ProjectStyle.PackageReference
+                };
+
+                var settings = Settings.LoadDefaultSettings(tempPath);
+
+                var logger = new NuGetLogger(_logger);
+
+                var dependencyProviders = RestoreCommandProviders.Create(
+                    SettingsUtility.GetGlobalPackagesFolder(settings),
+                    Enumerable.Empty<string>(),
+                    SettingsUtility.GetEnabledSources(settings).Select(source =>
+                        Repository.Factory.GetCoreV3(source.Source)),
+                    cacheContext,
+                    new LocalPackageFileCache(),
+                    logger);
+
+                var clientPolicyContext = ClientPolicyContext.GetClientPolicy(settings, logger);
+                var packageSourceMapping = PackageSourceMapping.GetPackageSourceMapping(settings);
+
+                var restoreRequest = new RestoreRequest(_packageSpec, dependencyProviders, cacheContext,
+                    clientPolicyContext, packageSourceMapping, logger, new LockFileBuilderCache())
+                {
+                    ProjectStyle = ProjectStyle.PackageReference, RestoreOutputPath = tempPath
+                };
+
+                var restoreCommand = new RestoreCommand(restoreRequest);
+
+                var result = await restoreCommand.ExecuteAsync(cancellationToken).ConfigureAwait(false);
+                if (!result.Success)
+                {
+                    throw new NuGetRestoreException(result);
+                }
+
+                return new NuGetRestoreInfo
+                {
+                    Result = result,
+                    Providers = dependencyProviders,
+                    SourceGenerators = CollectAnalyzers(dependencyProviders, result)
+                };
+            }
+            finally
+            {
+                Directory.Delete(tempPath, true);
+            }
+        }
+
+        // Collect C# analyzers from the direct NuGet dependencies (ignores transitive dependencies)
+        private List<ISourceGenerator> CollectAnalyzers(RestoreCommandProviders dependencyProviders, RestoreResult result)
+        {
+            var generators = new List<ISourceGenerator>();
+
+            LockFileTarget netstandardTarget = result.LockFile.Targets
+                .First(p => p.TargetFramework.Framework == NetStandardFramework &&
+                            p.TargetFramework.Version == NetStandard20);
+
+            foreach (var directDependency in _packageSpec.Dependencies)
+            {
+                // Get the exact version we restored
+                var version = netstandardTarget.Libraries.FirstOrDefault(p => p.Name == directDependency.Name)?.Version;
+                if (version is not null)
+                {
+                    var localPackageInfo =
+                        dependencyProviders.GlobalPackages.FindPackage(directDependency.Name, version);
+
+                    // For now, we explicitly only handle Roslyn 4.0 analyzers
+                    foreach (var file in localPackageInfo.Files.Where(p => p.StartsWith("analyzers/dotnet/roslyn4.0/cs/")))
+                    {
+                        // Ignore resource assemblies, just look in the root
+                        var suffix = file.Substring("analyzers/dotnet/roslyn4.0/cs/".Length);
+                        if (!suffix.Contains('/'))
+                        {
+                            generators.AddRange(GetGenerators(Path.Join(localPackageInfo.ExpandedPath, file)));
+                        }
+                    }
+                }
+            }
+
+            return generators;
+        }
+
+        // Instantiate source generators from an analyzer assembly
+        private IEnumerable<ISourceGenerator> GetGenerators(string file)
+        {
+            var assembly = _assemblyLoadContext.LoadFromAssemblyPath(file);
+
+            var generatorTypes = assembly.ExportedTypes.Where(p =>
+                p.IsClass && !p.IsGenericTypeDefinition && !p.IsAbstract
+                && p.GetCustomAttribute<GeneratorAttribute>() != null);
+
+            foreach (var generatorType in generatorTypes)
+            {
+                switch (Activator.CreateInstance(generatorType))
+                {
+                    case ISourceGenerator sourceGenerator:
+                        yield return sourceGenerator;
+                        break;
+
+                    case IIncrementalGenerator incrementalGenerator:
+                        yield return incrementalGenerator.AsSourceGenerator();
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/Yardarm/Packaging/NuGetRestoreInfo.cs
+++ b/src/Yardarm/Packaging/NuGetRestoreInfo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using NuGet.Commands;
+
+namespace Yardarm.Packaging
+{
+    public class NuGetRestoreInfo
+    {
+        /// <summary>
+        /// Providers used to execute the restore command.
+        /// </summary>
+        public RestoreCommandProviders? Providers { get; set; }
+
+        /// <summary>
+        /// Result of the restore command.
+        /// </summary>
+        public RestoreResult? Result { get; set; }
+
+        /// <summary>
+        /// List of loaded source generators to be run after other code generation is complete.
+        /// </summary>
+        public IReadOnlyList<ISourceGenerator>? SourceGenerators { get; set; }
+    }
+}

--- a/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -108,6 +108,7 @@ namespace Yardarm
                 .AddLogging()
                 .AddSingleton<GenerationContext>()
                 .AddSingleton<YardarmAssemblyLoadContext>()
+                .AddTransient<NuGetRestoreProcessor>()
                 .AddSingleton(settings)
                 .AddSingleton(document)
                 .AddTransient<NuGetPacker>();

--- a/src/Yardarm/YardarmGenerationResult.cs
+++ b/src/Yardarm/YardarmGenerationResult.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Emit;
 
 namespace Yardarm
@@ -9,12 +13,27 @@ namespace Yardarm
 
         public EmitResult CompilationResult { get; }
 
+        public ImmutableArray<Diagnostic>? AdditionalDiagnostics { get; }
+
         public bool Success => CompilationResult.Success;
 
-        public YardarmGenerationResult(GenerationContext context, EmitResult compilationResult)
+        public YardarmGenerationResult(GenerationContext context, EmitResult compilationResult, ImmutableArray<Diagnostic>? additionalDiagnostics = null)
         {
             Context = context ?? throw new ArgumentNullException(nameof(context));
             CompilationResult = compilationResult ?? throw new ArgumentNullException(nameof(compilationResult));
+            AdditionalDiagnostics = additionalDiagnostics;
+        }
+
+        public IEnumerable<Diagnostic> GetAllDiagnostics()
+        {
+            if (AdditionalDiagnostics is not null)
+            {
+                return AdditionalDiagnostics.Concat(CompilationResult.Diagnostics);
+            }
+            else
+            {
+                return CompilationResult.Diagnostics;
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
Allow extensions like System.Text.Json to execute their source
generators to add additional SyntaxTrees to the compilation.

Modifications
-------------
Refactor NuGet restoration into a separate step that puts information
onto the GenerationContext and which is executed before constructing the
CSharpCompilation. Collect source generators from the analyzers in the
NuGet packages are part of this process.

Execute the source generators as a final step after all compilation
enrichers have been executed. Collect their diagnostic output to be
returned in the YardarmGenerationResult.