### PR TITLE
Pass extentions from SDK

### DIFF
--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -134,6 +134,7 @@
       AssemblyName="$(AssemblyName)"
       TargetFramework="$(TargetFramework)"
       SpecFile="@(SpecFile)"
+      Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
     >
       <Output TaskParameter="PackageReference" ItemName="PackageReference" />
@@ -161,6 +162,7 @@
       TargetFramework="$(TargetFramework)"
       Version="$(Version)"
       SpecFile="@(SpecFile)"
+      Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
       EmbedAllSources="$(EmbedAllSources)"
       OutputAssembly="@(IntermediateAssembly)"


### PR DESCRIPTION
Motivation
----------
We're not forwarding YardarmExtension items to the MSBuild tasks.

Modifications
-------------
Forward the items.