### PR TITLE
Embed source files in PDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 netstandard2.0 --n
 # Related files will be output beside that file.
 ```
 
+## Source Code
+
+Source code for the generated SDKs is created dynamically, in-memory and is never persisted
+to disk. This is an intentional decision for performance. However, the source code itself
+may be useful. Perhaps a decompiler would like to offer a better-formatted look at your
+generated SDK. Or perhaps the SDK consumer would like to step through the SDK code in their
+debugger.
+
+This is supported using the `--embed` command line switch. When this switch is set, the generated
+code will be formatted with standard whitespace and embedded in the PDB file with any symbols
+output. If generating a NuGet package, they will be included in the `snupkg` file. This makes
+the source code available to modern debuggers and decompilers.
+
+Note: To debug into a generated SDK in Visual Studio, be sure to uncheck Just My Code in the
+debugging options of Visual Studio.
+
 ## A note on System.Text.Json support
 
 When using System.Text.Json, it is recommended that you target net6.0 at a minimum. Multi-targeting and including

--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -45,7 +45,8 @@ namespace Yardarm.CommandLine
 
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
-                BasePath = basePath
+                BasePath = basePath,
+                EmbedAllSources = _options.EmbedAllSources,
             };
 
             ApplyVersion(settings);

--- a/src/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/Yardarm.CommandLine/GenerateOptions.cs
@@ -23,6 +23,9 @@ namespace Yardarm.CommandLine
         [Option("keyfile", HelpText = "Key file to create a strongly-named assembly")]
         public string KeyFile { get; set; }
 
+        [Option("embed", HelpText = "Embed source files with debug symbols")]
+        public bool EmbedAllSources { get; set; }
+
         #region DLL
 
         [Option('o', "output", HelpText = "Output directory or .dll file. Indicate a directory with a trailing slash.", SetName = "dll")]

--- a/src/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
+++ b/src/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
@@ -12,7 +12,8 @@ namespace Yardarm.Enrichment.Compilation
                 .AddCompilationEnricher<ResourceFileCompilationEnricher>()
                 .AddCompilationEnricher<SyntaxTreeCompilationEnricher>()
                 .AddCompilationEnricher<OpenApiCompilationEnricher>()
-                .AddCompilationEnricher<DefaultTypeSerializersEnricher>();
+                .AddCompilationEnricher<DefaultTypeSerializersEnricher>()
+                .AddCompilationEnricher<FormatCompilationEnricher>();
 
         public static IServiceCollection AddAssemblyInfoEnricher<T>(this IServiceCollection services)
             where T : class, IAssemblyInfoEnricher =>

--- a/src/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.Extensions.Logging;
+using Yardarm.Generation;
+
+namespace Yardarm.Enrichment.Compilation
+{
+    /// <summary>
+    /// When <see cref="YardarmGenerationSettings.EmbedAllSources"/> is enabled, formats each
+    /// <see cref="SyntaxTree"/> with proper whitespace formatting so that embedded source files
+    /// are legible.
+    /// </summary>
+    /// <remarks>
+    /// This does not run when not embedding source code for performance reasons.
+    /// </remarks>
+    public class FormatCompilationEnricher : ICompilationEnricher
+    {
+        private readonly YardarmGenerationSettings _settings;
+        private readonly ILogger<FormatCompilationEnricher> _logger;
+
+        public Type[] ExecuteAfter { get; } =
+        {
+            typeof(VersionAssemblyInfoEnricher),
+            typeof(SyntaxTreeCompilationEnricher),
+            typeof(DefaultTypeSerializersEnricher)
+        };
+
+        public FormatCompilationEnricher(YardarmGenerationSettings settings,
+            ILogger<FormatCompilationEnricher> logger)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(logger);
+
+            _settings = settings;
+            _logger = logger;
+        }
+
+        public async ValueTask<CSharpCompilation> EnrichAsync(CSharpCompilation target,
+            CancellationToken cancellationToken = default)
+        {
+            if (!_settings.EmbedAllSources)
+            {
+                // Don't bother formatting if we're not embedding source
+                return target;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+
+            using var workspace = new AdhocWorkspace();
+            Project project = workspace
+                .AddSolution(
+                    SolutionInfo.Create(
+                        SolutionId.CreateNewId(_settings.AssemblyName),
+                        VersionStamp.Default))
+                .AddProject(_settings.AssemblyName, _settings.AssemblyName + ".dll",
+                    LanguageNames.CSharp);
+
+            // Exclude resource files (already formatted) or files with no path (won't be embedded)
+            IEnumerable<SyntaxTree> treesToBeFormatted = target.SyntaxTrees
+                .Where(static p => p.FilePath != "" && p.HasCompilationUnitRoot &&
+                                   p.GetCompilationUnitRoot().GetResourceNameAnnotation() is null);
+
+            // Process formatting in parallel, this gives a slight perf boost
+            object lockObj = new();
+            await Parallel.ForEachAsync(treesToBeFormatted, cancellationToken,
+                async (syntaxTree, localCt) =>
+                {
+                    SyntaxNode root = await syntaxTree.GetRootAsync(localCt);
+                    Document document = project.AddDocument(Guid.NewGuid().ToString(), root);
+
+                    document = await Formatter.FormatAsync(document, cancellationToken: localCt);
+                    SyntaxNode? newRoot = await document.GetSyntaxRootAsync(localCt);
+
+                    if (newRoot is not null && newRoot != root)
+                    {
+                        lock (lockObj)
+                        {
+                            target = target.ReplaceSyntaxTree(syntaxTree,
+                                syntaxTree.WithRootAndOptions(newRoot, syntaxTree.Options));
+                        }
+                    }
+                });
+
+            stopwatch.Stop();
+
+            _logger.LogInformation("Sources formatted for embedding in {elapsed}ms", stopwatch.ElapsedMilliseconds);
+
+            return target;
+        }
+    }
+}

--- a/src/Yardarm/Yardarm.csproj
+++ b/src/Yardarm/Yardarm.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.3.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -37,6 +37,12 @@ namespace Yardarm
         /// </summary>
         public string BasePath { get; set; } = AppContext.BaseDirectory;
 
+        /// <summary>
+        /// If true, embed generated source code in the symbols PDB file and package. This
+        /// enables stepping into the generated SDK when debugging.
+        /// </summary>
+        public bool EmbedAllSources { get; set; }
+
         public Stream DllOutput
         {
             get => _dllOutput ??= new MemoryStream();


### PR DESCRIPTION
Motivation
----------
Support for debugging the generated SDK and improved decompilation in
modern decompilers that read source from the PDB.

Modifications
-------------
- Add a command line switch.
- When enabled, perform a formatting step on the generated source files
  to ensure proper whitespace.
- When enabled, include the generated files and other files such as
  resource files in the PDB with filenames matching the compilation.

Results
-------
- Modern decompilers can show well formed C# code from the PDB.
- Debuggers such as Visual Studio (with Just My Code disabled) can step
  into the SDK source code from the PDB.