### PR TITLE
Cleanup some issues with the MSBuild tasks

### DIFF
--- a/src/sdk/Yardarm.Build.Tasks/YardarmCollectDependencies.cs
+++ b/src/sdk/Yardarm.Build.Tasks/YardarmCollectDependencies.cs
@@ -37,13 +37,24 @@ public class YardarmCollectDependencies : YardarmCommonTask
     private readonly List<ITaskItem> _frameworkReference = new();
 
     [Output]
-    public ITaskItem[] PackageReference => _packageReference.ToArray();
+    public ITaskItem[]? PackageReference { get; set; }
 
     [Output]
-    public ITaskItem[] PackageDownload => _packageDownload.ToArray();
+    public ITaskItem[]? PackageDownload { get; set; }
 
     [Output]
-    public ITaskItem[] FrameworkReference => _frameworkReference.ToArray();
+    public ITaskItem[]? FrameworkReference { get; set; }
+
+    public override bool Execute()
+    {
+        bool result = base.Execute();
+
+        PackageReference = _packageReference.ToArray();
+        PackageDownload = _packageDownload.ToArray();
+        FrameworkReference = _frameworkReference.ToArray();
+
+        return result;
+    }
 
     protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
     {
@@ -61,7 +72,7 @@ public class YardarmCollectDependencies : YardarmCommonTask
             var item = JsonSerializer.Deserialize<AddItemDto>(singleLine, s_serializerOptions)!;
 #else
             // Since we need to be compatible with net472 and don't want to take dependencies, we must engage in this ugliness
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(singleLine.Substring(AddItemPrefix.Length)));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(singleLine));
             var item = (AddItemDto) s_serializer.ReadObject(stream);
 #endif
 

--- a/src/sdk/Yardarm.Build.Tasks/YardarmCommonTask.cs
+++ b/src/sdk/Yardarm.Build.Tasks/YardarmCommonTask.cs
@@ -9,7 +9,10 @@ namespace Yardarm.Build.Tasks
         protected abstract string Verb { get; }
 
         public string? AssemblyName { get; set; }
+
+        [Required]
         public string? TargetFramework { get; set; }
+
         public string? BaseIntermediateOutputPath { get; set; }
 
         public ITaskItem[]? SpecFile { get; set; }
@@ -54,6 +57,8 @@ namespace Yardarm.Build.Tasks
                     builder.Append(extension.ItemSpec);
                 }
             }
+
+            AppendAdditionalArguments(builder);
 
             return builder.ToString();
         }

--- a/src/sdk/Yardarm.Build.Tasks/YardarmGenerate.cs
+++ b/src/sdk/Yardarm.Build.Tasks/YardarmGenerate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text;
 using Microsoft.Build.Framework;
 
@@ -10,13 +11,34 @@ public class YardarmGenerate : YardarmCommonTask
 
     public string? Version { get; set; }
     public bool EmbedAllSources { get; set; } = true;
+
+    [Required]
     public string? OutputAssembly { get; set; }
+
     public string? OutputRefAssembly { get; set; }
     public string? OutputDebugSymbols { get; set; }
     public string? OutputXmlDocumentation { get; set; }
 
+    protected override bool ValidateParameters()
+    {
+        if (!base.ValidateParameters())
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(OutputAssembly))
+        {
+            Log.LogError("Must supply an OutputAssembly.");
+            return false;
+        }
+
+        return true;
+    }
+
     protected override void AppendAdditionalArguments(StringBuilder builder)
     {
+        builder.AppendFormat(" --no-restore"); // Restore is performed by MSBuild
+
         if (!string.IsNullOrEmpty(Version))
         {
             builder.AppendFormat(" -v {0}", Version);


### PR DESCRIPTION
Motivation
----------
They aren't working quite right.

Modifications
-------------
- Send --no-restore to generate
- Make the missing call to AppendAdditionalArguments
- Add some required attributes
- Adjust the approach to output parameters
- Stop double-trimming the input string when decoding logs in net472