### PR TITLE
Simplify constructors for OperationResponse

### DIFF
--- a/src/Yardarm.Client/Responses/OperationResponse.cs
+++ b/src/Yardarm.Client/Responses/OperationResponse.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using RootNamespace.Serialization;
 
 // ReSharper disable once CheckNamespace
@@ -16,19 +17,24 @@ namespace RootNamespace.Responses
 
         protected ITypeSerializerRegistry TypeSerializerRegistry { get; }
 
+        protected OperationResponse(HttpResponseMessage message)
+            : this (message, Serialization.TypeSerializerRegistry.Instance)
+        {
+        }
+
         protected OperationResponse(HttpResponseMessage message, ITypeSerializerRegistry typeSerializerRegistry)
         {
             Message = message ?? throw new ArgumentNullException(nameof(message));
             TypeSerializerRegistry = typeSerializerRegistry ?? throw new ArgumentNullException(nameof(typeSerializerRegistry));
 
             // ReSharper disable once VirtualMemberCallInConstructor
-            ParseHeaders();
+            ParseHeaders(message.Headers);
         }
 
         /// <summary>
         /// Called during construction to parse headers from the message into properties.
         /// </summary>
-        protected virtual void ParseHeaders()
+        protected virtual void ParseHeaders(HttpResponseHeaders headers)
         {
         }
 

--- a/src/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
+++ b/src/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
@@ -8,6 +8,20 @@ namespace RootNamespace.Serialization
 {
     public class TypeSerializerRegistry : ITypeSerializerRegistry
     {
+        private static ITypeSerializerRegistry? s_instance;
+        public static ITypeSerializerRegistry Instance
+        {
+            get => s_instance ??= CreateDefaultRegistry();
+            set {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
+                s_instance = value;
+            }
+        }
+
         private readonly IDictionary<string, ITypeSerializer> _registry = new Dictionary<string, ITypeSerializer>();
 
         public ITypeSerializer Get(string mediaType) => _registry[mediaType];

--- a/src/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
+++ b/src/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -40,10 +41,22 @@ namespace Yardarm.Enrichment.Responses
 
         public MethodDeclarationSyntax GenerateMethod(ILocatedOpenApiElement<OpenApiResponse> response) =>
             MethodDeclaration(
-                    PredefinedType(Token(SyntaxKind.VoidKeyword)),
-                    "ParseHeaders")
-                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword))
-                .WithBody(Block(GenerateStatements(response)));
+                default,
+                new SyntaxTokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)),
+                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                null,
+                Identifier("ParseHeaders"),
+                null,
+                ParameterList(SingletonSeparatedList(
+                    Parameter(
+                        default,
+                        default,
+                        WellKnownTypes.System.Net.Http.Headers.HttpResponseHeaders.Name,
+                        Identifier("headers"),
+                        null))),
+                default,
+                Block(GenerateStatements(response)),
+                null);
 
         protected virtual IEnumerable<StatementSyntax> GenerateStatements(
             ILocatedOpenApiElement<OpenApiResponse> response)
@@ -77,8 +90,7 @@ namespace Yardarm.Enrichment.Responses
 
                 yield return IfStatement(
                     WellKnownTypes.System.Net.Http.Headers.HttpHeaders.TryGetValues(
-                        SyntaxHelpers.MemberAccess(IdentifierName("Message"),
-                            "Headers"),
+                        IdentifierName("headers"),
                         SyntaxHelpers.StringLiteral(header.Key),
                         valuesName),
                     Block(

--- a/src/Yardarm/Helpers/WellKnownTypes.Http.cs
+++ b/src/Yardarm/Helpers/WellKnownTypes.Http.cs
@@ -49,6 +49,13 @@ namespace Yardarm.Helpers
                                         Argument(null, Token(SyntaxKind.OutKeyword), outValues));
                         }
 
+                        public static class HttpResponseHeaders
+                        {
+                            public static NameSyntax Name { get; } = QualifiedName(
+                                Headers.Name,
+                                IdentifierName("HttpResponseHeaders"));
+                        }
+
                         public static class MediaTypeWithQualityHeaderValue
                         {
                             public static NameSyntax Name { get; } = QualifiedName(


### PR DESCRIPTION
Motivation
----------
Improve the ability to mock operation responses for unit tests which
consume a mock API.

Modifications
-------------
Add additional constructors to OperationResponse and its descendants
that don't require a TypeSerializerRegistry. Add a static instance of
the registry which is used as the fallback.

Change ParseHeaders to take the headers as a parameter rather than pull
them from the HttpResponseMessage. This will allow the addition of
other constructor overloads which receive headers elsewhere in future
commits.

Relates to #77