### PR TITLE
Improve embedded code formatting

### DIFF
--- a/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
@@ -38,7 +38,8 @@ namespace Yardarm.NewtonsoftJson
                         EqualsValueClause(ObjectCreationExpression(_backingFieldType))))))
             .AddModifiers(Token(SyntaxKind.PrivateKeyword), Token(SyntaxKind.ReadOnlyKeyword))
             .WithAttributeLists(SingletonList(AttributeList(SingletonSeparatedList(
-                Attribute(NewtonsoftJsonTypes.JsonExtensionDataAttributeName)))));
+                Attribute(NewtonsoftJsonTypes.JsonExtensionDataAttributeName)))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed)));
 
         private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
 
@@ -92,14 +93,16 @@ namespace Yardarm.NewtonsoftJson
                 // Remove the old initializer
                 .WithInitializer(null)
                 // Prevent serialization
-                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(NewtonsoftJsonTypes.JsonIgnoreAttributeName))))
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(NewtonsoftJsonTypes.JsonIgnoreAttributeName)))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed))
                 // Provide an AdditionalPropertiesDictionary referencing the backing field
                 .WithExpressionBody(ArrowExpressionClause(
                     AssignmentExpression(SyntaxKind.CoalesceAssignmentExpression,
                         IdentifierName(WrapperFieldName),
                         ObjectCreationExpression(wrapperType)
                             .AddArgumentListArguments(
-                                Argument(IdentifierName(BackingFieldName))))));
+                                Argument(IdentifierName(BackingFieldName))))))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
         }
     }
 }

--- a/src/Yardarm.NewtonsoftJson/JsonDiscriminatorEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonDiscriminatorEnricher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -74,7 +75,8 @@ namespace Yardarm.NewtonsoftJson
                 attribute = attribute.AddArgumentListArguments(SyntaxFactory.AttributeArgument(paramArray));
             }
 
-            return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(attribute));
+            return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(attribute)
+                .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm.NewtonsoftJson/JsonEnumEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonEnumEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
@@ -14,7 +15,8 @@ namespace Yardarm.NewtonsoftJson
                 ? target
                     .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
                         SyntaxFactory.Attribute(NewtonsoftJsonTypes.JsonConverterAttributeName).AddArgumentListArguments(
-                            SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(NewtonsoftJsonTypes.StringEnumConverterName)))))
+                            SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(NewtonsoftJsonTypes.StringEnumConverterName))))
+                        .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed))
                 : target;
     }
 }

--- a/src/Yardarm.NewtonsoftJson/JsonPropertyEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonPropertyEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Generation;
@@ -44,7 +45,8 @@ namespace Yardarm.NewtonsoftJson
                     NewtonsoftJsonTypes.NullValueHandling.Ignore));
             }
 
-            return target.AddAttributeLists(AttributeList(SingletonSeparatedList(attribute)));
+            return target.AddAttributeLists(AttributeList(SingletonSeparatedList(attribute))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGenerator.cs
+++ b/src/Yardarm.SystemTextJson/Internal/DiscriminatorConverterTypeGenerator.cs
@@ -103,7 +103,8 @@ namespace Yardarm.SystemTextJson.Internal
                     InitializerExpression(SyntaxKind.ArrayInitializerExpression,
                         SeparatedList(propertyName.Select(p =>
                             (ExpressionSyntax)LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(p))))))),
-                null);
+                null,
+                Token(SyntaxKind.SemicolonToken));
         }
 
         private MethodDeclarationSyntax GenerateCanConvert(TypeSyntax schemaType)
@@ -132,7 +133,8 @@ namespace Yardarm.SystemTextJson.Internal
                         null))),
                 default,
                 null,
-                expressionBody);
+                expressionBody,
+                Token(SyntaxKind.SemicolonToken));
         }
 
         private MethodDeclarationSyntax GenerateRead(TypeSyntax schemaType)

