### PR TITLE
Include project name in NuGet logs

### DIFF
--- a/src/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
+++ b/src/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
@@ -27,6 +27,7 @@ namespace Yardarm.Packaging
                 .ToList())
             {
                 Name = _settings.AssemblyName,
+                FilePath = _settings.AssemblyName,
                 Dependencies = new List<LibraryDependency>()
             }.Enrich(Enrichers);
     }


### PR DESCRIPTION
Motivation
----------
We currently get an odd log message "Restoring packages for ...".

Modifications
-------------
Set the FilePath during restore to the output name, which is what NuGet
uses to output that log.