### PR TITLE
Support saving and reusing project.assets.json for NuGet restore

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,7 +6,11 @@ mkdir -p ./bin
 curl -sSL https://api.adv.centeredge.io/v1/swagger/api/swagger.json -o ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/Yardarm.CommandLine -- \
-    generate -n TestSTJ -x src/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --embed --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
+    restore -n TestSTJ -x src/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --intermediate ./obj/ -i ./bin/mashtub.json
+dotnet run --no-build --no-launch-profile -c Release --project src/Yardarm.CommandLine -- \
+    generate --no-restore -n TestSTJ -x src/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --embed --intermediate ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/Yardarm.CommandLine -- \
-    generate -n TestNJ -x src/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --embed --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
+    restore -n TestNJ -x src/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --intermediate ./obj/  -i ./bin/mashtub.json
+dotnet run --no-build --no-launch-profile -c Release --project src/Yardarm.CommandLine -- \
+    generate --no-restore -n TestNJ -x src/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --embed --intermediate ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json

--- a/src/Yardarm.CommandLine/CommonCommand.cs
+++ b/src/Yardarm.CommandLine/CommonCommand.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+using NuGet.Packaging.Core;
+
+namespace Yardarm.CommandLine
+{
+    public class CommonCommand
+    {
+        private readonly CommonOptions _options;
+
+        public CommonCommand(CommonOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+
+            _options = options;
+        }
+
+        protected async Task<OpenApiDocument> ReadDocumentAsync()
+        {
+            var reader = new OpenApiStreamReader();
+
+            await using var stream = File.OpenRead(_options.InputFile);
+
+            return reader.Read(stream, out _);
+        }
+
+        protected void ApplyExtensions(YardarmGenerationSettings settings)
+        {
+            foreach (string extensionFile in _options.ExtensionFiles)
+            {
+                try
+                {
+                    if (extensionFile.EndsWith(".dll"))
+                    {
+                        // Appears to be a file reference
+
+                        string fullPath = !Path.IsPathFullyQualified(extensionFile)
+                            ? Path.Combine(Directory.GetCurrentDirectory(), extensionFile)
+                            : extensionFile;
+
+                        Assembly assembly = Assembly.LoadFile(fullPath);
+
+                        settings.AddExtension(assembly);
+                    }
+                    else
+                    {
+                        // Appears to be an assembly name
+
+                        Assembly assembly = Assembly.Load(extensionFile);
+
+                        settings.AddExtension(assembly);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    throw new Exception($"Error loading extension '{extensionFile}'.", ex);
+                }
+            }
+        }
+
+        protected virtual void ApplyNuGetSettings(YardarmGenerationSettings settings)
+        {
+            string[] targetFrameworks = _options.TargetFrameworks.ToArray();
+            if (targetFrameworks.Length > 0)
+            {
+                settings.TargetFrameworkMonikers = targetFrameworks.ToImmutableArray();
+            }
+        }
+    }
+}

--- a/src/Yardarm.CommandLine/CommonOptions.cs
+++ b/src/Yardarm.CommandLine/CommonOptions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using CommandLine;
+
+namespace Yardarm.CommandLine
+{
+    public class CommonOptions
+    {
+        [Option('i', "input", Required = true, HelpText = "OpenAPI 3 files to process")]
+        public string InputFile { get; set; }
+
+        [Option('n', "name", Required = true, HelpText = "Generated assembly name")]
+        public string AssemblyName { get; set; }
+
+        [Option('f', "frameworks", HelpText = "List of target framework monikers. Must be a single item unless outputting a NuGet package.")]
+        public IEnumerable<string> TargetFrameworks { get; set; }
+
+        [Option('x', "extension", HelpText = "Extension assemblies to enable")]
+        public IEnumerable<string> ExtensionFiles { get; set; }
+
+        [Option("intermediate", HelpText = "Intermediate output directory")]
+        public string IntermediateOutputPath { get; set; }
+    }
+}

--- a/src/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/Yardarm.CommandLine/GenerateOptions.cs
@@ -6,25 +6,19 @@ using CommandLine;
 namespace Yardarm.CommandLine
 {
     [Verb("generate", HelpText = "Generate an assembly")]
-    public class GenerateOptions
+    public class GenerateOptions : CommonOptions
     {
-        [Option('i', "input", Required = true, HelpText = "OpenAPI 3 files to process")]
-        public string InputFile { get; set; }
-
-        [Option('n', "name", Required = true, HelpText = "Generated assembly name")]
-        public string AssemblyName { get; set; }
-
         [Option('v', "version", Default = "1.0.0", HelpText = "Generated assembly version")]
         public string Version { get; set; }
-
-        [Option('f', "frameworks", HelpText = "List of target framework monikers. Must be a single item unless outputting a NuGet package.")]
-        public IEnumerable<string> TargetFrameworks { get; set; }
 
         [Option("keyfile", HelpText = "Key file to create a strongly-named assembly")]
         public string KeyFile { get; set; }
 
         [Option("embed", HelpText = "Embed source files with debug symbols")]
         public bool EmbedAllSources { get; set; }
+
+        [Option("no-restore", HelpText = "Use existing restore lock file from the intermediate directory.")]
+        public bool NoRestore { get; set; }
 
         #region DLL
 
@@ -75,8 +69,5 @@ namespace Yardarm.CommandLine
         public string RepositoryCommit { get; set; }
 
         #endregion
-
-        [Option('x', "extension", HelpText = "Extension assemblies to enable")]
-        public IEnumerable<string> ExtensionFiles { get; set; }
     }
 }

--- a/src/Yardarm.CommandLine/Program.cs
+++ b/src/Yardarm.CommandLine/Program.cs
@@ -4,26 +4,22 @@ using CommandLine;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
+using Yardarm.CommandLine;
 
-namespace Yardarm.CommandLine
-{
-    class Program
-    {
-        static async Task<int> Main(string[] args)
-        {
-            Log.Logger = new LoggerConfiguration()
-                .WriteTo.Console(
-                    theme: AnsiConsoleTheme.Code,
-                    outputTemplate: "[{Level:u3}] {Message:lj}{NewLine}{Exception}",
-                    standardErrorFromLevel: LogEventLevel.Error)
-                .CreateLogger();
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console(
+        theme: AnsiConsoleTheme.Code,
+        outputTemplate: "[{Level:u3}] {Message:lj}{NewLine}{Exception}",
+        standardErrorFromLevel: LogEventLevel.Error)
+    .CreateLogger();
 
-            await Parser.Default.ParseArguments<GenerateOptions, object>(args)
-                .WithParsedAsync<GenerateOptions>(options => new GenerateCommand(options).ExecuteAsync());
+int exitCode = await Parser.Default
+    .ParseArguments<GenerateOptions, RestoreOptions>(args)
+    .MapResult(
+        (GenerateOptions options) => new GenerateCommand(options).ExecuteAsync(),
+        (RestoreOptions options) => new RestoreCommand(options).ExecuteAsync(),
+        errs => Task.FromResult(1));
 
-            Log.CloseAndFlush();
+Log.CloseAndFlush();
 
-            return Environment.ExitCode;
-        }
-    }
-}
+return exitCode;

--- a/src/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/Yardarm.CommandLine/RestoreCommand.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
+using Yardarm.Packaging;
+
+namespace Yardarm.CommandLine
+{
+    public class RestoreCommand : CommonCommand
+    {
+        private readonly RestoreOptions _options;
+
+        public RestoreCommand(RestoreOptions options) : base(options)
+        {
+            _options = options;
+        }
+
+        public async Task<int> ExecuteAsync()
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var document = await ReadDocumentAsync();
+
+            var generator = new YardarmGenerator();
+
+            var settings = new YardarmGenerationSettings(_options.AssemblyName)
+            {
+                IntermediateOutputPath = _options.IntermediateOutputPath,
+            };
+
+            try
+            {
+                ApplyExtensions(settings);
+
+                ApplyNuGetSettings(settings);
+
+                settings
+                    .AddLogging(builder =>
+                    {
+                        builder
+                            .SetMinimumLevel(LogLevel.Information)
+                            .AddSerilog();
+                    });
+
+                await generator.RestoreAsync(document, settings);
+
+                stopwatch.Stop();
+                Log.Information("Restore complete in {0:f3}s", stopwatch.Elapsed.TotalSeconds);
+
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error(ex, "Error restoring SDK");
+                return 1;
+            }
+        }
+    }
+}

