### PR TITLE
Don't add unnecessary base type list

### DIFF
--- a/src/Yardarm/Enrichment/Schema/BaseTypeEnricher.cs
+++ b/src/Yardarm/Enrichment/Schema/BaseTypeEnricher.cs
@@ -19,11 +19,6 @@ namespace Yardarm.Enrichment.Schema
             OpenApiEnrichmentContext<OpenApiSchema> context)
         {
             var feature = _context.GenerationServices.GetRequiredService<ISchemaBaseTypeRegistry>();
-            if (feature == null)
-            {
-                return target;
-            }
-
             var additionalBaseTypes = feature.GetBaseTypes(context.LocatedElement);
 
             if (target.BaseList != null)
@@ -32,7 +27,10 @@ namespace Yardarm.Enrichment.Schema
                     target.BaseList.Types.Any(currentType => !currentType.IsEquivalentTo(additionalBaseType)));
             }
 
-            return target.AddBaseListTypes(additionalBaseTypes.ToArray());
+            var arr = additionalBaseTypes.ToArray();
+            return arr.Length > 0
+                ? target.AddBaseListTypes(arr)
+                : target;
         }
     }
 }

--- a/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
+++ b/src/Yardarm/Generation/Request/RequestTypeGenerator.cs
@@ -15,9 +15,6 @@ namespace Yardarm.Generation.Request
 {
     public class RequestTypeGenerator : TypeGeneratorBase<OpenApiOperation>
     {
-        public static IdentifierNameSyntax SerializationInfoPropertyName { get; } =
-            IdentifierName("SerializationInfo");
-
         protected IMediaTypeSelector MediaTypeSelector { get; }
         protected IList<IRequestMemberGenerator> MemberGenerators { get; }
         protected ISerializerSelector SerializerSelector { get; }


### PR DESCRIPTION
Motivation
----------
Output code is showing a `:` after schema class declarations where there
are no base types inherited.

Modifications
-------------
When the schema has no base types don't call `AddBaseListTypes`.