### PR TITLE
Add strong naming support to the Yardarm SDK

### DIFF
--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -278,14 +278,35 @@ namespace Yardarm.CommandLine
 
         private void ApplyStrongNaming(YardarmGenerationSettings settings)
         {
-            if (string.IsNullOrEmpty(_options.KeyFile))
+            if (string.IsNullOrEmpty(_options.KeyFile) && string.IsNullOrEmpty(_options.KeyContainerName))
             {
                 return;
             }
 
-            settings.CompilationOptions = settings.CompilationOptions
-                .WithStrongNameProvider(new DesktopStrongNameProvider(ImmutableArray.Create(Directory.GetCurrentDirectory())))
-                .WithCryptoKeyFile(_options.KeyFile);
+            var options = settings.CompilationOptions
+                .WithStrongNameProvider(
+                    new DesktopStrongNameProvider(ImmutableArray.Create(Directory.GetCurrentDirectory())));
+
+            if (!string.IsNullOrEmpty(_options.KeyFile))
+            {
+                options = options.WithCryptoKeyFile(_options.KeyFile);
+            }
+            else
+            {
+                options = options.WithCryptoKeyContainer(_options.KeyContainerName);
+            }
+
+            if (_options.DelaySign)
+            {
+                options = options.WithDelaySign(true);
+            }
+
+            if (_options.PublicSign)
+            {
+                options = options.WithPublicSign(true);
+            }
+
+            settings.CompilationOptions = options;
         }
 
         protected override void ApplyNuGetSettings(YardarmGenerationSettings settings)

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using CommandLine;
-using Yardarm.Packaging;
 
 namespace Yardarm.CommandLine
 {
@@ -14,6 +12,12 @@ namespace Yardarm.CommandLine
 
         [Option("keyfile", HelpText = "Key file to create a strongly-named assembly")]
         public string KeyFile { get; set; }
+
+        [Option("keycontainername", HelpText = "Key container to create a strongly-named assembly")]
+        public string KeyContainerName { get; set; }
+
+        [Option("public-sign", HelpText = "Sign the strongly-named assembly with the public key only")]
+        public bool PublicSign { get; set; }
 
         [Option("embed", HelpText = "Embed source files with debug symbols")]
         public bool EmbedAllSources { get; set; }
@@ -46,6 +50,9 @@ namespace Yardarm.CommandLine
 
         [Option("no-ref", HelpText = "Suppress output of the reference assembly file", SetName = "dll")]
         public bool NoReferenceAssembly { get; set; }
+
+        [Option("delay-sign", HelpText = "Delay signing of a strongly-named assembly", SetName = "dll")]
+        public bool DelaySign { get; set; }
 
         #endregion
 

--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <KeyFile>..\..\Yardarm.snk</KeyFile>
 
     <!-- Override these for local testing, get directly from build output -->
     <YardarmToolPath Condition=" $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\main\Yardarm.CommandLine\bin\$(Configuration)\net6.0\linux-x64\</YardarmToolPath>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -159,6 +159,10 @@
       OutputDebugSymbols="@(_DebugSymbolsIntermediatePath)"
       OutputXmlDocumentation="$(DocumentationFile)"
       References="@(ReferencePathWithRefAssemblies)"
+      KeyFile="$(KeyOriginatorFile)"
+      KeyContainerName="$(KeyContainerName)"
+      DelaySign="$(DelaySign)"
+      PublicSign="$(PublicSign)"
     >
     </YardarmGenerate>
 

--- a/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
@@ -18,6 +18,10 @@ public class YardarmGenerate : YardarmCommonTask
     public string? OutputRefAssembly { get; set; }
     public string? OutputDebugSymbols { get; set; }
     public string? OutputXmlDocumentation { get; set; }
+    public string? KeyFile { get; set; }
+    public string? KeyContainerName { get; set; }
+    public string? DelaySign { get; set; }
+    public string? PublicSign { get; set; }
 
     public ITaskItem[]? References { get; set; }
 
@@ -63,6 +67,22 @@ public class YardarmGenerate : YardarmCommonTask
         if (!string.IsNullOrEmpty(OutputXmlDocumentation))
         {
             builder.AppendFormat(" --xml {0}", OutputXmlDocumentation);
+        }
+        if (!string.IsNullOrEmpty(KeyFile))
+        {
+            builder.AppendFormat(" --keyfile {0}", KeyFile);
+        }
+        if (!string.IsNullOrEmpty(KeyContainerName))
+        {
+            builder.AppendFormat(" --keycontainername {0}", KeyContainerName);
+        }
+        if (DelaySign == "true")
+        {
+            builder.Append(" --delay-sign");
+        }
+        if (PublicSign == "true")
+        {
+            builder.Append(" --public-sign");
         }
 
         if (References is {Length: > 0})


### PR DESCRIPTION
Motivation
----------
If a key file is provided through the normal C# project means, such as
`<KeyFile>`, we should strong name the output assembly.

Modifications
-------------
- Add `--delay-sign`, `--public-sign`, and `--keycontainername` params
  for consistency with options provided for C# projects
- Forward these values from the Yardarm SDK via the task