### PR TITLE
Resolve some null ref warnings in Newtonsoft.Json extension

### DIFF
--- a/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/AdditionalPropertiesDictionary.cs
+++ b/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/AdditionalPropertiesDictionary.cs
@@ -122,7 +122,7 @@ namespace RootNamespace.Serialization.Json
         public bool TryGetValue(string key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore 8767
         {
-            if (_dictionary.TryGetValue(key, out JToken token))
+            if (_dictionary.TryGetValue(key, out JToken? token))
             {
                 value = ToValue(token);
                 return true;

--- a/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/DiscriminatorConverter.cs
+++ b/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/DiscriminatorConverter.cs
@@ -68,8 +68,12 @@ namespace RootNamespace.Serialization.Json
                 }
             }
 
-            var result = Activator.CreateInstance(type);
-            serializer.Populate(json.CreateReader(), result);
+            object? result = Activator.CreateInstance(type);
+            if (result is not null)
+            {
+                serializer.Populate(json.CreateReader(), result);
+            }
+
             return result;
         }
 

--- a/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonAdditionalPropertiesEnricher.cs
@@ -62,7 +62,7 @@ namespace Yardarm.NewtonsoftJson
             target = target.TrackNodes((IEnumerable<PropertyDeclarationSyntax>) members);
 
             return members.Aggregate(target,
-                (current, member) => current.ReplaceNode(current.GetCurrentNode(member), GenerateNewNodes(member)));
+                (current, member) => current.ReplaceNode(current.GetCurrentNode(member)!, GenerateNewNodes(member)));
         }
 
         private IEnumerable<MemberDeclarationSyntax> GenerateNewNodes(PropertyDeclarationSyntax property)

--- a/src/Yardarm.NewtonsoftJson/JsonDiscriminatorEnricher.cs
+++ b/src/Yardarm.NewtonsoftJson/JsonDiscriminatorEnricher.cs
@@ -59,7 +59,7 @@ namespace Yardarm.NewtonsoftJson
                                     // Add two parameters to the object array for each mapping
                                     // First is the string key of the mapping, second is the Type to deserialize
 
-                                    OpenApiSchema referencedSchema = schema.OneOf
+                                    OpenApiSchema? referencedSchema = schema.OneOf
                                         .FirstOrDefault(p => p.Reference?.ReferenceV3 == mapping.Value);
 
                                     return referencedSchema != null


### PR DESCRIPTION
Motivation
----------
The Newtonsoft extension and it's generated code both include some null
ref warnings when targeting .NET 6.

Modifications
-------------
Resolve the warnings.