### PR TITLE
Use BinaryStream serializer as a fallback for Stream and byte[]

### DIFF
--- a/src/Yardarm.Client.UnitTests/Serialization/TypeSerializerRegistryTests.cs
+++ b/src/Yardarm.Client.UnitTests/Serialization/TypeSerializerRegistryTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -42,6 +44,61 @@ namespace Yardarm.Client.UnitTests.Serialization
 
             registry.Get("text/plain").Should().BeOfType<RegistryConstructorSerializer>()
                 .Subject.Registry.Should().BeSameAs(registry);
+        }
+
+        #endregion
+
+        #region Get By Schema Type
+
+        [Fact]
+        public void GetBySchemaType_ExactMatch_Success()
+        {
+            // Arrange
+
+            var registry = new TypeSerializerRegistry();
+
+            // Act
+
+            registry.Add<RegistryConstructorSerializer>(null, new[] { typeof(Stream) });
+
+            // Assert
+
+            registry.Get(typeof(Stream)).Should().BeOfType<RegistryConstructorSerializer>()
+                .Subject.Registry.Should().BeSameAs(registry);
+        }
+
+        [Fact]
+        public void GetBySchemaType_InheritedClassMatch_Success()
+        {
+            // Arrange
+
+            var registry = new TypeSerializerRegistry();
+
+            // Act
+
+            registry.Add<RegistryConstructorSerializer>(null, new[] { typeof(Stream) });
+
+            // Assert
+
+            registry.Get(typeof(MemoryStream)).Should().BeOfType<RegistryConstructorSerializer>()
+                .Subject.Registry.Should().BeSameAs(registry);
+        }
+
+        [Fact]
+        public void GetBySchemaType_NoMatch_KeyNotFound()
+        {
+            // Arrange
+
+            var registry = new TypeSerializerRegistry();
+
+            // Act
+
+            registry.Add<RegistryConstructorSerializer>(null, new[] { typeof(Stream) });
+
+            // Assert
+
+            Action action = () => registry.Get(typeof(object));
+            action.Should().Throw<KeyNotFoundException>();
         }
 
         #endregion

--- a/src/Yardarm.Client/Serialization/BinaryStreamSerializer.cs
+++ b/src/Yardarm.Client/Serialization/BinaryStreamSerializer.cs
@@ -11,6 +11,12 @@ namespace RootNamespace.Serialization
     {
         public static string[] SupportedMediaTypes => new[] {MediaTypeNames.Application.Octet};
 
+        public static Type[] SupportedSchemaTypes => new[]
+        {
+            typeof(Stream),
+            typeof(byte[])
+        };
+
         public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData)
         {
             HttpContent content = value switch

--- a/src/Yardarm.Client/Serialization/ITypeSerializerRegistry.cs
+++ b/src/Yardarm.Client/Serialization/ITypeSerializerRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
@@ -8,5 +9,9 @@ namespace RootNamespace.Serialization
         ITypeSerializer Get(string mediaType);
         bool TryGet(string mediaType, [MaybeNullWhen(false)] out ITypeSerializer typeSerializer);
         ITypeSerializerRegistry Add(string mediaType, ITypeSerializer serializer);
+
+        ITypeSerializer Get(Type schemaType);
+        bool TryGet(Type schemaType, [MaybeNullWhen(false)] out ITypeSerializer typeSerializer);
+        ITypeSerializerRegistry Add(Type schemaType, ITypeSerializer serializer);
     }
 }

--- a/src/Yardarm.Client/Serialization/MultipartPropertyInfo`1.cs
+++ b/src/Yardarm.Client/Serialization/MultipartPropertyInfo`1.cs
@@ -39,15 +39,12 @@ namespace RootNamespace.Serialization
         public HttpContent Serialize(ITypeSerializerRegistry typeSerializerRegistry, T value)
         {
             string mediaType = MediaTypes.First();
-            if (!typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? serializer))
-            {
-                throw new UnknownMediaTypeException(mediaType);
-            }
 
-            return Serialize(serializer, mediaType, value);
+            return Serialize(typeSerializerRegistry, mediaType, value);
         }
 
-        protected abstract HttpContent Serialize(ITypeSerializer serializer, string mediaType, T value);
+        protected abstract HttpContent Serialize(ITypeSerializerRegistry typeSerializerRegistry,
+            string mediaType, T value);
 
         public static MultipartPropertyInfo<T> Create<TProperty>(
             Func<T, TProperty> propertyGetter, string propertyName, params string[] mediaTypes) =>

