### PR TITLE
Add collect-package-references command

### DIFF
--- a/src/Yardarm.CommandLine/CollectPackageReferencesCommand.cs
+++ b/src/Yardarm.CommandLine/CollectPackageReferencesCommand.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Yardarm.CommandLine.Interop;
+
+namespace Yardarm.CommandLine
+{
+    public class CollectPackageReferencesCommand : CommonCommand
+    {
+        private readonly CollectPackageReferencesOptions _options;
+
+        public CollectPackageReferencesCommand(CollectPackageReferencesOptions options) : base(options)
+        {
+            _options = options;
+        }
+
+        public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            var document = await ReadDocumentAsync();
+
+            var settings = new YardarmGenerationSettings(_options.AssemblyName)
+            {
+                IntermediateOutputPath = _options.IntermediateOutputPath,
+            };
+
+            try
+            {
+                ApplyExtensions(settings);
+
+                ApplyNuGetSettings(settings);
+
+                settings
+                    .AddLogging(builder =>
+                    {
+                        builder
+                            .SetMinimumLevel(LogLevel.Information)
+                            .AddSerilog();
+                    });
+
+                var generator = new YardarmGenerator(document, settings);
+                var packageSpec = await generator.GetPackageSpecAsync(cancellationToken);
+
+                foreach (var dependency in packageSpec.Dependencies)
+                {
+                    var item = new AddItemDto
+                    {
+                        ItemType = "PackageReference",
+                        Identity = dependency.Name,
+                        Metadata = new Dictionary<string, string>()
+                        {
+                            ["Version"] = dependency.LibraryRange.VersionRange.OriginalString
+                        }
+                    };
+
+                    AddItem(item);
+                }
+
+                foreach (var framework in packageSpec.TargetFrameworks)
+                {
+                    foreach (var dependency in framework.Dependencies.Where(p => !p.AutoReferenced))
+                    {
+                        var item = new AddItemDto
+                        {
+                            ItemType = "PackageReference",
+                            TargetFramework = framework.FrameworkName.GetShortFolderName(),
+                            Identity = dependency.Name,
+                            Metadata = new Dictionary<string, string>()
+                            {
+                                ["Version"] = dependency.LibraryRange.VersionRange.OriginalString
+                            }
+                        };
+
+                        AddItem(item);
+                    }
+                }
+
+                stopwatch.Stop();
+                Log.Information("Collect package references complete in {0:f3}s", stopwatch.Elapsed.TotalSeconds);
+
+                return 0;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                Log.Logger.Error(ex, "Error collecting package references");
+                return 1;
+            }
+        }
+
+        private static void AddItem(AddItemDto item)
+        {
+            Console.WriteLine($"AddItem: {JsonSerializer.Serialize(item, DtoSerializerContext.Default.AddItemDto)}");
+        }
+    }
+}

--- a/src/Yardarm.CommandLine/CollectPackageReferencesOptions.cs
+++ b/src/Yardarm.CommandLine/CollectPackageReferencesOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using CommandLine;
+
+namespace Yardarm.CommandLine
+{
+    /// <summary>
+    /// This command is used to generate a list of package references for a given target framework. It may be used
+    /// by MSBuild as part of the CollectPackageReferences extension point.
+    /// </summary>
+    [Verb("collect-package-references", HelpText = "Collect NuGet package references to include in MSBuild")]
+    public class CollectPackageReferencesOptions : CommonOptions
+    {
+    }
+}

--- a/src/Yardarm.CommandLine/Interop/AddItemDto.cs
+++ b/src/Yardarm.CommandLine/Interop/AddItemDto.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+#nullable enable
+
+namespace Yardarm.CommandLine.Interop
+{
+    // Note: DataContract attributes are used for deserialization within legacy framework MSBuild
+
+    [DataContract]
+    internal class AddItemDto
+    {
+        [DataMember(Name = "itemType")]
+        public string? ItemType { get; set; }
+
+        [DataMember(Name = "targetFramework")]
+        public string? TargetFramework { get; set; }
+
+        [DataMember(Name = "identity")]
+        public string? Identity { get; set; }
+
+        [DataMember(Name = "metadata")]
+        public Dictionary<string, string>? Metadata { get; set; }
+    }
+}

--- a/src/Yardarm.CommandLine/Interop/DtoSerializerContext.cs
+++ b/src/Yardarm.CommandLine/Interop/DtoSerializerContext.cs
@@ -1,0 +1,17 @@
+﻿#if NET6_0_OR_GREATER
+
+using System;
+using System.Text.Json.Serialization;
+
+#nullable enable
+
+namespace Yardarm.CommandLine.Interop
+{
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(AddItemDto))]
+    internal partial class DtoSerializerContext : JsonSerializerContext
+    {
+    }
+}
+
+#endif

--- a/src/Yardarm.CommandLine/Program.cs
+++ b/src/Yardarm.CommandLine/Program.cs
@@ -37,10 +37,11 @@ Console.CancelKeyPress += (_, e) =>
 try
 {
     exitCode = await Parser.Default
-        .ParseArguments<GenerateOptions, RestoreOptions>(args)
+        .ParseArguments<GenerateOptions, RestoreOptions, CollectPackageReferencesOptions>(args)
         .MapResult(
             (GenerateOptions options) => new GenerateCommand(options).ExecuteAsync(cts.Token),
             (RestoreOptions options) => new RestoreCommand(options).ExecuteAsync(cts.Token),
+            (CollectPackageReferencesOptions options) => new CollectPackageReferencesCommand(options).ExecuteAsync(cts.Token),
             errs => Task.FromResult(1));
 
     completedGracefully = true;


### PR DESCRIPTION
Motivation
----------
Provide an extension point that outputs package references in a format
which can be read by an MSBuild task. This will allow NuGet restore
from an MSBuild project to know the correct packages to restore.

Modifications
-------------
Add the command and DTOs for serializing JSON information on the console
to be received by MSBuild.