### PR TITLE
Prevent null ref warning parsing response headers

### DIFF
--- a/src/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
+++ b/src/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
@@ -66,7 +66,7 @@ namespace Yardarm.Enrichment.Responses
             // Declare values variable to hold TryGetValue out results
             yield return LocalDeclarationStatement(VariableDeclaration(
                     WellKnownTypes.System.Collections.Generic.IEnumerableT.Name(
-                        PredefinedType(Token(SyntaxKind.StringKeyword))))
+                        PredefinedType(Token(SyntaxKind.StringKeyword))).MakeNullable())
                 .AddVariables(VariableDeclarator("values")));
 
             NameSyntax valuesName = IdentifierName("values");


### PR DESCRIPTION
Motivation
----------
Response header parsing is currently throwing a null ref warning for the
values out parameter.

Modifications
-------------
Mark the values local variable as nullable.