### PR TITLE
Allow manual setting of content type on multipart requests

### DIFF
--- a/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
+++ b/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
@@ -13,9 +13,10 @@ namespace RootNamespace.Serialization
         private readonly Func<T, TProperty> _propertyGetter;
 
         public MultipartPropertyInfo(Func<T, TProperty> propertyGetter,
+            Func<T, string?> contentTypeGetter,
             string propertyName,
             params string[] mediaTypes)
-            : base(propertyName, mediaTypes)
+            : base(contentTypeGetter, propertyName, mediaTypes)
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(propertyGetter);

--- a/src/Yardarm/Helpers/DocumentationSyntaxHelpers.cs
+++ b/src/Yardarm/Helpers/DocumentationSyntaxHelpers.cs
@@ -69,6 +69,6 @@ namespace Yardarm.Helpers
         /// Builds a new line with leading comment characters for the next line
         /// </summary>
         /// <returns></returns>
-        private static XmlNodeSyntax InteriorNewLine() => XmlText(XmlTextNewLine(Environment.NewLine, true));
+        public static XmlNodeSyntax InteriorNewLine() => XmlText(XmlTextNewLine(Environment.NewLine, true));
     }
 }


### PR DESCRIPTION
Motivation
----------
It is generally necessary to provide a content type other than the
default for a multipart request when dealing with binary data.

Modifications
-------------
For multipart requests, inherit from the schema and add a content type
property for each schema property. Supply a lambda to get this property
to the `MultipartPropertyInfo`. When left as null, fallback to the
first content type in the array as before.