### PR TITLE
Allow enrichers to get all registered types

### DIFF
--- a/src/Yardarm/Generation/GeneratorSyntaxNodeExtensions.cs
+++ b/src/Yardarm/Generation/GeneratorSyntaxNodeExtensions.cs
@@ -14,6 +14,11 @@ namespace Yardarm.Generation
             node.AddGeneratorAnnotation(generator.GetType());
 
         public static TSyntaxNode AddGeneratorAnnotation<TSyntaxNode>(this TSyntaxNode node,
+            ISyntaxTreeGenerator generator)
+            where TSyntaxNode : SyntaxNode =>
+            node.AddGeneratorAnnotation(generator.GetType());
+
+        public static TSyntaxNode AddGeneratorAnnotation<TSyntaxNode>(this TSyntaxNode node,
             Type generatorType)
             where TSyntaxNode : SyntaxNode =>
             node.WithAdditionalAnnotations(

--- a/src/Yardarm/Generation/ITypeGeneratorRegistry`2.cs
+++ b/src/Yardarm/Generation/ITypeGeneratorRegistry`2.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.Interfaces;
+﻿using System.Collections.Generic;
+using Microsoft.OpenApi.Interfaces;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation
@@ -8,5 +9,7 @@ namespace Yardarm.Generation
         where TElement : IOpenApiElement
     {
         public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element);
+
+        IEnumerable<ITypeGenerator> GetAll();
     }
 }

--- a/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
+++ b/src/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Yardarm.Spec;
@@ -30,6 +31,8 @@ namespace Yardarm.Generation.Internal
         public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element) =>
             _registry
                 .GetOrAdd(element, _createTypeGenerator);
+
+        public IEnumerable<ITypeGenerator> GetAll() => _registry.Values;
 
         private ITypeGenerator CreateTypeGenerator(ILocatedOpenApiElement<TElement> element)
         {

--- a/src/Yardarm/Generation/PrimaryGeneratorCategory.cs
+++ b/src/Yardarm/Generation/PrimaryGeneratorCategory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.OpenApi.Interfaces;
 using Yardarm.Spec;
 
@@ -30,6 +31,8 @@ namespace Yardarm.Generation
             }
 
             public ITypeGenerator Get(ILocatedOpenApiElement<TElement> element) => _innerRegistry.Get(element);
+
+            public IEnumerable<ITypeGenerator> GetAll() => _innerRegistry.GetAll();
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
Adding support for JsonSerializerContext will require knowing all
registered types so they can be listed in JsonSerializable attributes.

Modifications
-------------
Add a GetAll method to ITypeGeneratorRegistry.