--- a/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
+++ b/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
@@ -29,7 +29,8 @@ namespace RootNamespace.Serialization
             _propertyGetter = propertyGetter;
         }
 
-        protected override HttpContent Serialize(ITypeSerializer serializer, string mediaType, T value) =>
-            serializer.Serialize(_propertyGetter(value), mediaType);
+        protected override HttpContent Serialize(ITypeSerializerRegistry typeSerializerRegistry,
+            string mediaType, T value) =>
+            typeSerializerRegistry.Serialize(_propertyGetter(value), mediaType);
     }
 }

--- a/src/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
+++ b/src/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
+using System.Threading;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
@@ -11,23 +11,62 @@ namespace RootNamespace.Serialization
         private static ITypeSerializerRegistry? s_instance;
         public static ITypeSerializerRegistry Instance
         {
-            get => s_instance ??= CreateDefaultRegistry();
-            set {
-                if (value is null)
+            get
+            {
+                if (s_instance is not null)
                 {
-                    throw new ArgumentNullException(nameof(value));
+                    return s_instance;
                 }
 
-                s_instance = value;
+                // In case two threads are getting Instance for the first time at the same time,
+                // use CompareExchange. One of the threads will not set the value, discarding the
+                // CreateDefaultRegistry result, and both calls will get the same value.
+                Interlocked.CompareExchange(ref s_instance, CreateDefaultRegistry(), null);
+                return s_instance;
             }
+            set => s_instance = value ?? throw new ArgumentNullException(nameof(value));
         }
 
-        private readonly IDictionary<string, ITypeSerializer> _registry = new Dictionary<string, ITypeSerializer>();
+        private readonly Dictionary<string, ITypeSerializer> _mediaTypeRegistry = new();
+        private readonly Dictionary<Type, ITypeSerializer> _schemaTypeRegistry = new();
 
-        public ITypeSerializer Get(string mediaType) => _registry[mediaType];
+        public ITypeSerializer Get(string mediaType)
+        {
+            if (mediaType is null)
+            {
+                throw new ArgumentNullException(nameof(mediaType));
+            }
+
+            return _mediaTypeRegistry[mediaType];
+        }
+
+        public ITypeSerializer Get(Type schemaType) => TryGet(schemaType, out ITypeSerializer? serializer)
+            ? serializer
+            : throw new KeyNotFoundException();
 
         public bool TryGet(string mediaType, [MaybeNullWhen(false)] out ITypeSerializer typeSerializer) =>
-            _registry.TryGetValue(mediaType, out typeSerializer);
+            _mediaTypeRegistry.TryGetValue(mediaType, out typeSerializer);
+
+        public bool TryGet(Type schemaType, [MaybeNullWhen(false)] out ITypeSerializer typeSerializer)
+        {
+            while (true)
+            {
+                if (_schemaTypeRegistry.TryGetValue(schemaType, out typeSerializer))
+                {
+                    return true;
+                }
+
+                if (schemaType.BaseType is not null)
+                {
+                    // Search recursively through parent types
+                    schemaType = schemaType.BaseType;
+                    continue;
+                }
+
+                typeSerializer = null;
+                return false;
+            }
+        }
 
         public ITypeSerializerRegistry Add(string mediaType, ITypeSerializer serializer)
         {
@@ -40,7 +79,23 @@ namespace RootNamespace.Serialization
                 throw new ArgumentNullException(nameof(serializer));
             }
 
-            _registry.Add(mediaType, serializer);
+            _mediaTypeRegistry.Add(mediaType, serializer);
+
+            return this;
+        }
+
+        public ITypeSerializerRegistry Add(Type schemaType, ITypeSerializer serializer)
+        {
+            if (schemaType == null)
+            {
+                throw new ArgumentNullException(nameof(schemaType));
+            }
+            if (serializer == null)
+            {
+                throw new ArgumentNullException(nameof(serializer));
+            }
+
+            _schemaTypeRegistry.Add(schemaType, serializer);
 
             return this;
         }
@@ -49,6 +104,6 @@ namespace RootNamespace.Serialization
             new TypeSerializerRegistry()
                 .Add<PlainTextSerializer>(PlainTextSerializer.SupportedMediaTypes)
                 .Add<MultipartFormDataSerializer>(MultipartFormDataSerializer.SupportedMediaTypes)
