### PR TITLE
Prevent duplicate registration of interface base types

### DIFF
--- a/src/Yardarm/Enrichment/Responses/Internal/ResponseBaseTypeRegistry.cs
+++ b/src/Yardarm/Enrichment/Responses/Internal/ResponseBaseTypeRegistry.cs
@@ -3,21 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
-using Yardarm.Helpers;
 using Yardarm.Spec;
 
 namespace Yardarm.Enrichment.Responses.Internal
 {
     internal class ResponseBaseTypeRegistry : IResponseBaseTypeRegistry
     {
-        private readonly ConcurrentDictionary<ILocatedOpenApiElement<OpenApiResponse>, ConcurrentBag<BaseTypeSyntax>> _inheritance =
-            new ConcurrentDictionary<ILocatedOpenApiElement<OpenApiResponse>, ConcurrentBag<BaseTypeSyntax>>(new LocatedElementEqualityComparer<OpenApiResponse>());
+        private readonly ConcurrentDictionary<ILocatedOpenApiElement<OpenApiResponse>, ConcurrentDictionary<string, BaseTypeSyntax>> _inheritance =
+            new(new LocatedElementEqualityComparer<OpenApiResponse>());
 
         public void AddBaseType(ILocatedOpenApiElement<OpenApiResponse> schema, BaseTypeSyntax type)
         {
-            var bag = _inheritance.GetOrAdd(schema, _ => new ConcurrentBag<BaseTypeSyntax>());
+            var bag = _inheritance.GetOrAdd(schema,
+                _ => new ConcurrentDictionary<string, BaseTypeSyntax>());
 
-            bag.Add(type);
+            bag.TryAdd(type.ToString(), type);
         }
 
         public IEnumerable<BaseTypeSyntax> GetBaseTypes(ILocatedOpenApiElement<OpenApiResponse> schema)
@@ -27,7 +27,7 @@ namespace Yardarm.Enrichment.Responses.Internal
                 return Enumerable.Empty<BaseTypeSyntax>();
             }
 
-            return list;
+            return list.Values;
         }
     }
 }

--- a/src/Yardarm/Enrichment/Schema/Internal/SchemaBaseTypeRegistry.cs
+++ b/src/Yardarm/Enrichment/Schema/Internal/SchemaBaseTypeRegistry.cs
@@ -3,21 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
-using Yardarm.Helpers;
 using Yardarm.Spec;
 
 namespace Yardarm.Enrichment.Schema.Internal
 {
     internal class SchemaBaseTypeRegistry : ISchemaBaseTypeRegistry
     {
-        private readonly ConcurrentDictionary<ILocatedOpenApiElement<OpenApiSchema>, ConcurrentBag<BaseTypeSyntax>> _inheritance =
-            new ConcurrentDictionary<ILocatedOpenApiElement<OpenApiSchema>, ConcurrentBag<BaseTypeSyntax>>(new LocatedElementEqualityComparer<OpenApiSchema>());
+        private readonly ConcurrentDictionary<ILocatedOpenApiElement<OpenApiSchema>, ConcurrentDictionary<string, BaseTypeSyntax>> _inheritance =
+            new(new LocatedElementEqualityComparer<OpenApiSchema>());
 
         public void AddBaseType(ILocatedOpenApiElement<OpenApiSchema> schema, BaseTypeSyntax type)
         {
-            var bag = _inheritance.GetOrAdd(schema, _ => new ConcurrentBag<BaseTypeSyntax>());
+            var bag = _inheritance.GetOrAdd(schema,
+                _ => new ConcurrentDictionary<string, BaseTypeSyntax>());
 
-            bag.Add(type);
+            bag.TryAdd(type.ToString(), type);
         }
 
         public IEnumerable<BaseTypeSyntax> GetBaseTypes(ILocatedOpenApiElement<OpenApiSchema> schema)
@@ -27,7 +27,7 @@ namespace Yardarm.Enrichment.Schema.Internal
                 return Enumerable.Empty<BaseTypeSyntax>();
             }
 
-            return list;
+            return list.Values;
         }
     }
 }


### PR DESCRIPTION
Motivation
----------
When we add support for dual targeting duplicate registrations will
cause errors.

Modifications
-------------
Ensure that each base type can only be registered once for schemas and
responses.

Results
--------
We can no longer register the same base types more than once, preventing
errors if we generate and compile more than once. It may also help prevent
other bugs.