### PR TITLE
Get dependencies per target framework

### DIFF
--- a/src/Yardarm.NewtonsoftJson/JsonDependencyGenerator.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonDependencyGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 using Yardarm.Packaging;
@@ -7,7 +8,7 @@ namespace Yardarm.NewtonsoftJson
 {
     public class JsonDependencyGenerator : IDependencyGenerator
     {
-        public IEnumerable<LibraryDependency> GetDependencies()
+        public IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework)
         {
             yield return new LibraryDependency
             {

--- a/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 using Yardarm.Packaging;
@@ -7,17 +9,22 @@ namespace Yardarm.SystemTextJson
 {
     public class JsonDependencyGenerator : IDependencyGenerator
     {
-        public IEnumerable<LibraryDependency> GetDependencies()
+        public IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework)
         {
-            yield return new LibraryDependency
+            if (targetFramework.Framework != NuGetFrameworkConstants.NetCoreApp || targetFramework.Version < new Version(6, 0))
             {
-                LibraryRange = new LibraryRange
+                // Only add System.Text.Json if we're not already targeting .NET 6
+
+                yield return new LibraryDependency
                 {
-                    Name = "System.Text.Json",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("6.0.0")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System.Text.Json",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("6.0.0")
+                    }
+                };
+            }
 
             yield return new LibraryDependency
             {

--- a/src/Yardarm/Enrichment/Packaging/DependencyPackageSpecEnricher.cs
+++ b/src/Yardarm/Enrichment/Packaging/DependencyPackageSpecEnricher.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
@@ -17,8 +18,11 @@ namespace Yardarm.Enrichment.Packaging
 
         public PackageSpec Enrich(PackageSpec packageSpec)
         {
-            packageSpec.Dependencies.AddRange(_dependencyGenerators
-                .SelectMany(p => p.GetDependencies()));
+            foreach (TargetFrameworkInformation targetFramework in packageSpec.TargetFrameworks)
+            {
+                targetFramework.Dependencies.AddRange(_dependencyGenerators
+                    .SelectMany(p => p.GetDependencies(targetFramework.FrameworkName)));
+            }
 
             return packageSpec;
         }

--- a/src/Yardarm/Packaging/IDependencyGenerator.cs
+++ b/src/Yardarm/Packaging/IDependencyGenerator.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 
 namespace Yardarm.Packaging
 {
     public interface IDependencyGenerator
     {
-        IEnumerable<LibraryDependency> GetDependencies();
+        IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework);
     }
 }

--- a/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
@@ -34,13 +34,12 @@ namespace Yardarm.Packaging.Internal
         private IEnumerable<string> ExtractDependencies(LockFile lockFile)
         {
             // Get the libraries to import for targeting netstandard2.0
-            LockFileTarget netstandardTarget = lockFile.Targets
-                .First(p => p.TargetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework &&
-                            p.TargetFramework.Version == NuGetFrameworkConstants.NetStandard20);
+            LockFileTarget lockFileTarget = lockFile.Targets
+                .First(p => p.TargetFramework == _context.CurrentTargetFramework);
 
             // Collect all DLL files from CompileTimeAssemblies from that target
-            // Note that we apply File.Exists since there may be muliple paths we're searching for each file listed
-            List<string> dependencies = netstandardTarget.Libraries
+            // Note that we apply File.Exists since there may be multiple paths we're searching for each file listed
+            List<string> dependencies = lockFileTarget.Libraries
                 .SelectMany(p => p.CompileTimeAssemblies.Select(q => new
                 {
                     Library = p,
@@ -55,17 +54,31 @@ namespace Yardarm.Packaging.Internal
                 .Where(File.Exists)
                 .ToList();
 
-            // NETStandard.Library is a bit different, it has reference assemblies in the build/netstandard2.0/ref directory
-            // which are imported via a MSBuild target file in the package. So we need to emulate that behavior here.
+            // Collect platform reference assemblies, i.e. .NET 6 assemblies
+            dependencies.AddRange(lockFileTarget.Libraries
+                .Where(package => package.PackageType.Any(type => type.Name == "DotnetPlatform"))
+                .Select(package =>
+                    _context.NuGetRestoreInfo!.Providers.GlobalPackages.FindPackage(package.Name, package.Version))
+                .SelectMany(localPackageInfo =>
+                    localPackageInfo.Files
+                        .Where(p => p.StartsWith($"ref/{lockFileTarget.TargetFramework.GetShortFolderName()}") &&
+                                    p.EndsWith(".dll"))
+                        .Select(p => Path.Combine(localPackageInfo.ExpandedPath, p.Replace('/', Path.DirectorySeparatorChar)))));
 
-            LockFileTargetLibrary netstandardLibrary = netstandardTarget.Libraries.First(p => p.Name == NetStandardLibrary);
+            LockFileTargetLibrary? netstandardLibrary = lockFileTarget.Libraries.FirstOrDefault(p => p.Name == NetStandardLibrary);
+            if (netstandardLibrary is not null)
+            {
+                // NETStandard.Library is a bit different, it has reference assemblies in the build/netstandard2.0/ref directory
+                // which are imported via a MSBuild target file in the package. So we need to emulate that behavior here.
 
-            string refDirectory = lockFile.PackageFolders.Select(p => p.Path)
-                .Select(p => Path.Combine(p, netstandardLibrary.Name.ToLowerInvariant(), netstandardLibrary.Version.ToString()))
-                .First(Directory.Exists);
-            refDirectory = Path.Combine(refDirectory, "build", "netstandard2.0", "ref");
+                string refDirectory = lockFile.PackageFolders.Select(p => p.Path)
+                    .Select(p => Path.Combine(p, netstandardLibrary.Name.ToLowerInvariant(),
+                        netstandardLibrary.Version.ToString()))
+                    .First(Directory.Exists);
+                refDirectory = Path.Combine(refDirectory, "build", "netstandard2.0", "ref");
 
-            dependencies.AddRange(Directory.EnumerateFiles(refDirectory, "*.dll"));
+                dependencies.AddRange(Directory.EnumerateFiles(refDirectory, "*.dll"));
+            }
 
             return dependencies;
         }

--- a/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using NuGet.Frameworks;
 using NuGet.LibraryModel;
 using NuGet.Versioning;
 
@@ -6,47 +7,70 @@ namespace Yardarm.Packaging.Internal
 {
     internal class StandardDependencyGenerator : IDependencyGenerator
     {
-        public IEnumerable<LibraryDependency> GetDependencies()
+        public IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework)
         {
-            yield return new LibraryDependency
+            if (targetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework
+                && targetFramework.Version == NuGetFrameworkConstants.NetStandard20)
             {
-                LibraryRange = new LibraryRange
+                // Only include NETStandard.Library for restore, not as a listed dependency on the generated package
+                yield return new LibraryDependency
                 {
-                    Name = "NETStandard.Library",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("2.0.3")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "NETStandard.Library",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("2.0.3")
+                    },
+                    SuppressParent = LibraryIncludeFlags.All
+                };
 
-            yield return new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
+                yield return new LibraryDependency
                 {
-                    Name = "Microsoft.CSharp",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("4.7.0")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System.ComponentModel.Annotations",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("4.7.0")
+                    }
+                };
 
-            yield return new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
+                yield return new LibraryDependency
                 {
-                    Name = "System.ComponentModel.Annotations",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("4.7.0")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System.Threading.Tasks.Extensions",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("4.5.4")
+                    }
+                };
 
-            yield return new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
+                yield return new LibraryDependency
                 {
-                    Name = "System.Threading.Tasks.Extensions",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("4.5.4")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "Microsoft.CSharp",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("4.7.0")
+                    }
+                };
+            }
+
+            if (targetFramework.Framework == NuGetFrameworkConstants.NetCoreApp)
+            {
+                yield return new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "Microsoft.NetCore.App.Ref",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = new VersionRange(minVersion: new NuGetVersion(
+                            targetFramework.Version.Major, targetFramework.Version.Minor, targetFramework.Version.Revision)),
+                    },
+                    IncludeType = LibraryIncludeFlags.None,
+                    SuppressParent = LibraryIncludeFlags.All,
+                    AutoReferenced = true,
+                };
+            }
         }
     }
 }

