### PR TITLE
Convert dynamic properties to JsonElement

### DIFF
--- a/src/Yardarm.SystemTextJson/JsonElementEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonElementEnricher.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.SystemTextJson.Helpers;
+
+namespace Yardarm.SystemTextJson
+{
+    /// <summary>
+    /// Converts schemas which use dynamic types to use <see cref="JsonElement"/> instead.
+    /// </summary>
+    /// <remarks>
+    /// This is done because System.Text.Json doesn't currently support dynamic types. This could have unwanted side effects
+    /// in the future if we're mixing JSON and non-JSON content types using the same schema. But we don't do that now so we'll
+    /// cross that bridge when we come to it.
+    /// </remarks>
+    public class JsonElementEnricher : IOpenApiSyntaxNodeEnricher<CompilationUnitSyntax, OpenApiSchema>
+    {
+        public CompilationUnitSyntax Enrich(CompilationUnitSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            var dynamicTypes = target
+                .DescendantNodes(p =>
+                    p is not QualifiedNameSyntax // Don't look inside qualified names, they can't be dynamic
+                    && p is not BlockSyntax // Don't look inside methods
+                    && p is not ArrowExpressionClauseSyntax)
+                .OfType<IdentifierNameSyntax>()
+                .Where(p => p.Identifier.ValueText == "dynamic")
+                .Select(p => p.Parent is NullableTypeSyntax nullableTypeSyntax ? nullableTypeSyntax : (TypeSyntax) p)
+                .ToArray();
+
+            if (dynamicTypes.Length == 0)
+            {
+                return target;
+            }
+
+            return target.ReplaceNodes(
+                dynamicTypes,
+                (_, _) => SystemTextJsonTypes.JsonElement);
+        }
+    }
+}

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -19,6 +19,7 @@ namespace Yardarm.SystemTextJson
                 .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonElementEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()

--- a/src/Yardarm.SystemTextJson/SystemTextJsonGeneratorCategory.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonGeneratorCategory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Yardarm.SystemTextJson.Internal
+namespace Yardarm.SystemTextJson
 {
     public class SystemTextJsonGeneratorCategory
     {


### PR DESCRIPTION
Motivation
----------
System.Text.Json can't handle dynamic properties, so use JsonElement
instead.

Modifications
-------------
Add an enricher which performs the conversion.

Note: This could have unwanted side effects in the future if we're
mixing JSON and non-JSON content types using the same schema. But we
don't do that now so we'll cross that bridge when we come to it.