### PR TITLE
Resolve source generators from .NET 6 libraries

### DIFF
--- a/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
@@ -61,7 +61,7 @@ namespace Yardarm.Packaging.Internal
                 {
                     LibraryRange = new LibraryRange
                     {
-                        Name = "Microsoft.NetCore.App.Ref",
+                        Name = "Microsoft.NETCore.App.Ref",
                         TypeConstraint = LibraryDependencyTarget.Package,
                         VersionRange = new VersionRange(minVersion: new NuGetVersion(
                             targetFramework.Version.Major, targetFramework.Version.Minor, targetFramework.Version.Revision)),


### PR DESCRIPTION
Motivation
----------
Source generators in Microsoft.NETCore.App.Ref are located slightly
differently than the ones in System.Text.Json.

Modifications
-------------
When loading source generators get framework-specific generators and
use a case-insensitive name comparison.

Use a RegEx to find matches and make "roslyn4.0" in the file path
optional.