### PR TITLE
Make compilation enrichers public

### DIFF
--- a/src/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
+++ b/src/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
@@ -18,10 +18,6 @@ namespace Yardarm.Enrichment.Compilation
             where T : class, IAssemblyInfoEnricher =>
             services.AddTransient<IAssemblyInfoEnricher, T>();
 
-        public static IServiceCollection AddCreateDefaultRegistryEnricher<T>(this IServiceCollection services)
-            where T : class, ICreateDefaultRegistryEnricher =>
-            services.AddTransient<ICreateDefaultRegistryEnricher, T>();
-
         public static IServiceCollection AddCompilationEnricher<T>(this IServiceCollection services)
             where T : class, ICompilationEnricher =>
             services.AddTransient<ICompilationEnricher, T>();

--- a/src/Yardarm/Enrichment/Compilation/DefaultTypeSerializersEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/DefaultTypeSerializersEnricher.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Yardarm.Enrichment.Compilation
 {
-    internal class DefaultTypeSerializersEnricher : ICompilationEnricher
+    public class DefaultTypeSerializersEnricher : ICompilationEnricher
     {
         private readonly IList<ICreateDefaultRegistryEnricher> _createDefaultRegistryEnrichers;
 

--- a/src/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
@@ -11,7 +11,7 @@ using Yardarm.Spec;
 
 namespace Yardarm.Enrichment.Compilation
 {
-    internal class OpenApiCompilationEnricher : ICompilationEnricher
+    public class OpenApiCompilationEnricher : ICompilationEnricher
     {
         private static readonly MethodInfo _genericEnrichCompilationMethod = typeof(OpenApiCompilationEnricher)
             .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)

--- a/src/Yardarm/Enrichment/Compilation/ReferenceCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/ReferenceCompilationEnricher.cs
@@ -8,7 +8,7 @@ using Yardarm.Generation;
 
 namespace Yardarm.Enrichment.Compilation
 {
-    internal class ReferenceCompilationEnricher : ICompilationEnricher
+    public class ReferenceCompilationEnricher : ICompilationEnricher
     {
         private readonly IList<IReferenceGenerator> _referenceGenerators;
 

--- a/src/Yardarm/Enrichment/Compilation/ResourceFileCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/ResourceFileCompilationEnricher.cs
@@ -14,7 +14,7 @@ namespace Yardarm.Enrichment.Compilation
     /// Applies <see cref="IResourceFileEnricher"/> enrichment to any syntax trees which were derived from
     /// resource files.
     /// </summary>
-    internal class ResourceFileCompilationEnricher : ICompilationEnricher
+    public class ResourceFileCompilationEnricher : ICompilationEnricher
     {
         private readonly IResourceFileEnricher[] _enrichers;
 

--- a/src/Yardarm/Enrichment/Compilation/SyntaxTreeCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/SyntaxTreeCompilationEnricher.cs
@@ -8,7 +8,7 @@ using Yardarm.Generation;
 
 namespace Yardarm.Enrichment.Compilation
 {
-    internal class SyntaxTreeCompilationEnricher : ICompilationEnricher
+    public class SyntaxTreeCompilationEnricher : ICompilationEnricher
     {
         private readonly IList<ISyntaxTreeGenerator> _generators;
 

--- a/src/Yardarm/Enrichment/Compilation/TargetRuntimeAssemblyInfoEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/TargetRuntimeAssemblyInfoEnricher.cs
@@ -4,7 +4,7 @@ using Yardarm.Helpers;
 
 namespace Yardarm.Enrichment.Compilation
 {
-    internal class TargetRuntimeAssemblyInfoEnricher : IAssemblyInfoEnricher
+    public class TargetRuntimeAssemblyInfoEnricher : IAssemblyInfoEnricher
     {
         public CompilationUnitSyntax Enrich(CompilationUnitSyntax syntax) => syntax
             .AddAttributeLists(


### PR DESCRIPTION
Motivation
----------
Allow extensions to reference compilation enrichers for ExecuteBefore
and ExecuteAfter.

Modifications
-------------
Make standard compilation enrichers public.

Remove an unused overload that causes extension confusion.