### PR TITLE
Apply JsonElement conversion to dynamic within generics

### DIFF
--- a/src/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json;
 using Yardarm.Enrichment;
 using Yardarm.Enrichment.Schema;
 using Yardarm.Generation;
-using Yardarm.Helpers;
 using Yardarm.SystemTextJson.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -57,18 +56,7 @@ namespace Yardarm.SystemTextJson
                 return property;
             }
 
-            // System.Text.Json requires dictionary values be JsonElement, so replace the types
-            var newDictionaryType = WellKnownTypes.System.Collections.Generic.DictionaryT.Name(
-                genericName.TypeArgumentList.Arguments[0],
-                SystemTextJsonTypes.JsonElement);
-
-            var interfaceType = WellKnownTypes.System.Collections.Generic.IDictionaryT.Name(
-                genericName.TypeArgumentList.Arguments[0],
-                SystemTextJsonTypes.JsonElement);
-
             return property
-                .WithType(interfaceType)
-                .WithInitializer(EqualsValueClause(ObjectCreationExpression(newDictionaryType)))
                 // We must have a setter for JsonExtensionData to work with System.Text.Json
                 .WithAccessorList(AccessorList(property.AccessorList!.Accessors.Add(AccessorDeclaration(SyntaxKind.SetAccessorDeclaration))))
                 // Add the JsonExtensionData attribute

--- a/src/Yardarm.SystemTextJson/JsonElementEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonElementEnricher.cs
@@ -24,11 +24,10 @@ namespace Yardarm.SystemTextJson
         {
             var dynamicTypes = target
                 .DescendantNodes(p =>
-                    p is not QualifiedNameSyntax // Don't look inside qualified names, they can't be dynamic
-                    && p is not BlockSyntax // Don't look inside methods
+                    p is not BlockSyntax // Don't look inside methods
                     && p is not ArrowExpressionClauseSyntax)
                 .OfType<IdentifierNameSyntax>()
-                .Where(p => p.Identifier.ValueText == "dynamic")
+                .Where(p => p.Parent is not QualifiedNameSyntax && p.Identifier.ValueText == "dynamic")
                 .Select(p => p.Parent is NullableTypeSyntax nullableTypeSyntax ? nullableTypeSyntax : (TypeSyntax) p)
                 .ToArray();
 


### PR DESCRIPTION
Motivation
----------
`List<dynamic>` and other generics should also be converted to
`List<JsonElement>`.

Modifications
-------------
Search within QualifiedNameSyntax for dynamic so it may find the node
within the GenericNameSyntax.

Drop the duplicate conversion in the JsonAdditionalPropertiesEnricher.