### PR TITLE
Resolve warnings when targeting .NET 6

### DIFF
--- a/src/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
+++ b/src/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
@@ -44,7 +44,7 @@ namespace RootNamespace.Authentication.Internal
 
                     for (int i = 0; i < set.SecuritySchemes.Length; i++)
                     {
-                        if (!_schemes.TryGetValue(set.SecuritySchemes[i], out PropertyInfo property))
+                        if (!_schemes.TryGetValue(set.SecuritySchemes[i], out PropertyInfo? property))
                         {
                             return null;
                         }

--- a/src/Yardarm.Client/OperationHelpers.cs
+++ b/src/Yardarm.Client/OperationHelpers.cs
@@ -35,8 +35,8 @@ namespace Yardarm.Client
                         builder.Append('&');
                     }
 
-                    builder.AppendFormat("{0}={1}", Uri.EscapeUriString(parameter.Key),
-                        Uri.EscapeUriString(parameter.Value.ToString()));
+                    builder.AppendFormat("{0}={1}", Uri.EscapeDataString(parameter.Key),
+                        Uri.EscapeDataString(parameter.Value.ToString() ?? ""));
                 }
             }
 

--- a/src/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -38,14 +38,14 @@ namespace RootNamespace.Serialization
         {
             MethodInfo joinList = _joinListMethod.MakeGenericMethod(itemType);
 
-            return (string)joinList.Invoke(this, new object[] {separator, list});
+            return (string)joinList.Invoke(this, new object[] {separator, list})!;
         }
 
         public object DeserializeList(IEnumerable<string> values, Type itemType)
         {
             MethodInfo deserializeList = _deserializeListMethod.MakeGenericMethod(itemType);
 
-            return deserializeList.Invoke(this, new object[] {values});
+            return deserializeList.Invoke(this, new object[] {values})!;
         }
 
         // ReSharper disable once UnusedMember.Local

--- a/src/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
+++ b/src/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
@@ -42,7 +42,7 @@ namespace RootNamespace.Serialization
         private void SerializeProperty(MultipartFormDataContent content,
             MultipartFormDataSerializationData serializationData, object? value, PropertyInfo property)
         {
-            if (!serializationData.Encoding.TryGetValue(property.Name, out MultipartEncoding encoding))
+            if (!serializationData.Encoding.TryGetValue(property.Name, out MultipartEncoding? encoding))
             {
                 // All properties should have a provided encoding
                 return;

--- a/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
+++ b/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
@@ -35,9 +35,9 @@ namespace RootNamespace.Serialization
         public static ValueTask<T> DeserializeAsync<T>(this ITypeSerializerRegistry typeSerializerRegistry,
             HttpContent content)
         {
-            string mediaType = content.Headers.ContentType.MediaType;
+            string? mediaType = content.Headers.ContentType?.MediaType;
 
-            if (!typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? typeSerializer))
+            if (mediaType is null || !typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? typeSerializer))
             {
                 throw new UnknownMediaTypeException(mediaType, content);
             }

--- a/src/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/Yardarm.Client/Yardarm.Client.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>RootNamespace</RootNamespace>
+    <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <RootNamespace>RootNamespace</RootNamespace>
+    <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
@@ -22,11 +22,11 @@ namespace RootNamespace.Serialization.Json
 
             foreach (string name in Enum.GetNames(type))
             {
-                var enumMember = type.GetField(name);
-                T enumValue = (T) enumMember.GetValue(null);
+                var enumMember = type.GetField(name)!;
+                T enumValue = (T) enumMember.GetValue(null)!;
 
                 var attribute = (EnumMemberAttribute?) enumMember.GetCustomAttributes(typeof(EnumMemberAttribute), false).FirstOrDefault();
-                var stringValue = attribute is not null ? attribute.Value : name;
+                var stringValue = attribute?.Value ?? name;
 
                 _stringToEnum.Add(stringValue, enumValue);
                 _enumToString.Add(enumValue, JsonEncodedText.Encode(stringValue));

--- a/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <RootNamespace>RootNamespace</RootNamespace>
+    <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
     <LangVersion>10</LangVersion>


### PR DESCRIPTION
Motivation
----------
We'd rather not have warnings.

Modifications
-------------
Add .NET 6 targets to .Client libraries so we get the warnings in VS as
well.

Fix various null reference warnings.

Switch to using Uri.EscapeDataString when building a query string.