### PR TITLE
Support application/json-patch+json content type

### DIFF
--- a/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -10,7 +10,11 @@ namespace RootNamespace.Serialization.Json
 {
     public class JsonTypeSerializer : ITypeSerializer
     {
-        public static string[] SupportedMediaTypes => new [] { "application/json" };
+        public static string[] SupportedMediaTypes => new []
+        {
+            "application/json",
+            "application/json-patch+json"
+        };
 
         private readonly JsonSerializer _serializer;
 

--- a/src/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -31,6 +31,12 @@ namespace Yardarm.NewtonsoftJson
                 serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
             ));
 
+            services.AddSerializerDescriptor(serviceProvider => new SerializerDescriptor(
+                ImmutableHashSet.Create(new SerializerMediaType("application/json-patch+json", 1.0)),
+                "JsonPatch",
+                serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
+            ));
+
             return services;
         }
     }

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -10,7 +10,11 @@ namespace RootNamespace.Serialization.Json
 {
     public class JsonTypeSerializer : ITypeSerializer
     {
-        public static string[] SupportedMediaTypes => new [] { "application/json" };
+        public static string[] SupportedMediaTypes => new []
+        {
+            "application/json",
+            "application/json-patch+json"
+        };
 
         private readonly JsonSerializerOptions _options;
 

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -36,6 +36,12 @@ namespace Yardarm.SystemTextJson
                 serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
             ));
 
+            services.AddSerializerDescriptor(serviceProvider => new SerializerDescriptor(
+                ImmutableHashSet.Create(new SerializerMediaType("application/json-patch+json", 1.0)),
+                "JsonPatch",
+                serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
+            ));
+
             return services;
         }
     }


### PR DESCRIPTION
Motivation
----------
JSON patch is a commonly used content type for partial object mutations.

Modifications
-------------
Add `application/json-patch+json` as a supported content type registered
on the default `TypeSerializerRegistry`.

Generate separate `JsonPatch` request types for requests that accept
json-patch content types. This allows for the separate schema used by
patch requests even when sent to the same path/method as a full JSON
update.