--- a/src/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
@@ -78,7 +78,8 @@ namespace Yardarm.SystemTextJson
                 .WithAccessorList(AccessorList(property.AccessorList!.Accessors.Add(AccessorDeclaration(SyntaxKind.SetAccessorDeclaration))))
                 // Add the JsonExtensionData attribute
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(
-                Attribute(SystemTextJsonTypes.Serialization.JsonExtensionDataAttributeName))));
+                Attribute(SystemTextJsonTypes.Serialization.JsonExtensionDataAttributeName)))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
@@ -37,7 +38,8 @@ namespace Yardarm.SystemTextJson
             var attribute = Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName,
                 AttributeArgumentList(SingletonSeparatedList(AttributeArgument(TypeOfExpression(converter.TypeInfo.Name)))));
 
-            return target.AddAttributeLists(AttributeList(SingletonSeparatedList(attribute)));
+            return target.AddAttributeLists(AttributeList(SingletonSeparatedList(attribute))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonEnumEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -23,7 +24,8 @@ namespace Yardarm.SystemTextJson
                     .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
                         SyntaxFactory.Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName).AddArgumentListArguments(
                             SyntaxFactory.AttributeArgument(SyntaxFactory.TypeOfExpression(
-                                _jsonSerializationNamespace.JsonStringEnumConverter(SyntaxFactory.IdentifierName(target.Identifier)))))))
+                                _jsonSerializationNamespace.JsonStringEnumConverter(SyntaxFactory.IdentifierName(target.Identifier))))))
+                        .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed))
                 : target;
     }
 }

--- a/src/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
@@ -46,6 +47,7 @@ namespace Yardarm.SystemTextJson
                         AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
                             NameEquals(IdentifierName("Condition")),
                             null,
-                            SystemTextJsonTypes.Serialization.JsonIgnoreCondition.WhenWritingNull)))))));
+                            SystemTextJsonTypes.Serialization.JsonIgnoreCondition.WhenWritingNull))))))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
     }
 }

--- a/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
+++ b/src/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
@@ -23,7 +24,8 @@ namespace Yardarm.SystemTextJson
 
             return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
                 SyntaxFactory.Attribute(SystemTextJsonTypes.Serialization.JsonPropertyNameAttributeName).AddArgumentListArguments(
-                    SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+                    SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key))))
+                .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm/Enrichment/Authentication/SecuritySchemeRequestEnricher.cs
+++ b/src/Yardarm/Enrichment/Authentication/SecuritySchemeRequestEnricher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -86,7 +87,9 @@ namespace Yardarm.Enrichment.Authentication
 
             if (attributes.Count > 0)
             {
-                target = target.AddAttributeLists(AttributeList(null, SeparatedList(attributes)));
+                target = target.AddAttributeLists(
+                    AttributeList(null, SeparatedList(attributes))
+                        .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
             }
 
             return target;

--- a/src/Yardarm/Enrichment/Compilation/TargetRuntimeAssemblyInfoEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/TargetRuntimeAssemblyInfoEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Helpers;
 
@@ -14,6 +15,7 @@ namespace Yardarm.Enrichment.Compilation
                             SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(".NETStandard,Version=v2.0")),
                             SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(""))
                                 .WithNameEquals(SyntaxFactory.NameEquals("FrameworkDisplayName"))))
-                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword))));
+                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)))
+                    .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
     }
 }

--- a/src/Yardarm/Enrichment/Compilation/VersionAssemblyInfoEnricher.cs
+++ b/src/Yardarm/Enrichment/Compilation/VersionAssemblyInfoEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Helpers;
@@ -20,16 +21,19 @@ namespace Yardarm.Enrichment.Compilation
                     SyntaxFactory.Attribute(SyntaxFactory.ParseName("System.Reflection.AssemblyVersion"))
                         .AddArgumentListArguments(SyntaxFactory.AttributeArgument(
                             SyntaxHelpers.StringLiteral(_settings.Version.ToString()))))
-                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword))),
+                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)))
+                    .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed),
                 SyntaxFactory.AttributeList().AddAttributes(
                         SyntaxFactory.Attribute(SyntaxFactory.ParseName("System.Reflection.AssemblyFileVersion"))
                             .AddArgumentListArguments(SyntaxFactory.AttributeArgument(
                                 SyntaxHelpers.StringLiteral(_settings.Version.ToString()))))
