### PR TITLE
Support "text/json" content types

### DIFF
--- a/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -13,6 +13,7 @@ namespace RootNamespace.Serialization.Json
         public static string[] SupportedMediaTypes => new []
         {
             "application/json",
+            "text/json",
             "application/json-patch+json"
         };
 

--- a/src/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -26,7 +26,13 @@ namespace Yardarm.NewtonsoftJson
                 .TryAddSingleton<IJsonSerializationNamespace, JsonSerializationNamespace>();
 
             services.AddSerializerDescriptor(serviceProvider => new SerializerDescriptor(
-                ImmutableHashSet.Create(new SerializerMediaType("application/json", 1.0)),
+                ImmutableHashSet.Create(
+                    new SerializerMediaType("application/json", 1.0),
+                    new SerializerMediaType("text/json", 0.9),
+                    // This is very low priority because we can't really use it for requests, since we don't know what the "*" should be.
+                    // However, we don't want to generate HttpContent-based types unnecessarily. Swashbuckle-generated OpenAPI specs like
+                    // to include this in the list of supported request bodies along with the other content types.
+                    new SerializerMediaType("application/*+json", 0)),
                 "Json",
                 serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
             ));

--- a/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -13,7 +13,8 @@ namespace RootNamespace.Serialization.Json
         public static string[] SupportedMediaTypes => new []
         {
             "application/json",
-            "application/json-patch+json"
+            "application/json-patch+json",
+            "text/json"
         };
 
         private readonly JsonSerializerOptions _options;

--- a/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -31,7 +31,13 @@ namespace Yardarm.SystemTextJson
                 .TryAddSingleton<IJsonSerializationNamespace, JsonSerializationNamespace>();
 
             services.AddSerializerDescriptor(serviceProvider => new SerializerDescriptor(
-                ImmutableHashSet.Create(new SerializerMediaType("application/json", 1.0)),
+                ImmutableHashSet.Create(
+                    new SerializerMediaType("application/json", 1.0),
+                    new SerializerMediaType("text/json", 0.9),
+                    // This is very low priority because we can't really use it for requests, since we don't know what the "*" should be.
+                    // However, we don't want to generate HttpContent-based types unnecessarily. Swashbuckle-generated OpenAPI specs like
+                    // to include this in the list of supported request bodies along with the other content types.
+                    new SerializerMediaType("application/*+json", 0)),
                 "Json",
                 serviceProvider.GetRequiredService<IJsonSerializationNamespace>().JsonTypeSerializer
             ));

--- a/src/Yardarm/Generation/MediaType/MediaTypeGenerator.cs
+++ b/src/Yardarm/Generation/MediaType/MediaTypeGenerator.cs
@@ -25,7 +25,6 @@ namespace Yardarm.Generation.MediaType
         public IEnumerable<SyntaxTree> Generate()
         {
             foreach (var syntaxTree in GetMediaTypes()
-                .Where(p => _serializerSelector.Select(p) != null)
                 .Select(Generate)
                 .Where(p => p != null))
             {
@@ -33,11 +32,37 @@ namespace Yardarm.Generation.MediaType
             }
         }
 
-        private IEnumerable<ILocatedOpenApiElement<OpenApiMediaType>> GetMediaTypes() =>
+        private IEnumerable<ILocatedOpenApiElement<OpenApiMediaType>> GetMediaTypes()
+        {
+            foreach (var requestBody in GetRequestBodies())
+            {
+                var mediaTypes = requestBody.GetMediaTypes()
+                    .Select(mediaType => (mediaType, descriptor: _serializerSelector.Select(mediaType)))
+                    .Where(p => p.descriptor is not null)
+                    .Select(p => (p.mediaType, descriptor: p.descriptor.GetValueOrDefault()));
+
+                // If multiple content types on the same request body match on the same serializer name, i.e. "application/json" and "text/json"
+                // then we pick the one that has the highest priority. This allows the following:
+                //   A) we can support alternate content types on requests like "text/json" when it is the only content type present
+                //   B) if BOTH the primary and alternate are present, we pick the primary and don't generate a type for the secondary,
+                //      without generating naming conflicts.
+                //   C) we don't generate HttpContent request bodies for known content types like "text/json"
+
+                var groupedByName = mediaTypes.GroupBy(p => p.descriptor.Descriptor.NameSegment);
+                foreach (var group in groupedByName)
+                {
+                    yield return group
+                        .OrderByDescending(p => p.descriptor.Quality)
+                        .Select(p => p.mediaType)
+                        .First();
+                }
+            }
+        }
+
+        private IEnumerable<ILocatedOpenApiElement<OpenApiRequestBody>> GetRequestBodies() =>
             _document.Paths.ToLocatedElements()
                 .GetOperations()
-                .GetRequestBodies()
-                .GetMediaTypes();
+                .GetRequestBodies();
 
         protected virtual SyntaxTree? Generate(ILocatedOpenApiElement<OpenApiMediaType> mediaType) =>
             _mediaTypeGeneratorRegistry.Get(mediaType).GenerateSyntaxTree();


### PR DESCRIPTION
Motivation
----------
Currently only "application/json" and "application/json-patch+json"
content types are supported for JSON, any others generate types that
use HttpContent.

Modifications
-------------
- Add "text/json" to the list of supported content types
- This causes naming conflicts if both "application/json" and
  "text/json" are present in the same request body, so select the one
  with the highest priority and ignore the other
- Also ignore "application/*+json" as a listed content type, which is
  often done by Swashbuckle-generated specs in .NET.

Results
-------
- "text/json" is supported when it is the only content type for a
  request as well as when returned in a response.
- Extra HttpContent requests classes are not generated when "text/json"
  or "application/*+json" are included alongside "application/json" in
  the request body definition.