### PR TITLE
Support cancellation via Ctrl+C, SIGINT, etc

### DIFF
--- a/src/Yardarm.CommandLine/Program.cs
+++ b/src/Yardarm.CommandLine/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using CommandLine;
 using Serilog;
@@ -13,13 +14,51 @@ Log.Logger = new LoggerConfiguration()
         standardErrorFromLevel: LogEventLevel.Error)
     .CreateLogger();
 
-int exitCode = await Parser.Default
-    .ParseArguments<GenerateOptions, RestoreOptions>(args)
-    .MapResult(
-        (GenerateOptions options) => new GenerateCommand(options).ExecuteAsync(),
-        (RestoreOptions options) => new RestoreCommand(options).ExecuteAsync(),
-        errs => Task.FromResult(1));
+var cts = new CancellationTokenSource();
+
+int exitCode;
+bool completedGracefully = false;
+
+AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+{
+    // ReSharper disable once AccessToModifiedClosure
+    if (!completedGracefully)
+    {
+        Cancel();
+    }
+};
+Console.CancelKeyPress += (_, e) =>
+{
+    Cancel();
+    // Don't terminate immediately, wait for cancellation to propagate
+    e.Cancel = true;
+};
+
+try
+{
+    exitCode = await Parser.Default
+        .ParseArguments<GenerateOptions, RestoreOptions>(args)
+        .MapResult(
+            (GenerateOptions options) => new GenerateCommand(options).ExecuteAsync(cts.Token),
+            (RestoreOptions options) => new RestoreCommand(options).ExecuteAsync(cts.Token),
+            errs => Task.FromResult(1));
+
+    completedGracefully = true;
+}
+catch (OperationCanceledException)
+{
+    exitCode = 2;
+}
 
 Log.CloseAndFlush();
 
 return exitCode;
+
+void Cancel()
+{
+    if (!cts.IsCancellationRequested)
+    {
+        Console.WriteLine("Cancelling...");
+        cts.Cancel();
+    }
+}

--- a/src/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/Yardarm.CommandLine/RestoreCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -19,7 +20,7 @@ namespace Yardarm.CommandLine
             _options = options;
         }
 
-        public async Task<int> ExecuteAsync()
+        public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
         {
             var stopwatch = new Stopwatch();
             stopwatch.Start();
@@ -46,14 +47,14 @@ namespace Yardarm.CommandLine
                     });
 
                 var generator = new YardarmGenerator(document, settings);
-                await generator.RestoreAsync();
+                await generator.RestoreAsync(cancellationToken);
 
                 stopwatch.Stop();
                 Log.Information("Restore complete in {0:f3}s", stopwatch.Elapsed.TotalSeconds);
 
                 return 0;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 Log.Logger.Error(ex, "Error restoring SDK");
                 return 1;

--- a/src/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -1,0 +1,15 @@
+<Project DefaultTargets="Build">
+  <Import Project="../Yardarm.Sdk/Sdk/Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <YardarmToolPath>$(MSBuildThisFileDirectory)..\Yardarm.CommandLine\bin\$(Configuration)\net6.0\</YardarmToolPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SpecFile Include="../Yardarm.CommandLine/mashtub.json" />
+  </ItemGroup>
+
+  <Import Project="../Yardarm.Sdk/Sdk/Sdk.targets" />
+</Project>


### PR DESCRIPTION
Motivation
----------
Allow the generation process to be canceled when required. This will be
helpful when dealing with builds via project files, especially in
Visual Studio

Modifications
-------------
Add a cancellation token to the program triggered by process exit or
Ctrl+C.