### PR TITLE
Add SDK extension point for dynamic spec generation/download

### DIFF
--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <SpecFile Include="../../main/Yardarm.CommandLine/centeredge-cardsystemapi.yaml">
+    <OpenApiSpec Include="../../main/Yardarm.CommandLine/centeredge-cardsystemapi.yaml">
       <Link>centeredge-cardsystemapi.yaml</Link>
-    </SpecFile>
+    </OpenApiSpec>
   </ItemGroup>
 
   <Import Project="../Yardarm.Sdk/Sdk/Sdk.targets" />

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -66,6 +66,9 @@
 
   <Import Project="$(CustomAfterYardarmProps)" Condition=" '$(CustomAfterYardarmProps)' != '' And Exists('$(CustomAfterYardarmProps)') " />
 
+  <!-- Extension point for dynamically generating/collecting OpenApiSpec items -->
+  <Target Name="CollectOpenApiSpecs" />
+
   <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
   <Target Name="CompileDesignTime" />
 </Project>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -34,10 +34,6 @@
       IncrementalClean;
       PostBuildEvent
     </CoreBuildDependsOn>
-    <CoreCompileDependsOn>
-      $(CoreCompileDependsOn);
-      _VerifyOpenApiSpecFile
-    </CoreCompileDependsOn>
   </PropertyGroup>
 
   <!--
@@ -75,22 +71,23 @@
   <Import Project="$(CustomAfterYardarm)" Condition="'$(CustomAfterYardarm)' != '' and Exists('$(CustomAfterYardarm)')" />
 
   <!--
-    Verify that the SpecFile is found and that there is only one specified.
+    Verify that the OpenApiSpec is found and that there is only one specified.
   -->
-  <Target Name="_VerifyOpenApiSpecFile">
+  <Target Name="_VerifyOpenApiSpecs"
+          DependsOnTargets="CollectOpenApiSpecs">
     <ItemGroup>
-      <_FilteredSpecFile Include="@(SpecFile->Exists())" />
+      <_FilteredOpenApiSpec Include="@(OpenApiSpec->Exists())" />
     </ItemGroup>
 
-    <Error Text="Open API spec file '@(SpecFile)' not found."
-           Condition=" @(_FilteredSpecFile->Count()) == 0 " />
+    <Error Text="Open API spec file '@(OpenApiSpec)' not found."
+           Condition=" @(_FilteredOpenApiSpec->Count()) == 0 " />
 
     <Error Text="Only one Open API spec file is allowed."
-           Condition=" @(_FilteredSpecFile->Count()) != 1 " />
+           Condition=" @(_FilteredOpenApiSpec->Count()) != 1 " />
 
     <ItemGroup>
-      <SpecFile Remove="@(SpecFile)" />
-      <SpecFile Include="@(_FilteredSpecFile)" />
+      <OpenApiSpec Remove="@(OpenApiSpec)" />
+      <OpenApiSpec Include="@(_FilteredOpenApiSpec)" />
     </ItemGroup>
   </Target>
 
@@ -101,13 +98,13 @@
   <Target Name="YardarmCollectDependencies"
           Condition=" '$(TargetFramework)' != '' "
           BeforeTargets="CollectPackageReferences;CollectPackageDownloads;CollectFrameworkReferences"
-          DependsOnTargets="_VerifyOpenApiSpecFile"
+          DependsOnTargets="_VerifyOpenApiSpecs"
           Returns="@(PackageReference);@(PackageDownload);@(FrameworkReference)">
     <YardarmCollectDependencies
       ToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
       TargetFramework="$(TargetFramework)"
-      SpecFile="@(SpecFile)"
+      SpecFile="@(OpenApiSpec)"
       Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
     >
@@ -135,8 +132,14 @@
   <!--
     Override stock CoreCompile target to execute Yardarm generation
   -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>
+      $(CoreCompileDependsOn);
+      _VerifyOpenApiSpecs
+    </CoreCompileDependsOn>
+  </PropertyGroup>
   <Target Name="CoreCompile"
-          Inputs="$(MSBuildAllProjects);$(OpenApiSpecFile);@(CustomAdditionalCompileInputs)"
+          Inputs="$(MSBuildAllProjects);@(OpenApiSpec);@(CustomAdditionalCompileInputs)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);
                    @(IntermediateRefAssembly);
@@ -150,7 +153,7 @@
       AssemblyName="$(AssemblyName)"
       TargetFramework="$(TargetFramework)"
       Version="$(Version)"
-      SpecFile="@(SpecFile)"
+      SpecFile="@(OpenApiSpec)"
       Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
       EmbedAllSources="$(EmbedAllSources)"
@@ -178,7 +181,7 @@
   <Target Name="_GenerateCompileDependencyCache" Condition="'$(BuildingProject)' == 'true'">
     <ItemGroup>
       <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
-      <CoreCompileCache Include="@(SpecFile)" />
+      <CoreCompileCache Include="@(OpenApiSpec)" />
       <CoreCompileCache Include="EmbedAllSources=$(EmbedAllSources)" />
       <CoreCompileCache Include="GenerateDocumentationFile=$(GenerateDocumentationFile)" />
       <CoreCompileCache Include="Version=$(Version)" />


### PR DESCRIPTION
Motivation
----------
Some projects may be downloading the spec from a remote source or
generating the spec via some other tool.

Modifications
-------------
- Add the CollectOpenApiSpecs extension point
- Rename the item name from `SpecFile` to `OpenApiSpec` to be more
  consistent with how C# projects name items.