### PR TITLE
Include source file names for generated syntax trees

### DIFF
--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -37,7 +37,16 @@ namespace Yardarm.CommandLine
 
             var generator = new YardarmGenerator();
 
-            var settings = new YardarmGenerationSettings(_options.AssemblyName);
+            string basePath = _options.InputFile;
+            if (!Path.IsPathFullyQualified(basePath))
+            {
+                basePath = Path.Combine(AppContext.BaseDirectory, basePath);
+            }
+
+            var settings = new YardarmGenerationSettings(_options.AssemblyName)
+            {
+                BasePath = basePath
+            };
 
             ApplyVersion(settings);
 

--- a/src/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
+++ b/src/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Yardarm.Enrichment;
@@ -9,10 +11,13 @@ namespace Yardarm.Generation.Internal
 {
     internal class AssemblyInfoGenerator : ISyntaxTreeGenerator
     {
+        private readonly GenerationContext _context;
         private readonly IEnumerable<IAssemblyInfoEnricher> _enrichers;
 
-        public AssemblyInfoGenerator(IEnumerable<IAssemblyInfoEnricher> enrichers)
+        public AssemblyInfoGenerator(GenerationContext context,
+            IEnumerable<IAssemblyInfoEnricher> enrichers)
         {
+            _context = context;
             _enrichers = enrichers ?? throw new ArgumentNullException(nameof(enrichers));
         }
 
@@ -21,7 +26,9 @@ namespace Yardarm.Generation.Internal
             yield return CSharpSyntaxTree.Create(
                 SyntaxFactory.CompilationUnit()
                     .Enrich(_enrichers)
-                    .NormalizeWhitespace());
+                    .NormalizeWhitespace(),
+                path: Path.Combine(_context.Settings.BasePath, "Properties", "AssemblyInfo.cs"),
+                encoding: Encoding.UTF8);
         }
     }
 }

--- a/src/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Yardarm.Generation.Internal;
+using Yardarm.Helpers;
 using Yardarm.Names;
 using Yardarm.Packaging;
 
@@ -58,10 +59,14 @@ namespace Yardarm.Generation
                 _ => Array.Empty<string>()
             };
 
-            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(rawText),
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(rawText, Encoding.UTF8),
                 CSharpParseOptions.Default
                     .WithLanguageVersion(LanguageVersion.CSharp10)
-                    .WithPreprocessorSymbols(preprocessorSymbols));
+                    .WithPreprocessorSymbols(preprocessorSymbols),
+                path: Path.Combine(
+                    GenerationContext.Settings.BasePath,
+                    "Resources",
+                    PathHelpers.NormalizePath(resourceName)));
 
             // Annotate the compilation root so we know which resource file it came from
             syntaxTree = syntaxTree.WithRootAndOptions(

--- a/src/Yardarm/Generation/TypeGeneratorBase.cs
+++ b/src/Yardarm/Generation/TypeGeneratorBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -41,8 +42,17 @@ namespace Yardarm.Generation
 
             var compilationUnit = GenerateCompilationUnit(members);
 
-            return CSharpSyntaxTree.Create(compilationUnit);
+            return CSharpSyntaxTree.Create(compilationUnit,
+                path: GetSourceFilePath(),
+                encoding: Encoding.UTF8);
         }
+
+        /// <summary>
+        /// For types that are not nested, returns the unique file path which should
+        /// be associated with the <see cref="SyntaxTree"/>.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract string? GetSourceFilePath();
 
         /// <summary>
         /// Gets the namespace to use when generated a full syntax tree.

--- a/src/Yardarm/Generation/TypeGeneratorBase`1.cs
+++ b/src/Yardarm/Generation/TypeGeneratorBase`1.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Interfaces;
+using Yardarm.Helpers;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation
@@ -20,5 +22,26 @@ namespace Yardarm.Generation
             base.GenerateCompilationUnit(members)
                 // Annotate the overall compilation unit with the element so it may be enriched with additional classes, etc
                 .AddElementAnnotation(Element, Context.ElementRegistry);
