### PR TITLE
Generate reference assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ the source code available to modern debuggers and decompilers.
 Note: To debug into a generated SDK in Visual Studio, be sure to uncheck Just My Code in the
 debugging options of Visual Studio.
 
+## Reference assemblies
+
+To improve build speed of SDK consumers, a reference assembly is created when:
+
+1. `--ref file.dll` is passed to specify a specific location for a reference assembly.
+2. `-o path/` is used to output to a directory. A `ref` subdirectory will be created for the reference assembly.
+3. `--nupkg` is  used to create a NuGet package. A reference assembly will be embedded in the package for each target framework.
+
+See [Reference Assemblies](https://docs.microsoft.com/en-us/dotnet/standard/assembly/reference-assemblies) for more
+information.
+
 ## A note on System.Text.Json support
 
 When using System.Text.Json, it is recommended that you target net6.0 at a minimum. Multi-targeting and including

--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -202,11 +202,23 @@ namespace Yardarm.CommandLine
                         {
                             _options.OutputDebugSymbols = Path.Combine(directory, $"{_options.AssemblyName}.pdb");
                         }
+
+                        if (!_options.NoReferenceAssembly && string.IsNullOrEmpty(_options.OutputReferenceAssembly))
+                        {
+                            string refDirectory = Path.Combine(directory, "ref");
+                            if (!Directory.Exists(refDirectory))
+                            {
+                                Directory.CreateDirectory(refDirectory);
+                            }
+
+                            _options.OutputReferenceAssembly = Path.Combine(refDirectory,
+                                $"{Path.GetFileNameWithoutExtension(_options.OutputFile)}.dll");
+                        }
                     }
                     else
                     {
-                        var directory = Path.GetDirectoryName(_options.OutputPackageFile) ??
-                                        Directory.GetCurrentDirectory();
+                        string directory = Path.GetDirectoryName(_options.OutputPackageFile) ??
+                                           Directory.GetCurrentDirectory();
 
                         if (string.IsNullOrEmpty(_options.OutputXmlFile))
                         {
@@ -219,9 +231,21 @@ namespace Yardarm.CommandLine
                             _options.OutputDebugSymbols = Path.Combine(directory,
                                 $"{Path.GetFileNameWithoutExtension(_options.OutputFile)}.pdb");
                         }
+
+                        if (!_options.NoReferenceAssembly && string.IsNullOrEmpty(_options.OutputReferenceAssembly))
+                        {
+                            string refDirectory = Path.Combine(directory, "ref");
+                            if (!Directory.Exists(refDirectory))
+                            {
+                                Directory.CreateDirectory(refDirectory);
+                            }
+
+                            _options.OutputReferenceAssembly = Path.Combine(refDirectory,
+                                $"{Path.GetFileNameWithoutExtension(_options.OutputFile)}.dll");
+                        }
                     }
 
-                    var dllStream = File.Create(_options.OutputFile);
+                    var dllStream = File.Create(_options.OutputFile!);
                     streams.Add(dllStream);
                     settings.DllOutput = dllStream;
 
@@ -237,6 +261,13 @@ namespace Yardarm.CommandLine
                         var pdbStream = File.Create(_options.OutputDebugSymbols);
                         streams.Add(pdbStream);
                         settings.PdbOutput = pdbStream;
+                    }
+
+                    if (!_options.NoReferenceAssembly && !string.IsNullOrEmpty(_options.OutputReferenceAssembly))
+                    {
+                        var referenceAssemblyStream = File.Create(_options.OutputReferenceAssembly);
+                        streams.Add(referenceAssemblyStream);
+                        settings.ReferenceAssemblyOutput = referenceAssemblyStream;
                     }
                 }
                 else if (!string.IsNullOrEmpty(_options.OutputPackageFile))

--- a/src/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/Yardarm.CommandLine/GenerateOptions.cs
@@ -43,6 +43,12 @@ namespace Yardarm.CommandLine
         [Option("no-pdb", HelpText = "Suppress output of .pdb debug symbols", SetName = "dll")]
         public bool NoDebugSymbols { get; set; }
 
