### PR TITLE
Correct semver prerelease handling in NuGet package output

### DIFF
--- a/src/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/Yardarm/Packaging/NuGetPacker.cs
@@ -38,7 +38,7 @@ namespace Yardarm.Packaging
             {
                 Id = _settings.AssemblyName,
                 Version = new NuGetVersion(_settings.Version,
-                    _settings.VersionSuffix?.Split(new[] {'-'}, StringSplitOptions.RemoveEmptyEntries),
+                    _settings.VersionSuffix?.TrimStart('-').Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries),
                     null, null),
                 Description = _settings.AssemblyName,
                 Summary = _document.Info.Description,
@@ -68,7 +68,7 @@ namespace Yardarm.Packaging
             {
                 Id = _settings.AssemblyName,
                 Version = new NuGetVersion(_settings.Version,
-                    _settings.VersionSuffix?.Split(new [] {'-'}, StringSplitOptions.RemoveEmptyEntries),
+                    _settings.VersionSuffix?.TrimStart('-').Split(new [] {'.'}, StringSplitOptions.RemoveEmptyEntries),
                     null, null),
                 PackageTypes =
                 {


### PR DESCRIPTION
Motivation
----------
We're incorrectly sending suffixes with dashes into the NuGet package
separated by periods.

Modifications
-------------
When splitting the release labels to fill the NuGetVersion, split on
periods not dashes. Also remove the leading dash.