+
+        /// <inheritdoc />
+        protected override string? GetSourceFilePath()
+        {
+            string? elementPath = Element.ToString();
+            if (string.IsNullOrEmpty(elementPath))
+            {
+                return null;
+            }
+
+            if (elementPath[0] == '/')
+            {
+                elementPath = $"{elementPath[1..]}.cs";
+            }
+            else
+            {
+                elementPath = $"{elementPath}.cs";
+            }
+
+            return Path.Combine(Context.Settings.BasePath, PathHelpers.NormalizePath(elementPath));
+        }
     }
 }

--- a/src/Yardarm/GenerationContext.cs
+++ b/src/Yardarm/GenerationContext.cs
@@ -17,6 +17,7 @@ namespace Yardarm
         private readonly Lazy<INameFormatterSelector> _nameFormatterSelector;
         private readonly Lazy<ITypeGeneratorRegistry> _typeGeneratorRegistry;
 
+        public YardarmGenerationSettings Settings { get; }
         public OpenApiDocument Document => _openApiDocument.Value;
         public IOpenApiElementRegistry ElementRegistry => _elementRegistry.Value;
         public IServiceProvider GenerationServices { get; }
@@ -35,6 +36,7 @@ namespace Yardarm
         public GenerationContext(IServiceProvider serviceProvider)
         {
             GenerationServices = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            Settings = serviceProvider.GetRequiredService<YardarmGenerationSettings>();
 
             _openApiDocument = new Lazy<OpenApiDocument>(serviceProvider.GetRequiredService<OpenApiDocument>);
             _elementRegistry = new Lazy<IOpenApiElementRegistry>(serviceProvider.GetRequiredService<IOpenApiElementRegistry>);

--- a/src/Yardarm/Helpers/PathHelpers.cs
+++ b/src/Yardarm/Helpers/PathHelpers.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Yardarm.Helpers
+{
+    internal static class PathHelpers
+    {
+        private static readonly HashSet<char> s_invalidPathChars;
+
+        static PathHelpers()
+        {
+            s_invalidPathChars = Path.GetInvalidPathChars().ToHashSet();
+
+            s_invalidPathChars.Add('{');
+            s_invalidPathChars.Add('}');
+        }
+
+        /// <summary>
+        /// Normalize an OpenAPI path into a file path.
+        /// </summary>
+        /// <param name="path">Path to normalize.</param>
+        /// <returns>Normalized path.</returns>
+        public static string NormalizePath(string path)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (path == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(path));
+            }
+
+            var builder = new StringBuilder(path);
+            NormalizePath(builder);
+            return builder.ToString();
+        }
+
+        public static void NormalizePath(StringBuilder builder)
+        {
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+            if (builder == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(builder));
+            }
+
+            for (int i = 0; i < builder.Length; i++)
+            {
+                char ch = builder[i];
+
+                if (Path.DirectorySeparatorChar != '/' && ch == '/')
+                {
+                    builder[i] = Path.DirectorySeparatorChar;
+                }
+                else if (s_invalidPathChars.Contains(ch))
+                {
+                    builder[i] = '_';
+                }
+            }
+        }
+    }
+}

--- a/src/Yardarm/Helpers/ThrowHelper.cs
+++ b/src/Yardarm/Helpers/ThrowHelper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Yardarm.Helpers
+{
+    internal static class ThrowHelper
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+    }
+}

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -25,10 +25,17 @@ namespace Yardarm
 
         public string AssemblyName { get; set; } = "Yardarm.Sdk";
         public string RootNamespace { get; set; } = "Yardarm.Sdk";
+
         public Version Version { get; set; } = new Version(1, 0, 0);
         public string? VersionSuffix { get; set; }
         public string Author { get; set; } = "anonymous";
         public RepositoryMetadata? Repository { get; set; }
+
+        /// <summary>
+        /// Base path for generated source files. Files are not persisted to this path,
+        /// but it is used within Roslyn to uniquely identify source files.
+        /// </summary>
+        public string BasePath { get; set; } = AppContext.BaseDirectory;
 
         public Stream DllOutput
         {


### PR DESCRIPTION
Motivation
----------
File names are required for source files, even generated source files,
to support linking debug information in the PDB.

Modifications
-------------
Generate a file name, relative to the incoming source OpenAPI file, for
each generated file. These file names are not necessarily valid paths,
given that they may have invalid characters, but should be sufficient
for linking debug information.