### PR TITLE
Support filtering resource files by target framework

### DIFF
--- a/src/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/Yardarm.Client/Yardarm.Client.csproj
@@ -15,4 +15,9 @@
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+  </ItemGroup>
+
 </Project>

--- a/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -26,6 +26,9 @@
     copy that's embedded.
     -->
     <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
+
+    <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 
 </Project>

--- a/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
@@ -29,6 +29,9 @@
     copy that's embedded.
     -->
     <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
+
+    <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 
 </Project>

--- a/src/Yardarm/GenerationContext.cs
+++ b/src/Yardarm/GenerationContext.cs
@@ -28,7 +28,7 @@ namespace Yardarm
         /// </summary>
         public NuGetRestoreInfo? NuGetRestoreInfo { get; set; }
 
-        public NuGetFramework? CurrentTargetFramework { get; set; }
+        public NuGetFramework CurrentTargetFramework { get; set; } = NuGetFramework.UnsupportedFramework;
 
         public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
 


### PR DESCRIPTION
Motivation
----------
For entire files that should be included or excluded by target
framework, detecting this based upon the file name would be helpful.

Modifications
-------------
When targeting .NET Standard, exclude any resource files ending in
".netstandard.cs".

When targeting .NET Core, exclude any resource files ending in
".netcoreapp.cs".

Add matching MSBuild statements to the .Client projects.