### PR TITLE
Provide SerializationData to serializers (framework only)

### DIFF
--- a/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
+++ b/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
@@ -33,7 +33,7 @@ namespace RootNamespace.Serialization
         }
 
         public static ValueTask<T> DeserializeAsync<T>(this ITypeSerializerRegistry typeSerializerRegistry,
-            HttpContent content)
+            HttpContent content, ISerializationData? serializationData = null)
         {
             string? mediaType = content.Headers.ContentType?.MediaType;
 
@@ -42,18 +42,18 @@ namespace RootNamespace.Serialization
                 throw new UnknownMediaTypeException(mediaType, content);
             }
 
-            return typeSerializer.DeserializeAsync<T>(content);
+            return typeSerializer.DeserializeAsync<T>(content, serializationData);
         }
 
         public static HttpContent Serialize<T>(this ITypeSerializerRegistry typeSerializerRegistry,
-            T value, string mediaType)
+            T value, string mediaType, ISerializationData? serializationData = null)
         {
             if (!typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? typeSerializer))
             {
                 throw new UnknownMediaTypeException(mediaType);
             }
 
-            return typeSerializer.Serialize(value, mediaType);
+            return typeSerializer.Serialize(value, mediaType, serializationData);
         }
     }
 }

--- a/src/Yardarm/Generation/MediaType/RequestMediaTypeGenerator.cs
+++ b/src/Yardarm/Generation/MediaType/RequestMediaTypeGenerator.cs
@@ -22,11 +22,11 @@ namespace Yardarm.Generation.MediaType
 
         protected IRequestsNamespace RequestsNamespace { get; }
         protected ISerializerSelector SerializerSelector { get; }
-        protected IBuildContentMethodGenerator BuildContentMethodGenerator { get; }
+        protected IList<IRequestMemberGenerator> MemberGenerators { get; }
 
         public RequestMediaTypeGenerator(ILocatedOpenApiElement<OpenApiMediaType> mediaTypeElement,
             GenerationContext context, ITypeGenerator parent, IRequestsNamespace requestsNamespace,
-            ISerializerSelector serializerSelector, IBuildContentMethodGenerator buildContentMethodGenerator)
+            ISerializerSelector serializerSelector, IList<IRequestMemberGenerator> memberGenerators)
             : base(mediaTypeElement, context, parent)
         {
             if (parent == null)
@@ -36,8 +36,8 @@ namespace Yardarm.Generation.MediaType
 
             RequestsNamespace = requestsNamespace ?? throw new ArgumentNullException(nameof(requestsNamespace));
             SerializerSelector = serializerSelector ?? throw new ArgumentNullException(nameof(serializerSelector));
-            BuildContentMethodGenerator = buildContentMethodGenerator ??
-                                          throw new ArgumentNullException(nameof(buildContentMethodGenerator));
+            MemberGenerators = memberGenerators ??
+                               throw new ArgumentNullException(nameof(memberGenerators));
 
             RequestTypeGenerator = FindParentRequestTypeGenerator(parent)
                                    ?? throw new InvalidOperationException(
@@ -109,7 +109,8 @@ namespace Yardarm.Generation.MediaType
             }
 
             yield return declaration.AddMembers(
-                BuildContentMethodGenerator.Generate(RequestTypeGenerator.Element, Element));
+                MemberGenerators.SelectMany(p => p.Generate(RequestTypeGenerator.Element, Element))
+                    .ToArray());
         }
 
         protected virtual PropertyDeclarationSyntax CreateBodyPropertyDeclaration(ILocatedOpenApiElement<OpenApiSchema> schema)

--- a/src/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -38,11 +38,19 @@ namespace Yardarm.Generation.Request
                     Parameter(Identifier(RequestMessageParameterName))
                         .WithType(WellKnownTypes.System.Net.Http.HttpRequestMessage.Name));
 
-        public MemberDeclarationSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType) =>
-            GenerateHeader(operation)
+        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
+        {
+            if (mediaType is not null)
+            {
+                // Only generate for the main request, not media types
+                yield break;
+            }
+
+            yield return GenerateHeader(operation)
                 .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                 .WithBody(Block(GenerateStatements(operation)));
+        }
 
         protected virtual IEnumerable<StatementSyntax> GenerateStatements(
             ILocatedOpenApiElement<OpenApiOperation> operation)

--- a/src/Yardarm/Generation/Request/BuildRequestMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildRequestMethodGenerator.cs
@@ -32,11 +32,19 @@ namespace Yardarm.Generation.Request
                     Parameter(Identifier(TypeSerializerRegistryParameterName))
                         .WithType(SerializationNamespace.ITypeSerializerRegistry));
 
-        public MemberDeclarationSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType) =>
-            GenerateHeader(operation)
+        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
+        {
+            if (mediaType is not null)
+            {
+                // Only generate for the main request, not media types
+                yield break;
+            }
+
+            yield return GenerateHeader(operation)
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .WithBody(Block(GenerateStatements(operation)));
+        }
 
         protected virtual IEnumerable<StatementSyntax> GenerateStatements(
             ILocatedOpenApiElement<OpenApiOperation> operation)

--- a/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -29,9 +30,15 @@ namespace Yardarm.Generation.Request
                 PredefinedType(Token(SyntaxKind.StringKeyword)),
                 BuildUriMethodName);
 
-        public MemberDeclarationSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
             ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
         {
+            if (mediaType is not null)
+            {
+                // Only generate for the main request, not media types
+                yield break;
+            }
+
             var propertyNameFormatter = Context.NameFormatterSelector.GetFormatter(NameKind.Property);
 
             var path = (LocatedOpenApiElement<OpenApiPathItem>)operation.Parent!;
@@ -82,7 +89,7 @@ namespace Yardarm.Generation.Request
                     pathExpression, buildArrayExpression);
             }
 
