### PR TITLE
Support multi-targeting NuGet packages

### DIFF
--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -296,6 +296,12 @@ namespace Yardarm.CommandLine
 
         private void ApplyNuGetSettings(YardarmGenerationSettings settings)
         {
+            string[] targetFrameworks = _options.TargetFrameworks.ToArray();
+            if (targetFrameworks.Length > 0)
+            {
+                settings.TargetFrameworkMonikers = targetFrameworks.ToImmutableArray();
+            }
+
             if (!string.IsNullOrEmpty(_options.RepositoryType) && !string.IsNullOrEmpty(_options.RepositoryUrl))
             {
                 settings.Repository =

--- a/src/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/Yardarm.CommandLine/GenerateOptions.cs
@@ -17,6 +17,9 @@ namespace Yardarm.CommandLine
         [Option('v', "version", Default = "1.0.0", HelpText = "Generated assembly version")]
         public string Version { get; set; }
 
+        [Option('t', "target-frameworks", HelpText = "List of target framework monikers. Must be a single item unless outputting a NuGet package.")]
+        public IEnumerable<string> TargetFrameworks { get; set; }
+
         [Option("keyfile", HelpText = "Key file to create a strongly-named assembly")]
         public string KeyFile { get; set; }
 

--- a/src/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
+++ b/src/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
@@ -22,10 +22,9 @@ namespace Yardarm.Packaging
         }
 
         public virtual PackageSpec Generate() =>
-            new PackageSpec(new[]
-            {
-                new TargetFrameworkInformation {FrameworkName = NuGetFramework.Parse("netstandard2.0")}
-            })
+            new PackageSpec(_settings.TargetFrameworkMonikers
+                .Select(tfm => new TargetFrameworkInformation {FrameworkName = NuGetFramework.Parse(tfm)})
+                .ToList())
             {
                 Name = _settings.AssemblyName,
                 Dependencies = new List<LibraryDependency>()

--- a/src/Yardarm/YardarmCompilationResult.cs
+++ b/src/Yardarm/YardarmCompilationResult.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using NuGet.Frameworks;
+
+namespace Yardarm
+{
+    public class YardarmCompilationResult
+    {
+        public NuGetFramework TargetFramework { get; set; }
+        public EmitResult EmitResult { get; }
+        internal Stream DllOutput { get; }
+        internal Stream PdbOutput { get; }
+        internal Stream XmlDocumentationOutput { get; }
+        public ImmutableArray<Diagnostic> AdditionalDiagnostics { get; }
+
+        internal YardarmCompilationResult(NuGetFramework targetFramework, EmitResult emitResult, Stream dllOutput, Stream pdbOutput,
+            Stream xmlDocumentationOutput, ImmutableArray<Diagnostic> additionalDiagnostics)
+        {
+            TargetFramework = targetFramework;
+            EmitResult = emitResult;
+            DllOutput = dllOutput;
+            PdbOutput = pdbOutput;
+            XmlDocumentationOutput = xmlDocumentationOutput;
+            AdditionalDiagnostics = additionalDiagnostics;
+        }
+    }
+}

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -46,6 +47,9 @@ namespace Yardarm
             get => _xmlDocumentationOutput ??= new MemoryStream();
             set => _xmlDocumentationOutput = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        public ImmutableArray<string> TargetFrameworkMonikers { get; set; } =
+            new[] {"netstandard2.0"}.ToImmutableArray();
 
         public Stream? NuGetOutput { get; set; }
 


### PR DESCRIPTION
Motivation
----------
Some features of System.Text.Json don't work well (or at all) when you
target netstandard2.0 and then use the feature on net6.0 or later.

Modifications
-------------
Refactor NuGet packaging to accept multiple compilation outputs against
multiple target frameworks.

Refactor YardarmGenerationResult to include multiple complication
outputs.

Add a new command-line parameter to specify the desired target
framework.