### PR TITLE
Don't include NETStandard.Library in collect-dependencies output

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -16,4 +16,4 @@ dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.
     generate --no-restore -n TestNJ -x src/main/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --embed --intermediate-dir ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
 
 # Basic test of the SDK
-dotnet build -c Release src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj -v Detailed
+dotnet build -c Release src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj

--- a/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
+++ b/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
@@ -68,9 +68,9 @@ namespace Yardarm.CommandLine
 
                     foreach (var download in framework.DownloadDependencies)
                     {
-                        if (download.Name == "Microsoft.NETCore.App.Ref")
+                        if (download.Name is "Microsoft.NETCore.App.Ref" or "NETStandard.Library.Ref")
                         {
-                            // Don't add PackageDownload for .NET Core, this is added automatically by the ProcessFrameworkReferences
+                            // Don't add PackageDownload for .NET Core or .NET Standard, this is added automatically by the ProcessFrameworkReferences
                             // target in MSBuild and we don't want a duplicate. This also has the advantage that MSBuild will automatically
                             // pull the latest known version.
                             continue;
@@ -84,22 +84,6 @@ namespace Yardarm.CommandLine
                             Metadata = new Dictionary<string, string>
                             {
                                 ["Version"] = download.VersionRange.ToNormalizedString()
-                            }
-                        };
-
-                        AddItem(item);
-                    }
-
-                    foreach (var reference in framework.FrameworkReferences)
-                    {
-                        var item = new AddItemDto
-                        {
-                            ItemType = "FrameworkReference",
-                            TargetFramework = framework.FrameworkName.GetShortFolderName(),
-                            Identity = reference.Name,
-                            Metadata = new Dictionary<string, string>
-                            {
-                                ["PrivateAssets"] = reference.PrivateAssets == FrameworkDependencyFlags.All ? "All" : "None"
                             }
                         };
 

--- a/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
+++ b/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
@@ -51,14 +51,14 @@ namespace Yardarm.CommandLine
                 var generator = new YardarmGenerator(document, settings);
                 var packageSpec = await generator.GetPackageSpecAsync(cancellationToken);
 
-                foreach (var dependency in packageSpec.Dependencies)
+                foreach (var dependency in packageSpec.Dependencies.Where(p => !p.AutoReferenced))
                 {
                     AddItem(GeneratePackageReference(dependency));
                 }
 
                 foreach (var framework in packageSpec.TargetFrameworks)
                 {
-                    foreach (var dependency in framework.Dependencies)
+                    foreach (var dependency in framework.Dependencies.Where(p => !p.AutoReferenced))
                     {
                         var item = GeneratePackageReference(dependency);
                         item.TargetFramework = framework.FrameworkName.GetShortFolderName();

--- a/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
+++ b/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -43,9 +43,6 @@
     <!-- Workload resolver is not required and doesn't work. -->
     <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
 
-    <!-- Targeting packs shouldn't be referenced as Yardarm adds these references automatically. -->
-    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
-
     <!-- Don't generate assembly info -->
     <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == ''">false</GenerateAssemblyInfo>
 
@@ -54,11 +51,6 @@
 
     <!-- Don't generate editor config file -->
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
-
-    <!-- Don't automatically reference assembly packages since Yardarm doesn't need reference assemblies -->
-    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
-    <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
-    <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
 
     <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
     <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck)' == ''">true</DisableFastUpToDateCheck>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -97,9 +97,9 @@
   -->
   <Target Name="YardarmCollectDependencies"
           Condition=" '$(TargetFramework)' != '' "
-          BeforeTargets="CollectPackageReferences;CollectPackageDownloads;CollectFrameworkReferences"
+          BeforeTargets="CollectPackageReferences;CollectPackageDownloads"
           DependsOnTargets="_VerifyOpenApiSpecs"
-          Returns="@(PackageReference);@(PackageDownload);@(FrameworkReference)">
+          Returns="@(PackageReference);@(PackageDownload)">
     <YardarmCollectDependencies
       ToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
@@ -110,7 +110,6 @@
     >
       <Output TaskParameter="PackageReference" ItemName="_YardarmPackageReference" />
       <Output TaskParameter="PackageDownload" ItemName="PackageDownload" />
-      <Output TaskParameter="FrameworkReference" ItemName="FrameworkReference" />
     </YardarmCollectDependencies>
 
     <!--

--- a/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
@@ -34,7 +34,6 @@ public class YardarmCollectDependencies : YardarmCommonTask
 
     private readonly List<ITaskItem> _packageReference = new();
     private readonly List<ITaskItem> _packageDownload = new();
-    private readonly List<ITaskItem> _frameworkReference = new();
 
     [Output]
     public ITaskItem[]? PackageReference { get; set; }
@@ -42,16 +41,12 @@ public class YardarmCollectDependencies : YardarmCommonTask
     [Output]
     public ITaskItem[]? PackageDownload { get; set; }
 
-    [Output]
-    public ITaskItem[]? FrameworkReference { get; set; }
-
     public override bool Execute()
     {
         bool result = base.Execute();
 
         PackageReference = _packageReference.ToArray();
         PackageDownload = _packageDownload.ToArray();
-        FrameworkReference = _frameworkReference.ToArray();
 
         return result;
     }
@@ -96,10 +91,6 @@ public class YardarmCollectDependencies : YardarmCommonTask
 
                     case "PackageDownload":
                         _packageDownload.Add(taskItem);
-                        break;
-
-                    case "FrameworkReference":
-                        _frameworkReference.Add(taskItem);
                         break;
                 }
             }


### PR DESCRIPTION
Motivation
----------
The reference to NETStandard.Library will be automatically added by
MSBuild when compiling from the SDK. Including it is unnecessary and can
cause warnings/errors in other csproj files depending on the Yardarm
project.

Modifications
-------------
- Exclude dependencies marked as AutoReferenced from the output of
  collect-dependencies.
- Drop FrameworkReference from collect-dependencies, just use the one
  from MSBuild instead. This avoids duplicate references, and make
  more sense now that we're pulling all references from MSBuild rather
  than collecting internally.