### PR TITLE
Support strongly-typed writes of undiscriminated oneOf schemas

### DIFF
--- a/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGeneratorFactory.cs
+++ b/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGeneratorFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.OpenApi.Models;
 using Yardarm.Generation;
+using Yardarm.Names;
 using Yardarm.Spec;
 
 namespace Yardarm.SystemTextJson.Internal
@@ -9,14 +10,17 @@ namespace Yardarm.SystemTextJson.Internal
     {
         private readonly GenerationContext _context;
         private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+        private readonly IRootNamespace _rootNamespace;
 
-        public DiscriminatorConverterTypeGeneratorFactory(GenerationContext context, IJsonSerializationNamespace jsonSerializationNamespace)
+        public DiscriminatorConverterTypeGeneratorFactory(GenerationContext context, IJsonSerializationNamespace jsonSerializationNamespace,
+            IRootNamespace rootNamespace)
         {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _jsonSerializationNamespace = jsonSerializationNamespace ?? throw new ArgumentNullException(nameof(jsonSerializationNamespace));
+            _rootNamespace = rootNamespace ?? throw new ArgumentNullException(nameof(rootNamespace));
         }
 
         public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiSchema> element, ITypeGenerator? parent) =>
-            new DiscriminatorConverterTypeGenerator(element, _context, parent, _jsonSerializationNamespace);
+            new DiscriminatorConverterTypeGenerator(element, _context, parent, _jsonSerializationNamespace, _rootNamespace);
     }
 }

--- a/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
@@ -3,6 +3,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Generation;
+using Yardarm.Generation.Schema;
+using Yardarm.Spec;
 using Yardarm.SystemTextJson.Helpers;
 using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -23,7 +25,7 @@ namespace Yardarm.SystemTextJson
 
         public InterfaceDeclarationSyntax Enrich(InterfaceDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            context.Element.Discriminator?.PropertyName != null
+            target.GetGeneratorAnnotation() == typeof(OneOfSchemaGenerator)
                 ? AddJsonConverter(target, context)
                 : target;
 


### PR DESCRIPTION
Motivation
----------
There are cases where oneOf may be used on a request body schema but
not on the response, but which don't have a discriminator. This case is
supportable, though deserialization is not.

Modifications
-------------
In OneOfSchemaGenerator generate an interface even when there is no
discriminator property. Also make it public and add the generator to the
interface so we can identify it.

Add extensions to help collect all distinct schemas from an
OpenApiDocument, recursing through all layers.

Generate JsonConverters in System.Text.Json for all schemas which are
handled by the OneOfSchemaGenerator, even if they don't have a
discriminator property. Also ensure we get unique names for the
converters.

In that case where we don't have a discriminator property throw an
exception on read in the converter.