### PR TITLE
Use JsonNode instead of JsonElement in models

### DIFF
--- a/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -12,10 +12,6 @@ namespace Yardarm.SystemTextJson.Helpers
                 IdentifierName("Text")),
             IdentifierName("Json"));
 
-        public static NameSyntax JsonElement { get; } = QualifiedName(
-            SystemTextJson,
-            IdentifierName("JsonElement"));
-
         public static NameSyntax JsonSerializer { get; } = QualifiedName(
             SystemTextJson,
             IdentifierName("JsonSerializer"));
@@ -48,6 +44,18 @@ namespace Yardarm.SystemTextJson.Helpers
                 SyntaxKind.SimpleMemberAccessExpression,
                 Name,
                 IdentifierName("StartObject"));
+        }
+
+        public static class Nodes
+        {
+            // ReSharper disable once MemberHidesStaticFromOuterClass
+            public static NameSyntax Name { get; } = QualifiedName(
+                SystemTextJson,
+                IdentifierName("Nodes"));
+
+            public static NameSyntax JsonNodeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonNode"));
         }
 
         public static class Serialization

--- a/src/Yardarm.SystemTextJson/JsonNodeEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonNodeEnricher.cs
@@ -1,24 +1,31 @@
 ﻿using System;
 using System.Linq;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
+using Yardarm.Helpers;
 using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson
 {
     /// <summary>
-    /// Converts schemas which use dynamic types to use <see cref="JsonElement"/> instead.
+    /// Converts schemas which use dynamic types to use <see cref="JsonNode"/> instead.
     /// </summary>
     /// <remarks>
     /// This is done because System.Text.Json doesn't currently support dynamic types. This could have unwanted side effects
     /// in the future if we're mixing JSON and non-JSON content types using the same schema. But we don't do that now so we'll
     /// cross that bridge when we come to it.
     /// </remarks>
-    public class JsonElementEnricher : IOpenApiSyntaxNodeEnricher<CompilationUnitSyntax, OpenApiSchema>
+    public class JsonNodeEnricher : IOpenApiSyntaxNodeEnricher<CompilationUnitSyntax, OpenApiSchema>
     {
+        public Type[] ExecuteAfter { get; } =
+        {
+            typeof(JsonAdditionalPropertiesEnricher),
+        };
+
         public CompilationUnitSyntax Enrich(CompilationUnitSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context)
         {
@@ -36,9 +43,10 @@ namespace Yardarm.SystemTextJson
                 return target;
             }
 
+            var nullableJsonNode = NullableType(SystemTextJsonTypes.Nodes.JsonNodeName);
             return target.ReplaceNodes(
                 dynamicTypes,
-                (_, _) => SystemTextJsonTypes.JsonElement);
+                (_, _) => nullableJsonNode);
         }
     }
 }

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -19,7 +19,7 @@ namespace Yardarm.SystemTextJson
                 .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
-                .AddOpenApiSyntaxNodeEnricher<JsonElementEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonNodeEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()


### PR DESCRIPTION
Motivation
----------
It's very difficult to dynamically build JsonElement to fill properties,
and it's required to at least build one for a null token. The default
structure can't be used for serialization.

Modifications
-------------
Use JsonNode instead of JsonElement for dynamic properties.

For JsonExtensionData, use object instead of JsonElement. There is a bug
in System.Text.Json preventing us from using JsonNode/JsonObject at this
time.