-            return GenerateHeader(operation)
+            yield return GenerateHeader(operation)
                 .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                 .WithExpressionBody(ArrowExpressionClause(
                     pathExpression));

--- a/src/Yardarm/Generation/Request/IRequestMemberGenerator.cs
+++ b/src/Yardarm/Generation/Request/IRequestMemberGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Spec;
 
@@ -6,6 +7,7 @@ namespace Yardarm.Generation.Request
 {
     public interface IRequestMemberGenerator
     {
-        MemberDeclarationSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation, ILocatedOpenApiElement<OpenApiMediaType>? mediaType);
+        IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+            ILocatedOpenApiElement<OpenApiMediaType>? mediaType);
     }
 }

--- a/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
@@ -65,7 +65,7 @@ namespace Yardarm.Generation.Request
             declaration = declaration.AddMembers(
                 GenerateParameterProperties(className)
                     .Concat(MemberGenerators
-                        .Select(p => p.Generate(Element, null)))
+                        .SelectMany(p => p.Generate(Element, null)))
                     .ToArray());
 
             yield return declaration;

--- a/src/Yardarm/Generation/Request/SerializationDataPropertyGenerator.cs
+++ b/src/Yardarm/Generation/Request/SerializationDataPropertyGenerator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Request
+{
+    public class SerializationDataPropertyGenerator : IRequestMemberGenerator
+    {
+        public const string SerializationDataPropertyName = "SerializationData";
+
+        protected ISerializationNamespace SerializationNamespace { get; }
+
+        public SerializationDataPropertyGenerator(ISerializationNamespace serializationNamespace)
+        {
+            ArgumentNullException.ThrowIfNull(serializationNamespace);
+
+            SerializationNamespace = serializationNamespace;
+        }
+
+        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
+        {
+            if (mediaType == null)
+            {
+                // Only add the property in inherited classes for a specific media type
+                yield break;
+            }
+
+            // TODO: Add handling for specific media types
+
+            // Default behavior is to return null
+            yield return PropertyDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.StaticKeyword)),
+                NullableType(SerializationNamespace.ISerializationData),
+                null,
+                Identifier(SerializationDataPropertyName),
+                null,
+                ArrowExpressionClause(LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                null,
+                Token(SyntaxKind.SemicolonToken));
+        }
+
+        // If type is null, assumes we're accessing from within the same class
+        public static ExpressionSyntax GetSerializationData(TypeSyntax? type = null) =>
+            type is not null
+                ? MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    type,
+                    IdentifierName(SerializationDataPropertyName))
+                : IdentifierName(SerializationDataPropertyName);
+    }
+}

--- a/src/Yardarm/Names/ISerializationNamespace.cs
+++ b/src/Yardarm/Names/ISerializationNamespace.cs
@@ -7,6 +7,7 @@ namespace Yardarm.Names
     {
         NameSyntax HeaderSerializer { get; }
         ExpressionSyntax HeaderSerializerInstance { get; }
+        NameSyntax ISerializationData { get; }
         NameSyntax ITypeSerializer { get; }
         NameSyntax ITypeSerializerRegistry { get; }
         NameSyntax MultipartEncodingAttribute { get; }

--- a/src/Yardarm/Names/Internal/SerializationNamespace.cs
+++ b/src/Yardarm/Names/Internal/SerializationNamespace.cs
@@ -11,6 +11,7 @@ namespace Yardarm.Names.Internal
         public NameSyntax HeaderSerializer { get; }
         public ExpressionSyntax HeaderSerializerInstance { get; }
         public NameSyntax Name { get; }
+        public NameSyntax ISerializationData { get; }
         public NameSyntax ITypeSerializer { get; }
         public NameSyntax ITypeSerializerRegistry { get; }
         public NameSyntax MultipartEncodingAttribute { get; }
@@ -38,6 +39,10 @@ namespace Yardarm.Names.Internal
             HeaderSerializerInstance = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                 HeaderSerializer,
                 IdentifierName("Instance"));
+
+            ISerializationData = QualifiedName(
+                Name,
+                IdentifierName("ISerializationData"));
 
             ITypeSerializer = QualifiedName(
                 Name,

--- a/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ namespace Yardarm
             services.AddSingleton<IRequestMemberGenerator, BuildContentMethodGenerator>();
             services.AddSingleton<IRequestMemberGenerator, BuildRequestMethodGenerator>();
             services.AddSingleton<IRequestMemberGenerator, BuildUriMethodGenerator>();
+            services.AddSingleton<IRequestMemberGenerator, SerializationDataPropertyGenerator>();
             services.AddSingleton<IResponseMethodGenerator, GetBodyMethodGenerator>();
             services.AddSingleton<IResponseMethodGenerator, BodyConstructorMethodGenerator>();
             services.AddSingleton<IResponseMethodGenerator, NoBodyConstructorMethodGenerator>();


### PR DESCRIPTION
Motivation
----------
Serializers, such as the multi-part serializer, require additional data
to function. This provides the framework of a method to provide this
data, though more work is required.

Modifications
-------------
Include a read-only, static SerializationData property on media type
specific request classes. This always returns null for now. Forward
this on to the serializer.

Call IRequestMemberGenerators for media type specific request classes,
and update them all to be more intelligent and recognize if they should
generate a member or not based on the mediaType parameter.

All IRequestMemberGenerators to return a variable number of members,
including zero members.