### PR TITLE
Improve trimmability

### DIFF
--- a/src/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
+++ b/src/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
@@ -1,12 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
 namespace RootNamespace.Authentication.Internal
 {
-    internal class SecuritySchemeSetRegistry<T>
+    internal class SecuritySchemeSetRegistry<
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+#endif
+        T>
     {
         private static readonly Dictionary<Type, PropertyInfo> _schemes =
             typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/src/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -9,7 +9,11 @@ namespace RootNamespace.Serialization
     {
         public static HeaderSerializer Instance { get; } = new HeaderSerializer();
 
-        public string Serialize<T>(T value, bool explode)
+        public string Serialize<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            T>(T value, bool explode)
         {
             if (value == null)
             {
@@ -30,7 +34,6 @@ namespace RootNamespace.Serialization
             return LiteralSerializer.Instance.Serialize(value);
         }
 
-        [return: MaybeNull]
         public T Deserialize<T>(IEnumerable<string> values, bool explode)
         {
             if (typeof(T) == typeof(string))

--- a/src/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -10,15 +10,13 @@ namespace RootNamespace.Serialization
 {
     public class LiteralSerializer
     {
-        private static readonly MethodInfo _joinListMethod = typeof(LiteralSerializer)
-            .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
-            .Single(p => p.IsGenericMethodDefinition && p.Name == nameof(JoinList));
-
-        private static readonly MethodInfo _deserializeListMethod = typeof(LiteralSerializer)
-            .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
-            .Single(p => p.IsGenericMethodDefinition && p.Name == nameof(DeserializeList));
-
         public static LiteralSerializer Instance { get; } = new LiteralSerializer();
+
+        private static readonly MethodInfo s_joinListMethod =
+            ((Func<string, IEnumerable<string>, string>)Instance.JoinList<string>).GetMethodInfo().GetGenericMethodDefinition();
+
+        private static readonly MethodInfo s_deserializeListMethod =
+            ((Func<IEnumerable<string>, List<string>>)Instance.DeserializeList<string>).GetMethodInfo().GetGenericMethodDefinition();
 
         public string Serialize<T>(T value) =>
             value != null
@@ -36,14 +34,14 @@ namespace RootNamespace.Serialization
 
         public string JoinList(string separator, object list, Type itemType)
         {
-            MethodInfo joinList = _joinListMethod.MakeGenericMethod(itemType);
+            MethodInfo joinList = s_joinListMethod.MakeGenericMethod(itemType);
 
             return (string)joinList.Invoke(this, new object[] {separator, list})!;
         }
 
         public object DeserializeList(IEnumerable<string> values, Type itemType)
         {
-            MethodInfo deserializeList = _deserializeListMethod.MakeGenericMethod(itemType);
+            MethodInfo deserializeList = s_deserializeListMethod.MakeGenericMethod(itemType);
 
             return deserializeList.Invoke(this, new object[] {values})!;
         }

--- a/src/Yardarm.Client/Serialization/PathSegmentSerializer.cs
+++ b/src/Yardarm.Client/Serialization/PathSegmentSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
@@ -9,7 +10,11 @@ namespace RootNamespace.Serialization
 
         public static PathSegmentSerializer Instance { get; } = new PathSegmentSerializer();
 
-        public string Serialize<T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false) =>
+        public string Serialize<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false) =>
             style switch
             {
                 PathSegmentStyle.Simple => SerializeSimple(value, explode),
@@ -18,7 +23,11 @@ namespace RootNamespace.Serialization
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
 
-        private static string SerializeSimple<T>(T value, bool explode)
+        private static string SerializeSimple<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            T>(T value, bool explode)
         {
             if (value == null)
             {
@@ -39,7 +48,11 @@ namespace RootNamespace.Serialization
             return LiteralSerializer.Instance.Serialize(value);
         }
 
-        private static string SerializeLabel<T>(T value, bool explode)
+        private static string SerializeLabel<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            T>(T value, bool explode)
         {
             if (value == null)
             {
@@ -60,7 +73,11 @@ namespace RootNamespace.Serialization
             return "." + LiteralSerializer.Instance.Serialize(value);
         }
 
-        private static string SerializeMatrix<T>(string name, T value, bool explode)
+        private static string SerializeMatrix<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            T>(string name, T value, bool explode)
         {
             if (value == null)
             {

--- a/src/Yardarm.Client/Serialization/SerializationHelpers.cs
+++ b/src/Yardarm.Client/Serialization/SerializationHelpers.cs
@@ -8,7 +8,11 @@ namespace RootNamespace.Serialization
 {
     internal static class SerializationHelpers
     {
-        public static bool IsEnumerable(Type type,
+        public static bool IsEnumerable(
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
+#endif
+            Type type,
             [NotNullWhen(true)] out Type? itemType)
         {
             itemType = null;


### PR DESCRIPTION
Motivation
----------
Eventually we'd like the generated SDKs to be trimmable.

Modifications
-------------
Move away from reflection to find methods and use `.GetMethodInfo()` on
lambda expressions instead, where possible.

Add `DynamicallyAccessedMembers` annotations where feasible when
targeting .NET 6.

Results
-------
The generated assemblies are still not trimmable due to the use of
`TypeDescriptor.GetConverter` as well as non-trimmable JSON serializers.
However, we've taken a step in the right direction and improved
trimming in cases where the consumer is trying to manually control
trimming.