--- a/src/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/Yardarm/Packaging/NuGetPacker.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using NuGet.Frameworks;
+using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
+using NuGet.ProjectModel;
 using NuGet.Versioning;
 using Yardarm.Enrichment;
 using Yardarm.Enrichment.Packaging;
@@ -16,16 +18,16 @@ namespace Yardarm.Packaging
     {
         private readonly OpenApiDocument _document;
         private readonly YardarmGenerationSettings _settings;
-        private readonly IList<IDependencyGenerator> _dependencyGenerators;
+        private readonly PackageSpec _packageSpec;
         private readonly IList<INuGetPackageEnricher> _packageEnrichers;
 
         public NuGetPacker(OpenApiDocument document, YardarmGenerationSettings settings,
-            IEnumerable<IDependencyGenerator> dependencyGenerators,
+            PackageSpec packageSpec,
             IEnumerable<INuGetPackageEnricher> packageEnrichers)
         {
             _document = document ?? throw new ArgumentNullException(nameof(document));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
-            _dependencyGenerators = dependencyGenerators.ToArray();
+            _packageSpec = packageSpec ?? throw new ArgumentNullException(nameof(packageSpec));
             _packageEnrichers = packageEnrichers.ToArray();
         }
 
@@ -45,16 +47,15 @@ namespace Yardarm.Packaging
                 {
                     new StreamPackageFile(dllStream, $"lib/netstandard2.0/{_settings.AssemblyName}.dll", "netstandard2.0"),
                     new StreamPackageFile(xmlDocumentationStream, $"lib/netstandard2.0/{_settings.AssemblyName}.xml", "netstandard2.0")
-                },
-                DependencyGroups =
-                {
-                    new PackageDependencyGroup(
-                        NuGetFramework.Parse("netstandard2.0"),
-                        _dependencyGenerators
-                            .SelectMany(p => p.GetDependencies())
-                            .Select(p => new PackageDependency(p.LibraryRange.Name, p.LibraryRange.VersionRange)))
                 }
             };
