### PR TITLE
Restore framework references in a more consistent manner

### DIFF
--- a/src/Yardarm/Enrichment/Packaging/DependencyPackageSpecEnricher.cs
+++ b/src/Yardarm/Enrichment/Packaging/DependencyPackageSpecEnricher.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.ProjectModel;
+using NuGet.Versioning;
 using Yardarm.Packaging;
 
 namespace Yardarm.Enrichment.Packaging
@@ -22,6 +24,34 @@ namespace Yardarm.Enrichment.Packaging
             {
                 targetFramework.Dependencies.AddRange(_dependencyGenerators
                     .SelectMany(p => p.GetDependencies(targetFramework.FrameworkName)));
+
+                if (targetFramework.FrameworkName.Framework == NuGetFrameworkConstants.NetCoreApp)
+                {
+                    targetFramework.FrameworkReferences.Add(new FrameworkDependency("Microsoft.NETCore.App",
+                        FrameworkDependencyFlags.All));
+
+                    var frameworkVersion = targetFramework.FrameworkName.Version;
+                    targetFramework.DownloadDependencies.Add(new DownloadDependency("Microsoft.NETCore.App.Ref",
+                        new VersionRange(
+                            minVersion: new NuGetVersion(frameworkVersion.Major, frameworkVersion.Minor, 0),
+                            maxVersion: new NuGetVersion(frameworkVersion.Major, frameworkVersion.Minor + 1, 0),
+                            includeMaxVersion: false)));
+                }
+                else if (targetFramework.FrameworkName.Framework == NuGetFrameworkConstants.NetStandardFramework
+                         && targetFramework.FrameworkName.Version == NuGetFrameworkConstants.NetStandard21)
+                {
+                    // Note that .NET Standard 2.0 is a library reference added by the StandardDependencyGenerator,
+                    // whereas .NET Standard 2.1 is a framework reference.
+
+                    targetFramework.FrameworkReferences.Add(new FrameworkDependency("NETStandard.Library",
+                        FrameworkDependencyFlags.All));
+
+                    targetFramework.DownloadDependencies.Add(new DownloadDependency("NETStandard.Library.Ref",
+                        new VersionRange(
+                            minVersion: new NuGetVersion(2, 1, 0),
+                            maxVersion: new NuGetVersion(2, 1, 0),
+                            includeMaxVersion: true)));
+                }
             }
 
             return packageSpec;

--- a/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
+++ b/src/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
@@ -37,22 +37,6 @@ namespace Yardarm.Packaging.Internal
                         }
                     };
                 }
-                else if (targetFramework.Version == NuGetFrameworkConstants.NetStandard21)
-                {
-                    // Only include NETStandard.Library.Ref for restore, not as a listed dependency on the generated package
-                    yield return new LibraryDependency
-                    {
-                        LibraryRange = new LibraryRange
-                        {
-                            Name = "NETStandard.Library.Ref",
-                            TypeConstraint = LibraryDependencyTarget.Package,
-                            VersionRange = VersionRange.Parse("2.1.0")
-                        },
-                        IncludeType = LibraryIncludeFlags.None,
-                        SuppressParent = LibraryIncludeFlags.All,
-                        AutoReferenced = true,
-                    };
-                }
 
                 yield return new LibraryDependency
                 {
@@ -72,22 +56,6 @@ namespace Yardarm.Packaging.Internal
                         TypeConstraint = LibraryDependencyTarget.Package,
                         VersionRange = VersionRange.Parse("4.7.0")
                     }
-                };
-            }
-            else if (targetFramework.Framework == NuGetFrameworkConstants.NetCoreApp)
-            {
-                yield return new LibraryDependency
-                {
-                    LibraryRange = new LibraryRange
-                    {
-                        Name = "Microsoft.NETCore.App.Ref",
-                        TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = new VersionRange(minVersion: new NuGetVersion(
-                            targetFramework.Version.Major, targetFramework.Version.Minor, targetFramework.Version.Revision)),
-                    },
-                    IncludeType = LibraryIncludeFlags.None,
-                    SuppressParent = LibraryIncludeFlags.All,
-                    AutoReferenced = true,
                 };
             }
         }


### PR DESCRIPTION
Motivation
----------
Improve our compatibility with how NuGet restoration works within
MSBuild.

Modifications
-------------
Restore .NET framework and .NET Standard 2.1 references as framework
references rather than general libraries.

Results
-------
This is much more consistent with how MSBuild will perform the restore
and add the dependencies the lock file. This should, in theory, allow
the lock file to be generated by an MSBuild restore and then passed to
the generate step in Yardarm.