### PR TITLE
Support netstandard2.1 target

### DIFF
--- a/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -24,17 +24,17 @@ namespace Yardarm.SystemTextJson
                         VersionRange = VersionRange.Parse("6.0.0")
                     }
                 };
-            }
 
-            yield return new LibraryDependency
-            {
-                LibraryRange = new LibraryRange
+                yield return new LibraryDependency
                 {
-                    Name = "System.Net.Http.Json",
-                    TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("6.0.0")
-                }
-            };
+                    LibraryRange = new LibraryRange
+                    {
+                        Name = "System.Net.Http.Json",
+                        TypeConstraint = LibraryDependencyTarget.Package,
+                        VersionRange = VersionRange.Parse("6.0.0")
+                    }
+                };
+            }
         }
     }
 }

--- a/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
@@ -9,20 +9,50 @@ namespace Yardarm.Packaging.Internal
     {
         public IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework)
         {
-            if (targetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework
-                && targetFramework.Version == NuGetFrameworkConstants.NetStandard20)
+            if (targetFramework.Framework == NuGetFrameworkConstants.NetStandardFramework)
             {
-                // Only include NETStandard.Library for restore, not as a listed dependency on the generated package
-                yield return new LibraryDependency
+                if (targetFramework.Version == NuGetFrameworkConstants.NetStandard20)
                 {
-                    LibraryRange = new LibraryRange
+                    // Only include NETStandard.Library for restore, not as a listed dependency on the generated package
+                    yield return new LibraryDependency
                     {
-                        Name = "NETStandard.Library",
-                        TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("2.0.3")
-                    },
-                    SuppressParent = LibraryIncludeFlags.All
-                };
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "NETStandard.Library",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("2.0.3")
+                        },
+                        SuppressParent = LibraryIncludeFlags.All,
+                        AutoReferenced = true,
+                    };
+
+                    // Only include System.Threading.Tasks.Extensions for netstandard2.0
+                    yield return new LibraryDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "System.Threading.Tasks.Extensions",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("4.5.4")
+                        }
+                    };
+                }
+                else if (targetFramework.Version == NuGetFrameworkConstants.NetStandard21)
+                {
+                    // Only include NETStandard.Library.Ref for restore, not as a listed dependency on the generated package
+                    yield return new LibraryDependency
+                    {
+                        LibraryRange = new LibraryRange
+                        {
+                            Name = "NETStandard.Library.Ref",
+                            TypeConstraint = LibraryDependencyTarget.Package,
+                            VersionRange = VersionRange.Parse("2.1.0")
+                        },
+                        IncludeType = LibraryIncludeFlags.None,
+                        SuppressParent = LibraryIncludeFlags.All,
+                        AutoReferenced = true,
+                    };
+                }
 
                 yield return new LibraryDependency
                 {
@@ -38,24 +68,13 @@ namespace Yardarm.Packaging.Internal
                 {
                     LibraryRange = new LibraryRange
                     {
-                        Name = "System.Threading.Tasks.Extensions",
-                        TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("4.5.4")
-                    }
-                };
-
-                yield return new LibraryDependency
-                {
-                    LibraryRange = new LibraryRange
-                    {
                         Name = "Microsoft.CSharp",
                         TypeConstraint = LibraryDependencyTarget.Package,
                         VersionRange = VersionRange.Parse("4.7.0")
                     }
                 };
             }
-
-            if (targetFramework.Framework == NuGetFrameworkConstants.NetCoreApp)
+            else if (targetFramework.Framework == NuGetFrameworkConstants.NetCoreApp)
             {
                 yield return new LibraryDependency
                 {

--- a/src/Yardarm/Packaging/NuGetFrameworkConstants.cs
+++ b/src/Yardarm/Packaging/NuGetFrameworkConstants.cs
@@ -6,6 +6,8 @@ namespace Yardarm.Packaging
     {
         public const string NetStandardFramework = ".NETStandard";
         public const string NetCoreApp = ".NETCoreApp";
+
         public static readonly Version NetStandard20 = new(2, 0, 0, 0);
+        public static readonly Version NetStandard21 = new(2, 1, 0, 0);
     }
 }

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -63,7 +63,12 @@ namespace Yardarm
                 .WithOverflowChecks(false)
                 .WithPlatform(Platform.AnyCpu)
                 .WithConcurrentBuild(true)
-                .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default);
+                .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
+                .WithSpecificDiagnosticOptions(new KeyValuePair<string, ReportDiagnostic>[]
+                {
+                    // Don't warn for binding redirects
+                    new("CS1701", ReportDiagnostic.Suppress)
+                });
 
         public YardarmGenerationSettings()
         {


### PR DESCRIPTION
Motivation
----------
We'd also like to be able to target .NET Standard 2.1.

Modifications
-------------
Add dependency version precedence when processing NuGet packages and
suppress binding redirect warnings.

Add standard dependencies for .NET Standard 2.1.

Remove the unnecessary dependency on System.Net.Http.Json from .NET 6.