+        [Option("ref", HelpText = "Output reference assembly file", SetName = "dll")]
+        public string OutputReferenceAssembly { get; set; }
+
+        [Option("no-ref", HelpText = "Suppress output of the reference assembly file", SetName = "dll")]
+        public bool NoReferenceAssembly { get; set; }
+
         #endregion
 
         #region NuGet

--- a/src/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/Yardarm/Packaging/NuGetPacker.cs
@@ -47,12 +47,26 @@ namespace Yardarm.Packaging
             };
 
             builder.Files.AddRange(compilationResults
-                .SelectMany(result => new[]
+                .SelectMany(result =>
                 {
-                    new StreamPackageFile(result.DllOutput, $"lib/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.dll",
-                        result.TargetFramework),
-                    new StreamPackageFile(result.XmlDocumentationOutput,
-                        $"lib/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.xml", result.TargetFramework)
+                    var files = new List<StreamPackageFile>(3)
+                    {
+                        new StreamPackageFile(result.DllOutput,
+                            $"lib/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.dll",
+                            result.TargetFramework),
+                        new StreamPackageFile(result.XmlDocumentationOutput,
+                            $"lib/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.xml",
+                            result.TargetFramework)
+                    };
+
+                    if (result.ReferenceAssemblyOutput is not null)
+                    {
+                        files.Add(new StreamPackageFile(result.ReferenceAssemblyOutput,
+                            $"ref/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.dll",
+                            result.TargetFramework));
+                    }
+
+                    return files;
                 }));
 
             builder.DependencyGroups.AddRange(GetDependencyGroups());

--- a/src/Yardarm/YardarmCompilationResult.cs
+++ b/src/Yardarm/YardarmCompilationResult.cs
@@ -14,16 +14,18 @@ namespace Yardarm
         internal Stream DllOutput { get; }
         internal Stream PdbOutput { get; }
         internal Stream XmlDocumentationOutput { get; }
+        internal Stream? ReferenceAssemblyOutput { get; }
         public ImmutableArray<Diagnostic> AdditionalDiagnostics { get; }
 
         internal YardarmCompilationResult(NuGetFramework targetFramework, EmitResult emitResult, Stream dllOutput, Stream pdbOutput,
-            Stream xmlDocumentationOutput, ImmutableArray<Diagnostic> additionalDiagnostics)
+            Stream xmlDocumentationOutput, Stream? referenceAssemblyOutput, ImmutableArray<Diagnostic> additionalDiagnostics)
         {
             TargetFramework = targetFramework;
             EmitResult = emitResult;
             DllOutput = dllOutput;
             PdbOutput = pdbOutput;
             XmlDocumentationOutput = xmlDocumentationOutput;
+            ReferenceAssemblyOutput = referenceAssemblyOutput;
             AdditionalDiagnostics = additionalDiagnostics;
         }
     }

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using NuGet.Packaging.Core;
-using Yardarm.Generation;
 
 namespace Yardarm
 {
@@ -60,6 +59,8 @@ namespace Yardarm
             get => _xmlDocumentationOutput ??= new MemoryStream();
             set => _xmlDocumentationOutput = value ?? throw new ArgumentNullException(nameof(value));
         }
+
+        public Stream? ReferenceAssemblyOutput { get; set; }
 
         public ImmutableArray<string> TargetFrameworkMonikers { get; set; } =
             new[] {"netstandard2.0"}.ToImmutableArray();


### PR DESCRIPTION
Motivation
----------
Reference assemblies are smaller and only contain the public members of
the assembly with no implementation. This can improve build speed for
projects referencing the assembly because there is less to load, and
using reference assemblies when available is considered the preferred
practice.

Modifications
-------------
- Add a command-line switch to specify a specific output file for the
  reference assembly.
- Add a command-line switch to suppress when output to a directory,
  otherwise output to a `ref` subdirectory.
- Always include in NuGet packages.