### PR TITLE
Accept filenames for multipart fields

### DIFF
--- a/src/Yardarm.Client/Serialization/MultipartFieldDetails.cs
+++ b/src/Yardarm.Client/Serialization/MultipartFieldDetails.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace RootNamespace.Serialization
+{
+    /// <summary>
+    /// Provides additional details about the value of a multipart encoded field.
+    /// </summary>
+    public class MultipartFieldDetails
+    {
+        /// <summary>
+        /// Optional Content-Type of the field. If null, a default value is used.
+        /// </summary>
+        public string? ContentType { get; set; }
+
+        /// <summary>
+        /// Optional file name of the field to apply within Content-Disposition.
+        /// </summary>
+        public string? Filename { get; set; }
+    }
+}

--- a/src/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
+++ b/src/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -24,9 +23,17 @@ namespace RootNamespace.Serialization
             {
                 foreach (MultipartPropertyInfo<T> property in serializationData.Properties)
                 {
-                    var propertyContent = property.Serialize(_typeSerializerRegistry, value);
+                    HttpContent propertyContent = property.Serialize(_typeSerializerRegistry, value);
 
-                    content.Add(propertyContent, property.PropertyName);
+                    string? filename = property.GetDetails(value)?.Filename;
+                    if (filename is null)
+                    {
+                        content.Add(propertyContent, property.PropertyName);
+                    }
+                    else
+                    {
+                        content.Add(propertyContent, property.PropertyName, filename);
+                    }
                 }
             }
 

--- a/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
+++ b/src/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
@@ -8,15 +8,15 @@ namespace RootNamespace.Serialization
     /// </summary>
     /// <typeparam name="T">Type of schema to be serialized.</typeparam>
     /// <typeparam name="TProperty">Type of the property to be serialized.</typeparam>
-    internal class MultipartPropertyInfo<T, TProperty> : MultipartPropertyInfo<T>
+    internal sealed class MultipartPropertyInfo<T, TProperty> : MultipartPropertyInfo<T>
     {
         private readonly Func<T, TProperty> _propertyGetter;
 
         public MultipartPropertyInfo(Func<T, TProperty> propertyGetter,
-            Func<T, string?> contentTypeGetter,
+            Func<T, MultipartFieldDetails?> detailsGetter,
             string propertyName,
             params string[] mediaTypes)
-            : base(contentTypeGetter, propertyName, mediaTypes)
+            : base(detailsGetter, propertyName, mediaTypes)
         {
 #if NET6_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(propertyGetter);

--- a/src/Yardarm/Enrichment/Requests/RequestMultipartEncodingEnricher.cs
+++ b/src/Yardarm/Enrichment/Requests/RequestMultipartEncodingEnricher.cs
@@ -88,20 +88,23 @@ namespace Yardarm.Enrichment.Requests
                     return (MemberDeclarationSyntax)PropertyDeclaration(
                             default,
                             TokenList(Token(SyntaxKind.PublicKeyword)),
-                            PredefinedType(Token(SyntaxKind.StringKeyword)).MakeNullable(),
+                            _serializationNamespace.MultipartFieldDetails.MakeNullable(),
                             null,
-                            Identifier(_propertyNameFormatter.Format(property.Key + "-ContentType")),
+                            Identifier(_propertyNameFormatter.Format(property.Key + "-Details")),
                             AccessorList(List(new[]
                             {
                                 AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
                                 AccessorDeclaration(SyntaxKind.SetAccessorDeclaration)
                                     .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
-                            })))
+                            })),
+                            null,
+                            EqualsValueClause(ImplicitObjectCreationExpression()),
+                            Token(SyntaxKind.SemicolonToken))
                         .WithLeadingTrivia(
                             DocumentationSyntaxHelpers.BuildXmlCommentTrivia(XmlSummaryElement(
                                 DocumentationSyntaxHelpers.InteriorNewLine(),
-                                XmlText(XmlTextLiteral("Optionally supplies the Content-Type for ")),
+                                XmlText(XmlTextLiteral("Optionally supplies additional details for ")),
                                 XmlSeeElement(NameMemberCref(IdentifierName(_propertyNameFormatter.Format(property.Key)))),
                                 XmlText(XmlTextLiteral(".")),
                                 DocumentationSyntaxHelpers.InteriorNewLine())));
@@ -188,7 +191,7 @@ namespace Yardarm.Enrichment.Requests
                     null,
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         IdentifierName("p"),
-                        IdentifierName(_propertyNameFormatter.Format(propertyName + "-ContentType"))))),
+                        IdentifierName(_propertyNameFormatter.Format(propertyName + "-Details"))))),
                 Argument(SyntaxHelpers.StringLiteral(propertyName))
             }.Concat(mediaTypes);
 

--- a/src/Yardarm/Names/ISerializationNamespace.cs
+++ b/src/Yardarm/Names/ISerializationNamespace.cs
@@ -10,6 +10,7 @@ namespace Yardarm.Names
         NameSyntax ISerializationData { get; }
         NameSyntax ITypeSerializer { get; }
         NameSyntax ITypeSerializerRegistry { get; }
+        NameSyntax MultipartFieldDetails { get; }
         NameSyntax MultipartFormDataSerializer { get; }
         NameSyntax PathSegmentStyle { get; }
         NameSyntax PathSegmentSerializer { get; }

--- a/src/Yardarm/Names/Internal/SerializationNamespace.cs
+++ b/src/Yardarm/Names/Internal/SerializationNamespace.cs
@@ -14,6 +14,7 @@ namespace Yardarm.Names.Internal
         public NameSyntax ISerializationData { get; }
         public NameSyntax ITypeSerializer { get; }
         public NameSyntax ITypeSerializerRegistry { get; }
+        public NameSyntax MultipartFieldDetails { get; }
         public NameSyntax MultipartFormDataSerializer { get; }
         public NameSyntax PathSegmentStyle { get; }
         public NameSyntax PathSegmentSerializer { get; }
@@ -49,6 +50,10 @@ namespace Yardarm.Names.Internal
             ITypeSerializerRegistry = QualifiedName(
                 Name,
                 IdentifierName("ITypeSerializerRegistry"));
+
+            MultipartFieldDetails = QualifiedName(
+                Name,
+                IdentifierName("MultipartFieldDetails"));
 
             MultipartFormDataSerializer = QualifiedName(
                 Name,


### PR DESCRIPTION
Motivation
----------
ASP.NET Core IFormField parameters require a filename or they are
ignored. Other use cases may also need a filename.

Modifications
-------------
Switch from a plain ContentType string field to `MultipartFieldDetails`
class which supplies both the Content-Type and filename.