-                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword))),
+                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)))
+                    .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed),
                 SyntaxFactory.AttributeList().AddAttributes(
                         SyntaxFactory.Attribute(SyntaxFactory.ParseName("System.Reflection.AssemblyInformationalVersion"))
                             .AddArgumentListArguments(SyntaxFactory.AttributeArgument(
                                 SyntaxHelpers.StringLiteral(_settings.Version.ToString() + (_settings.VersionSuffix ?? "")))))
-                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword))));
+                    .WithTarget(SyntaxFactory.AttributeTargetSpecifier(SyntaxFactory.Token(SyntaxKind.AssemblyKeyword)))
+                    .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
     }
 }

--- a/src/Yardarm/Enrichment/Requests/RequiredParameterEnricher.cs
+++ b/src/Yardarm/Enrichment/Requests/RequiredParameterEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Yardarm.Helpers;
@@ -28,7 +29,8 @@ namespace Yardarm.Enrichment.Requests
 
             syntax = syntax
                 .AddAttributeLists(AttributeList().AddAttributes(
-                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name)));
+                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
 
             return syntax;
         }

--- a/src/Yardarm/Enrichment/Responses/RequiredHeaderEnricher.cs
+++ b/src/Yardarm/Enrichment/Responses/RequiredHeaderEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Yardarm.Helpers;
@@ -21,6 +22,7 @@ namespace Yardarm.Enrichment.Responses
             syntax
                 .MakeNullableOrInitializeIfReferenceType(context.Compilation)
                 .AddAttributeLists(AttributeList().AddAttributes(
-                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name)));
+                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
     }
 }

--- a/src/Yardarm/Enrichment/Responses/ResponseTypeCastExtensionEnricher.cs
+++ b/src/Yardarm/Enrichment/Responses/ResponseTypeCastExtensionEnricher.cs
@@ -81,7 +81,8 @@ namespace Yardarm.Enrichment.Responses
                             ThrowExpression(ObjectCreationExpression(_responsesNamespace.StatusCodeMismatchException)
                                 .AddArgumentListArguments(
                                     Argument(IdentifierName("response")),
-                                    Argument(TypeOfExpression(typeName)))))));
+                                    Argument(TypeOfExpression(typeName)))))))
+                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
             }
         }
     }

--- a/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/MultipartPropertyEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -35,7 +36,8 @@ namespace Yardarm.Enrichment.Schema
             return target.AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
                 SyntaxFactory.Attribute(_serializationNamespace.MultipartPropertyAttribute)
                     .AddArgumentListArguments(
-                        SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key)))));
+                        SyntaxFactory.AttributeArgument(SyntaxHelpers.StringLiteral(context.LocatedElement.Key))))
+                .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm/Enrichment/Schema/RequiredPropertyEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/RequiredPropertyEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Helpers;
 using Yardarm.Spec;
@@ -30,7 +31,8 @@ namespace Yardarm.Enrichment.Schema
 
             return newSyntax
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(
-                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name))));
+                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name)))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
         }
     }
 }

--- a/src/Yardarm/Enrichment/Tags/DeprecatedOperationEnricher.cs
+++ b/src/Yardarm/Enrichment/Tags/DeprecatedOperationEnricher.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -20,7 +21,8 @@ namespace Yardarm.Enrichment.Tags
             target.AddAttributeLists(AttributeList(SingletonSeparatedList(
                 Attribute(WellKnownTypes.System.ObsoleteAttribute.Name,
                     AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
-                        SyntaxHelpers.StringLiteral($"Operation {operationId} has been marked deprecated."))))))));
+                        SyntaxHelpers.StringLiteral($"Operation {operationId} has been marked deprecated.")))))))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
 
     }
 }

--- a/src/Yardarm/Generation/Authentication/BasicSecuritySchemeTypeGenerator.cs
+++ b/src/Yardarm/Generation/Authentication/BasicSecuritySchemeTypeGenerator.cs
@@ -47,7 +47,8 @@ namespace Yardarm.Generation.Authentication
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddAccessorListAccessors(
                     AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(UsernameFieldName))),
+                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(UsernameFieldName)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
                     AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, Block(
                         ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                             IdentifierName(UsernameFieldName),
@@ -60,7 +61,8 @@ namespace Yardarm.Generation.Authentication
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddAccessorListAccessors(
                     AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(PasswordFieldName))),