-                .Add<BinaryStreamSerializer>(BinaryStreamSerializer.SupportedMediaTypes);
+                .Add<BinaryStreamSerializer>(BinaryStreamSerializer.SupportedMediaTypes, BinaryStreamSerializer.SupportedSchemaTypes);
     }
 }

--- a/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
+++ b/src/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -14,14 +15,48 @@ namespace RootNamespace.Serialization
         {
             foreach (string mediaType in mediaTypes)
             {
-                typeSerializerRegistry = typeSerializerRegistry.Add(mediaType, typeSerializer);
+                typeSerializerRegistry.Add(mediaType, typeSerializer);
             }
 
             return typeSerializerRegistry;
         }
 
-        public static ITypeSerializerRegistry Add<T>(this ITypeSerializerRegistry typeSerializerRegistry,
+        public static ITypeSerializerRegistry Add(this ITypeSerializerRegistry typeSerializerRegistry,
+            IEnumerable<Type> schemaTypes, ITypeSerializer typeSerializer)
+        {
+            foreach (Type schemaType in schemaTypes)
+            {
+                typeSerializerRegistry.Add(schemaType, typeSerializer);
+            }
+
+            return typeSerializerRegistry;
+        }
+
+        public static ITypeSerializerRegistry Add<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            T>(this ITypeSerializerRegistry typeSerializerRegistry,
             IEnumerable<string> mediaTypes)
+            where T : ITypeSerializer =>
+            typeSerializerRegistry.Add<T>(mediaTypes, null);
+
+        public static ITypeSerializerRegistry Add<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            T>(this ITypeSerializerRegistry typeSerializerRegistry,
+            IEnumerable<Type> schemaTypes)
+            where T : ITypeSerializer =>
+            typeSerializerRegistry.Add<T>(null, schemaTypes);
+
+        internal static ITypeSerializerRegistry Add<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            T>(this ITypeSerializerRegistry typeSerializerRegistry,
+            IEnumerable<string>? mediaTypes = null,
+            IEnumerable<Type>? schemaTypes = null)
             where T : ITypeSerializer
         {
             ConstructorInfo? constructor = typeof(T).GetConstructor(new[] {typeof(ITypeSerializerRegistry)});
@@ -29,7 +64,17 @@ namespace RootNamespace.Serialization
             ITypeSerializer serializer = (ITypeSerializer?)constructor?.Invoke(new object[] {typeSerializerRegistry}) ??
                                          Activator.CreateInstance<T>();
 
-            return typeSerializerRegistry.Add(mediaTypes, serializer);
+            if (mediaTypes is not null)
+            {
+                typeSerializerRegistry.Add(mediaTypes, serializer);
+            }
+
+            if (schemaTypes is not null)
+            {
+                typeSerializerRegistry.Add(schemaTypes, serializer);
+            }
+
+            return typeSerializerRegistry;
         }
 
         public static ValueTask<T> DeserializeAsync<T>(this ITypeSerializerRegistry typeSerializerRegistry,
@@ -39,7 +84,11 @@ namespace RootNamespace.Serialization
 
             if (mediaType is null || !typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? typeSerializer))
             {
-                throw new UnknownMediaTypeException(mediaType, content);
+                // If there is no exact match by media type, fallback to find a match by schema type
+                if (!typeSerializerRegistry.TryGet(typeof(T), out typeSerializer))
+                {
+                    throw new UnknownMediaTypeException(mediaType, content);
+                }
             }
 
             return typeSerializer.DeserializeAsync<T>(content, serializationData);
@@ -50,7 +99,11 @@ namespace RootNamespace.Serialization
         {
             if (!typeSerializerRegistry.TryGet(mediaType, out ITypeSerializer? typeSerializer))
             {
-                throw new UnknownMediaTypeException(mediaType);
+                // If there is no exact match by media type, fallback to find a match by schema type
+                if (!typeSerializerRegistry.TryGet(typeof(T), out typeSerializer))
+                {
+                    throw new UnknownMediaTypeException(mediaType);
+                }
             }
 
             return typeSerializer.Serialize(value, mediaType, serializationData);


### PR DESCRIPTION
Motivation
----------
Anytime we have a Stream or byte[] schema we should fallback to using
the BinarySerializer, even if the Content-Type isn't recognized.

Modifications
-------------
Add `Type` based key indexing to `TypeSerializerRegistry` with handling
for inherited types.

Register the `BinarySerializer` for `Stream` (and therefore all types
inherited from `Stream` and `byte[]`.

When finding a serializer, fallback to schema type lookup if media type
lookup doesn't find a match.