### PR TITLE
Move doc/settings to YardarmGenerator constructor

### DIFF
--- a/src/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/Yardarm.CommandLine/GenerateCommand.cs
@@ -32,8 +32,6 @@ namespace Yardarm.CommandLine
 
             var document = await ReadDocumentAsync();
 
-            var generator = new YardarmGenerator();
-
             string basePath = _options.InputFile;
             if (!Path.IsPathFullyQualified(basePath))
             {
@@ -67,7 +65,9 @@ namespace Yardarm.CommandLine
                             .AddSerilog();
                     });
 
-                YardarmGenerationResult generationResult = await generator.EmitAsync(document, settings);
+                var generator = new YardarmGenerator(document, settings);
+
+                YardarmGenerationResult generationResult = await generator.EmitAsync();
 
                 foreach (Diagnostic diagnostic in generationResult.GetAllDiagnostics()
                     .Where(p => p.Severity >= DiagnosticSeverity.Info))

--- a/src/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/Yardarm.CommandLine/RestoreCommand.cs
@@ -26,8 +26,6 @@ namespace Yardarm.CommandLine
 
             var document = await ReadDocumentAsync();
 
-            var generator = new YardarmGenerator();
-
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
                 IntermediateOutputPath = _options.IntermediateOutputPath,
@@ -47,7 +45,8 @@ namespace Yardarm.CommandLine
                             .AddSerilog();
                     });
 
-                await generator.RestoreAsync(document, settings);
+                var generator = new YardarmGenerator(document, settings);
+                await generator.RestoreAsync();
 
                 stopwatch.Stop();
                 Log.Information("Restore complete in {0:f3}s", stopwatch.Elapsed.TotalSeconds);


### PR DESCRIPTION
Motivation
----------
Now that we have multiple methods on YardarmGenerator, it makes more
sense to pass in dependencies and build the service provider once in the
constructor instead of on every method call. This will allow reuse of
generated values across multiple calls if the YardarmGenerator instance
is retained.

Modifications
-------------
Move OpenApiDocument and YardarmGenerationSettings to the constructor,
and build the IServiceProvider in the constructor.

Drop those parameters from the public methods.

Remove YardarmGenerationSettings from several private methods and use
the instance field instead.

Add a method to get the package spec. This will likely be useful for
calculating the dependency graph from a MSBuild project.