### PR TITLE
Use "global::" before well known namespaces

### DIFF
--- a/src/Yardarm.NewtonsoftJson/Helpers/NewtonsoftJsonTypes.cs
+++ b/src/Yardarm.NewtonsoftJson/Helpers/NewtonsoftJsonTypes.cs
@@ -7,7 +7,9 @@ namespace Yardarm.NewtonsoftJson.Helpers
     internal static class NewtonsoftJsonTypes
     {
         public static NameSyntax NewtonsoftJson { get; } = QualifiedName(
-            IdentifierName("Newtonsoft"),
+            AliasQualifiedName(
+                IdentifierName(Token(SyntaxKind.GlobalKeyword)),
+                IdentifierName("Newtonsoft")),
             IdentifierName("Json"));
 
         public static NameSyntax NewtonsoftJsonConverters { get; } = QualifiedName(

--- a/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -8,7 +8,9 @@ namespace Yardarm.SystemTextJson.Helpers
     {
         public static NameSyntax SystemTextJson { get; } = QualifiedName(
             QualifiedName(
-                IdentifierName("System"),
+                AliasQualifiedName(
+                    IdentifierName(Token(SyntaxKind.GlobalKeyword)),
+                    IdentifierName("System")),
                 IdentifierName("Text")),
             IdentifierName("Json"));
 

--- a/src/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/Yardarm/Helpers/WellKnownTypes.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -10,7 +11,9 @@ namespace Yardarm.Helpers
     {
         public static partial class System
         {
-            public static NameSyntax Name { get; } = IdentifierName("System");
+            public static NameSyntax Name { get; } = AliasQualifiedName(
+                IdentifierName(Token(SyntaxKind.GlobalKeyword)),
+                IdentifierName("System"));
 
             public static class ArgumentNullException
             {
@@ -69,6 +72,24 @@ namespace Yardarm.Helpers
                                 GenericName(
                                     Identifier("List"),
                                     TypeArgumentList(SingletonSeparatedList(itemType))));
+
+                        public static bool IsOfType(TypeSyntax nameSyntax, [NotNullWhen(true)] out TypeSyntax? genericArgument)
+                        {
+                            if (nameSyntax is not QualifiedNameSyntax qualifiedName
+                                || !qualifiedName.Left.IsEquivalentTo(Generic.Name)
+                                || qualifiedName.Right is not GenericNameSyntax
+                                {
+                                    Identifier.ValueText: "List",
+                                    TypeArgumentList.Arguments.Count: 1
+                                } genericName)
+                            {
+                                genericArgument = null;
+                                return false;
+                            }
+
+                            genericArgument = genericName.TypeArgumentList.Arguments[0];
+                            return true;
+                        }
                     }
 
                     public static class KeyValuePair


### PR DESCRIPTION
Motivation
----------
Prevent possible name conflicts if we have using statements in an
extension.

Modifications
-------------
Qualify all well known namespaces with "global::".

Add a helper that tests if a type is `List<T>` and extracts the `T`.