+                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(PasswordFieldName)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
                     AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, Block(
                         ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                             IdentifierName(PasswordFieldName),

--- a/src/Yardarm/Generation/Request/BuildContentMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildContentMethodGenerator.cs
@@ -47,7 +47,8 @@ namespace Yardarm.Generation.Request
                 methodDeclaration = methodDeclaration
                     .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
                     .WithExpressionBody(ArrowExpressionClause(
-                        LiteralExpression(SyntaxKind.NullLiteralExpression)));
+                        LiteralExpression(SyntaxKind.NullLiteralExpression)))
+                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
             }
             else
             {

--- a/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -91,8 +92,8 @@ namespace Yardarm.Generation.Request
 
             yield return GenerateHeader(operation)
                 .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
-                .WithExpressionBody(ArrowExpressionClause(
-                    pathExpression));
+                .WithExpressionBody(ArrowExpressionClause(pathExpression))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
         }
 
         public static InvocationExpressionSyntax InvokeBuildUri(ExpressionSyntax requestInstance) =>

--- a/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/Internal/HttpContentRequestTypeGenerator.cs
@@ -54,7 +54,8 @@ namespace Yardarm.Generation.Request.Internal
             var buildContentMethod = _buildContentMethod
                 .WithModifiers(TokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)))
                 .WithExpressionBody(ArrowExpressionClause(
-                    IdentifierName(RequestMediaTypeGenerator.BodyPropertyName)));
+                    IdentifierName(RequestMediaTypeGenerator.BodyPropertyName)))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
 
             declaration = declaration.AddMembers(new MemberDeclarationSyntax[]
             {

--- a/src/Yardarm/Generation/Schema/EnumSchemaGenerator.cs
+++ b/src/Yardarm/Generation/Schema/EnumSchemaGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Any;
@@ -64,7 +65,8 @@ namespace Yardarm.Generation.Schema
 
             return SyntaxFactory.EnumMemberDeclaration(memberName)
                 .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
-                    CreateEnumMemberAttribute(stringPrimitive.Value)));
+                    CreateEnumMemberAttribute(stringPrimitive.Value))
+                    .WithTrailingTrivia(SyntaxFactory.ElasticCarriageReturnLineFeed));
         }
 
         protected static AttributeSyntax CreateEnumMemberAttribute(string value) =>

--- a/src/Yardarm/Helpers/PathHelpers.cs
+++ b/src/Yardarm/Helpers/PathHelpers.cs
@@ -16,6 +16,7 @@ namespace Yardarm.Helpers
 
             s_invalidPathChars.Add('{');
             s_invalidPathChars.Add('}');
+            s_invalidPathChars.Add(':');
         }
 
         /// <summary>

--- a/src/Yardarm/Helpers/PropertyHelpers.cs
+++ b/src/Yardarm/Helpers/PropertyHelpers.cs
@@ -71,7 +71,8 @@ namespace Yardarm.Helpers
                     // Initialize to an empty string
 
                     property = property
-                        .WithInitializer(EqualsValueClause(SyntaxHelpers.StringLiteral("")));
+                        .WithInitializer(EqualsValueClause(SyntaxHelpers.StringLiteral("")))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
                 }
                 else if (!typeInfo.Type.IsAbstract && typeInfo.Type.GetMembers()
                     .Where(p => p.Kind == SymbolKind.Method && p.Name == ".ctor")
@@ -81,7 +82,8 @@ namespace Yardarm.Helpers
                     // Build a default object using the default constructor
 
                     property = property
-                        .WithInitializer(EqualsValueClause(ObjectCreationExpression(property.Type)));
+                        .WithInitializer(EqualsValueClause(ObjectCreationExpression(property.Type)))
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
                 }
                 else
                 {


### PR DESCRIPTION
Motivation
----------
Some of the embedded code was still poorly formatted and not always
well recognized by decompilers.

Modifications
-------------
- Remove colons from file paths.
- Ensure that the formatter runs after any OpenAPI enrichers.
- Add trailing semicolons to initializers and expression bodied
  functions.
- Add newlines after attribute lists.
- Small perf bump by passing explicit workspace options to formatter.