### PR TITLE
Make Yardarm SDK compatible with central package versioning

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+
+  <packageSourceMapping>
+    <!-- key value for <packageSource> should match key values from <packageSources> element -->
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
+++ b/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+</Project>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -111,10 +111,25 @@
       Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
     >
-      <Output TaskParameter="PackageReference" ItemName="PackageReference" />
+      <Output TaskParameter="PackageReference" ItemName="_YardarmPackageReference" />
       <Output TaskParameter="PackageDownload" ItemName="PackageDownload" />
       <Output TaskParameter="FrameworkReference" ItemName="FrameworkReference" />
     </YardarmCollectDependencies>
+
+    <!--
+      If using the new NuGet central package versioning system, remove the version specified by Yardarm
+      and use the centrally set version instead.
+    -->
+    <ItemGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
+      <_YardarmPackageReference Update="@(_YardarmPackageReference)">
+        <Version />
+      </_YardarmPackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="@(_YardarmPackageReference)" />
+      <_YardarmPackageReference Remove="@(_YardarmPackageReference)" />
+    </ItemGroup>
   </Target>
 
   <!--


### PR DESCRIPTION
Motivation
----------
Currently solutions using central package versioning will receive errors
on Yardarm SDK projects without special handling.

Modifications
-------------
If central package versioning is detected strip the Yardarm generated
versions from PackageReferences and let the version by controlled by
central package versioning instead.