### PR TITLE
Accept resolved framework references

### DIFF
--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -13,6 +13,7 @@ using NuGet.Packaging.Core;
 using Serilog;
 using Serilog.Events;
 using Yardarm.Helpers;
+using Yardarm.Packaging;
 using Yardarm.Spec;
 
 namespace Yardarm.CommandLine
@@ -45,6 +46,7 @@ namespace Yardarm.CommandLine
                 EmbedAllSources = _options.EmbedAllSources,
                 IntermediateOutputPath = _options.IntermediateOutputPath,
                 NoRestore = _options.NoRestore,
+                ResolvedFrameworkReferences = _options.FrameworkReferences?.ToList(),
             };
 
             ApplyVersion(settings);

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using CommandLine;
+using Yardarm.Packaging;
 
 namespace Yardarm.CommandLine
 {
@@ -19,6 +20,9 @@ namespace Yardarm.CommandLine
 
         [Option("no-restore", HelpText = "Use existing restore lock file from the intermediate directory.")]
         public bool NoRestore { get; set; }
+
+        [Option("framework-references", HelpText = "Resolved framework references, typically only supplied by MSBuild. Format \"name=path\".")]
+        public IEnumerable<ResolvedFrameworkReference> FrameworkReferences { get; set; }
 
         #region DLL
 

--- a/src/main/Yardarm/Packaging/ResolvedFrameworkReference.cs
+++ b/src/main/Yardarm/Packaging/ResolvedFrameworkReference.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Yardarm.Packaging
+{
+    public class ResolvedFrameworkReference
+    {
+        public string Name { get; }
+        public string Path { get; }
+
+        public ResolvedFrameworkReference(string resolvedPair)
+        {
+            ArgumentNullException.ThrowIfNull(resolvedPair);
+
+            string[] pair = resolvedPair.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (pair.Length != 2)
+            {
+                throw new ArgumentException("Invalid framework reference.", nameof(resolvedPair));
+            }
+
+            Name = pair[0];
+            Path = pair[1];
+        }
+
+        public ResolvedFrameworkReference(string name, string path)
+        {
+            ArgumentNullException.ThrowIfNull(path);
+            ArgumentNullException.ThrowIfNull(name);
+
+            Name = name;
+            Path = path;
+        }
+    }
+}

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using NuGet.Packaging.Core;
+using Yardarm.Packaging;
 
 namespace Yardarm
 {
@@ -79,6 +80,12 @@ namespace Yardarm
         public Stream? NuGetOutput { get; set; }
 
         public Stream? NuGetSymbolsOutput { get; set; }
+
+        /// <summary>
+        /// A list of resolved framework references, typically passed in from MSBuild. If there is a framework
+        /// reference which is not included in this list Yardarm will try to resolve itself.
+        /// </summary>
+        public List<ResolvedFrameworkReference>? ResolvedFrameworkReferences { get; set; }
 
         public CSharpCompilationOptions CompilationOptions { get; set; } =
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)


### PR DESCRIPTION
Motivation
----------
When the restore is performed by MSBuild the framework references will
often come from other places such as targeting packs rather than being
downloaded from NuGet.

Modifications
-------------
Provide a command line argument where MSBuild may provided the precise
directory to obtain reference assemblies for frameworks such as .NET
Standard 2.1 and .NET 6. When present, this is preferred over attempting
to discover them ourselves.