--- a/src/Yardarm.CommandLine/RestoreOptions.cs
+++ b/src/Yardarm.CommandLine/RestoreOptions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using CommandLine;
+
+namespace Yardarm.CommandLine
+{
+    [Verb("restore", HelpText = "Restore NuGet packages prior to generating an assembly")]
+    public class RestoreOptions : CommonOptions
+    {
+    }
+}

--- a/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
@@ -25,10 +25,10 @@ namespace Yardarm.Packaging.Internal
 
         public IAsyncEnumerable<MetadataReference> Generate(CancellationToken cancellationToken = default)
         {
-            var result = _context.NuGetRestoreInfo?.Result;
-            Debug.Assert(result is not null);
+            var lockFile = _context.NuGetRestoreInfo?.LockFile;
+            Debug.Assert(lockFile is not null);
 
-            var dependencies = ExtractDependencies(result.LockFile);
+            var dependencies = ExtractDependencies(lockFile);
 
             return dependencies.Select(dependency => MetadataReference.CreateFromFile(dependency)).ToAsyncEnumerable();
         }
@@ -58,7 +58,7 @@ namespace Yardarm.Packaging.Internal
 
             // Collect platform reference assemblies, i.e. .NET 6 assemblies
             dependencies.AddRange(lockFileTarget.Libraries
-                .Where(package => package.PackageType.Any(type => type.Name == "DotnetPlatform"))
+                .Where(package => package.Name == "Microsoft.NETCore.App.Ref")
                 .Select(package =>
                     _context.NuGetRestoreInfo!.Providers.GlobalPackages.FindPackage(package.Name, package.Version))
                 .SelectMany(localPackageInfo =>

--- a/src/Yardarm/Packaging/NuGetRestoreInfo.cs
+++ b/src/Yardarm/Packaging/NuGetRestoreInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NuGet.Commands;
+using NuGet.ProjectModel;
 
 namespace Yardarm.Packaging
 {
@@ -13,12 +14,12 @@ namespace Yardarm.Packaging
         /// <summary>
         /// Result of the restore command.
         /// </summary>
-        public RestoreResult Result { get; set; }
+        public LockFile LockFile { get; set; }
 
-        public NuGetRestoreInfo(RestoreCommandProviders providers, RestoreResult result)
+        public NuGetRestoreInfo(RestoreCommandProviders providers, LockFile lockFile)
         {
             Providers = providers;
-            Result = result;
+            LockFile = lockFile;
         }
     }
 }

--- a/src/Yardarm/YardarmGenerationSettings.cs
+++ b/src/Yardarm/YardarmGenerationSettings.cs
@@ -62,6 +62,17 @@ namespace Yardarm
 
         public Stream? ReferenceAssemblyOutput { get; set; }
 
+        /// <summary>
+        /// Optional intermediate output path. Typically used to store files useful in incremental builds
+        /// and NuGet restores, such as project.assets.json.
+        /// </summary>
+        public string? IntermediateOutputPath { get; set; }
+
+        /// <summary>
+        /// Bypass the restore on generation, assume that a restore has already been done using <see cref="IntermediateOutputPath"/>.
+        /// </summary>
+        public bool NoRestore { get; set; }
+
         public ImmutableArray<string> TargetFrameworkMonikers { get; set; } =
             new[] {"netstandard2.0"}.ToImmutableArray();
 


### PR DESCRIPTION
Motivation
----------
As we move towards an MSBuild integration for generating SDKs, we need
to support separating the restore and build steps and reusing previous
results for incremental builds.

Modifications
-------------
- Add a separate `restore` command which only performs a restore.
- Add a `--no-restore` option to the `generate` command which prevents
  the restore from executing automatically.
- Add an `--intermediate` path option to both commands to control where
  intermediate files such as `project.assets.json` are stored.

Results
-------
The default behavior is unchanged. However, incremental and/or split
build steps may be performed by providing an intermediate output path.

Note: An invalid command line will now correctly return a non-zero exit
code.