### PR TITLE
Execute source generators per target framework

### DIFF
--- a/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -16,7 +16,6 @@ using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using Yardarm.Generation.Internal;
-using Yardarm.Internal;
 
 namespace Yardarm.Packaging.Internal
 {

--- a/src/Yardarm/Packaging/NuGetRestoreInfo.cs
+++ b/src/Yardarm/Packaging/NuGetRestoreInfo.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using Microsoft.CodeAnalysis;
 using NuGet.Commands;
 
 namespace Yardarm.Packaging
@@ -10,16 +8,17 @@ namespace Yardarm.Packaging
         /// <summary>
         /// Providers used to execute the restore command.
         /// </summary>
-        public RestoreCommandProviders? Providers { get; set; }
+        public RestoreCommandProviders Providers { get; set; }
 
         /// <summary>
         /// Result of the restore command.
         /// </summary>
-        public RestoreResult? Result { get; set; }
+        public RestoreResult Result { get; set; }
 
-        /// <summary>
-        /// List of loaded source generators to be run after other code generation is complete.
-        /// </summary>
-        public IReadOnlyList<ISourceGenerator>? SourceGenerators { get; set; }
+        public NuGetRestoreInfo(RestoreCommandProviders providers, RestoreResult result)
+        {
+            Providers = providers;
+            Result = result;
+        }
     }
 }

--- a/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -16,7 +16,6 @@ using Yardarm.Generation.Request;
 using Yardarm.Generation.Response;
 using Yardarm.Generation.Schema;
 using Yardarm.Generation.Tag;
-using Yardarm.Internal;
 using Yardarm.Names;
 using Yardarm.Names.Internal;
 using Yardarm.Packaging;

--- a/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -107,7 +107,6 @@ namespace Yardarm
             services
                 .AddLogging()
                 .AddSingleton<GenerationContext>()
-                .AddSingleton<YardarmAssemblyLoadContext>()
                 .AddTransient<NuGetRestoreProcessor>()
                 .AddSingleton(settings)
                 .AddSingleton(document)

--- a/src/Yardarm/YardarmGenerationResult.cs
+++ b/src/Yardarm/YardarmGenerationResult.cs
@@ -13,11 +13,11 @@ namespace Yardarm
 
         public EmitResult CompilationResult { get; }
 
-        public ImmutableArray<Diagnostic>? AdditionalDiagnostics { get; }
+        public ImmutableArray<Diagnostic> AdditionalDiagnostics { get; }
 
         public bool Success => CompilationResult.Success;
 
-        public YardarmGenerationResult(GenerationContext context, EmitResult compilationResult, ImmutableArray<Diagnostic>? additionalDiagnostics = null)
+        public YardarmGenerationResult(GenerationContext context, EmitResult compilationResult, ImmutableArray<Diagnostic> additionalDiagnostics)
         {
             Context = context ?? throw new ArgumentNullException(nameof(context));
             CompilationResult = compilationResult ?? throw new ArgumentNullException(nameof(compilationResult));
@@ -26,7 +26,7 @@ namespace Yardarm
 
         public IEnumerable<Diagnostic> GetAllDiagnostics()
         {
-            if (AdditionalDiagnostics is not null)
+            if (!AdditionalDiagnostics.IsDefaultOrEmpty)
             {
                 return AdditionalDiagnostics.Concat(CompilationResult.Diagnostics);
             }


### PR DESCRIPTION
Motivation
----------
Source generators may vary by target framework since dependencies may
vary by target framework once we support multi-targeting.

Modifications
-------------
Remove SourceGenerators from NuGetRestoreInfo and instead call
NuGetRestoreProcessor to request source generators for a specific
framework.

Make the lifetime of the AssemblyLoadContext specific to the analyzer
steps.

Results
-------
When we add multi-targeting we'll be able to execute source generators
differently for each target.