+
+            builder.DependencyGroups.AddRange(_packageSpec.TargetFrameworks.Select(
+                targetFramework => new PackageDependencyGroup(
+                    targetFramework.FrameworkName,
+                    targetFramework.Dependencies
+                        .Where(dependency => dependency.SuppressParent != LibraryIncludeFlags.All)
+                        .Select(dependency => new PackageDependency(dependency.LibraryRange.Name, dependency.LibraryRange.VersionRange)))));
 
             builder = builder.Enrich(_packageEnrichers);
 
@@ -79,16 +80,15 @@ namespace Yardarm.Packaging
                 Files =
                 {
                     new StreamPackageFile(pdbStream, $"lib/netstandard2.0/{_settings.AssemblyName}.pdb", "netstandard2.0"),
-                },
-                DependencyGroups =
-                {
-                    new PackageDependencyGroup(
-                        NuGetFramework.Parse("netstandard2.0"),
-                        _dependencyGenerators
-                            .SelectMany(p => p.GetDependencies())
-                            .Select(p => new PackageDependency(p.LibraryRange.Name, p.LibraryRange.VersionRange)))
                 }
             };
+
+            builder.DependencyGroups.AddRange(_packageSpec.TargetFrameworks.Select(
+                targetFramework => new PackageDependencyGroup(
+                    targetFramework.FrameworkName,
+                    targetFramework.Dependencies
+                        .Where(dependency => dependency.SuppressParent != LibraryIncludeFlags.All)
+                        .Select(dependency => new PackageDependency(dependency.LibraryRange.Name, dependency.LibraryRange.VersionRange)))));
 
             builder = builder.Enrich(_packageEnrichers);
 


### PR DESCRIPTION
Motivation
----------
When we add multi-targeting the dependencies will vary per target
framework.

Modifications
-------------
Add a target framework parameter to IDependencyGenerator, and update
call sites.

Add logic to StandardDependencyGenerator to vary dependencies between
netstandard2.0 and net6.0. Also vary the dependencies slightly for
System.Text.Json support.

Add support for excluding packages marked as SuppresParents from the
output nuspec file. Also update the NuGetPacker to use the previously
collected dependencies from the PackageSpec rather than generating them
again.