### PR TITLE
Make the tool build for the SDK build not self-contained

### DIFF
--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -6,8 +6,8 @@
 
     <UsingYardarmSdk>true</UsingYardarmSdk>
 
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' And $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\tools\linux-x64\yardarm\</YardarmToolPath>
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\win10-x64\yardarm\</YardarmToolPath>
+    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' And $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\tools\net6.0\linux-x64\yardarm\</YardarmToolPath>
+    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\net6.0\win10-x64\yardarm\</YardarmToolPath>
     <YardarmTaskBasePath Condition=" '$(YardarmTaskBasePath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\</YardarmTaskBasePath>
   </PropertyGroup>
 

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -67,7 +67,7 @@
       Ensure that the CommandLine build has been run for both RuntimeIdentifier values
     -->
     <MSBuild Projects="@(_YardarmCommandLine)"
-             Properties="Configuration=$(Configuration);TargetFramework=net6.0"
+             Properties="Configuration=$(Configuration);TargetFramework=net6.0;SelfContained=False"
              Targets="Build"
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="false"

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -125,12 +125,12 @@
                      Condition=" '%(_FilteredYardarmCommandLineFiles.AdditionalProperties)' == 'RuntimeIdentifier=win10-x64' "
                      BuildAction="None"
                      Pack="true"
-                     PackagePath="tools\win10-x64\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
+                     PackagePath="tools\net6.0\win10-x64\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
       <_PackageFiles Include="@(_FilteredYardarmCommandLineFiles)"
                      Condition=" '%(_FilteredYardarmCommandLineFiles.AdditionalProperties)' == 'RuntimeIdentifier=linux-x64' "
                      BuildAction="None"
                      Pack="true"
-                     PackagePath="tools\linux-x64\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
+                     PackagePath="tools\net6.0\linux-x64\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Motivation
----------
While the publish of the command line tool used by the SDK is a smaller,
not self-contained publish, the runtimeconfig is still marked for a
self-contained distribution. This makes the run fail.

Modifications
-------------
Build with SelfContained=false so that the runtimeconfig.json file is
properly generated.