### PR TITLE
Include more complete preprocessor symbols for resources

### DIFF
--- a/src/Yardarm.NewtonsoftJson/Internal/ClientGenerator.cs
+++ b/src/Yardarm.NewtonsoftJson/Internal/ClientGenerator.cs
@@ -7,8 +7,8 @@ namespace Yardarm.NewtonsoftJson.Internal
     {
         protected override string ResourcePrefix => "Yardarm.NewtonsoftJson.Client.";
 
-        public ClientGenerator(IRootNamespace rootNamespace)
-            : base(rootNamespace)
+        public ClientGenerator(GenerationContext generationContext, IRootNamespace rootNamespace)
+            : base(generationContext, rootNamespace)
         {
         }
     }

--- a/src/Yardarm.SystemTextJson/Internal/ClientGenerator.cs
+++ b/src/Yardarm.SystemTextJson/Internal/ClientGenerator.cs
@@ -7,8 +7,8 @@ namespace Yardarm.SystemTextJson.Internal
     {
         protected override string ResourcePrefix => "Yardarm.SystemTextJson.Client.";
 
-        public ClientGenerator(IRootNamespace rootNamespace)
-            : base(rootNamespace)
+        public ClientGenerator(GenerationContext generationContext,IRootNamespace rootNamespace)
+            : base(generationContext, rootNamespace)
         {
         }
     }

--- a/src/Yardarm/Generation/Internal/ClientGenerator.cs
+++ b/src/Yardarm/Generation/Internal/ClientGenerator.cs
@@ -6,8 +6,8 @@ namespace Yardarm.Generation.Internal
     {
         protected override string ResourcePrefix => "Yardarm.Client.";
 
-        public ClientGenerator(IRootNamespace rootNamespace)
-            : base(rootNamespace)
+        public ClientGenerator(GenerationContext generationContext, IRootNamespace rootNamespace)
+            : base(generationContext, rootNamespace)
         {
         }
     }

--- a/src/Yardarm/GenerationContext.cs
+++ b/src/Yardarm/GenerationContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using NuGet.Frameworks;
 using Yardarm.Generation;
 using Yardarm.Names;
 using Yardarm.Packaging;
@@ -26,6 +27,8 @@ namespace Yardarm
         /// Details about the NuGet restore operation, once it is completed.
         /// </summary>
         public NuGetRestoreInfo? NuGetRestoreInfo { get; set; }
+
+        public NuGetFramework? CurrentTargetFramework { get; set; }
 
         public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
 

--- a/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
@@ -35,8 +35,8 @@ namespace Yardarm.Packaging.Internal
         {
             // Get the libraries to import for targeting netstandard2.0
             LockFileTarget netstandardTarget = lockFile.Targets
-                .First(p => p.TargetFramework.Framework == NuGetRestoreProcessor.NetStandardFramework &&
-                            p.TargetFramework.Version == NuGetRestoreProcessor.NetStandard20);
+                .First(p => p.TargetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework &&
+                            p.TargetFramework.Version == NuGetFrameworkConstants.NetStandard20);
 
             // Collect all DLL files from CompileTimeAssemblies from that target
             // Note that we apply File.Exists since there may be muliple paths we're searching for each file listed

--- a/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -20,9 +20,6 @@ namespace Yardarm.Packaging.Internal
 {
     internal class NuGetRestoreProcessor
     {
-        public const string NetStandardFramework = ".NETStandard";
-        public static readonly Version NetStandard20 = new(2, 0, 0, 0);
-
         private readonly PackageSpec _packageSpec;
         private readonly YardarmAssemblyLoadContext _assemblyLoadContext;
         private readonly ILogger<NuGetReferenceGenerator> _logger;
@@ -99,8 +96,8 @@ namespace Yardarm.Packaging.Internal
             var generators = new List<ISourceGenerator>();
 
             LockFileTarget netstandardTarget = result.LockFile.Targets
-                .First(p => p.TargetFramework.Framework == NetStandardFramework &&
-                            p.TargetFramework.Version == NetStandard20);
+                .First(p => p.TargetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework &&
+                            p.TargetFramework.Version == NuGetFrameworkConstants.NetStandard20);
 
             foreach (var directDependency in _packageSpec.Dependencies)
             {

--- a/src/Yardarm/Packaging/NuGetFrameworkConstants.cs
+++ b/src/Yardarm/Packaging/NuGetFrameworkConstants.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Yardarm.Packaging
+{
+    public static class NuGetFrameworkConstants
+    {
+        public const string NetStandardFramework = ".NETStandard";
+        public const string NetCoreApp = ".NETCoreApp";
+        public static readonly Version NetStandard20 = new(2, 0, 0, 0);
+    }
+}

--- a/src/Yardarm/YardarmGenerator.cs
+++ b/src/Yardarm/YardarmGenerator.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using NuGet.Frameworks;
 using Yardarm.Enrichment;
 using Yardarm.Enrichment.Compilation;
 using Yardarm.Internal;
@@ -33,8 +34,10 @@ namespace Yardarm
             var serviceProvider = settings.BuildServiceProvider(document);
             try
             {
-                // Perform the NuGet restore
                 var context = serviceProvider.GetRequiredService<GenerationContext>();
+                context.CurrentTargetFramework = NuGetFramework.Parse("netstandard2.0"));
+
+                // Perform the NuGet restore
                 var restoreProcessor = serviceProvider.GetRequiredService<NuGetRestoreProcessor>();
                 context.NuGetRestoreInfo = await restoreProcessor.ExecuteAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Yardarm/YardarmGenerator.cs
+++ b/src/Yardarm/YardarmGenerator.cs
@@ -35,7 +35,7 @@ namespace Yardarm
             try
             {
                 var context = serviceProvider.GetRequiredService<GenerationContext>();
-                context.CurrentTargetFramework = NuGetFramework.Parse("netstandard2.0"));
+                context.CurrentTargetFramework = NuGetFramework.Parse("netstandard2.0");
 
                 // Perform the NuGet restore
                 var restoreProcessor = serviceProvider.GetRequiredService<NuGetRestoreProcessor>();


### PR DESCRIPTION
Motivation
----------
We want to start supporting targets other than netstandard2.0.

Modifications
-------------
Add a CurrentTargetFramework property to GenerationContext, always set
to netstandard2.0 for now.

Update ResourceSyntaxTreeGenerator to add standard multi-targeting
preprocessor symbols for most of the frameworks we care about, based on
the CurrentTargetFramework.

Move some constants to be more accessible.

Results
-------
No significant difference for now, but a step closer to multi-target.