### PR TITLE
Use dot notation within JsonMode property

### DIFF
--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -11,7 +11,7 @@
     <YardarmTaskBasePath Condition=" '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)..\Yardarm.Sdk\bin\$(Configuration)\</YardarmTaskBasePath>
     <YardarmTaskBasePath Condition=" '$(MSBuildRuntimeType)' != 'Core' ">$(MSBuildThisFileDirectory)..\Yardarm.Sdk\bin\$(Configuration)\</YardarmTaskBasePath>
 
-    <JsonMode>NewtonsoftJson</JsonMode>
+    <JsonMode>Newtonsoft.Json</JsonMode>
   </PropertyGroup>
 
   <Import Project="../Yardarm.Sdk/Sdk/Sdk.targets" />

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -15,10 +15,10 @@
 
   <PropertyGroup>
     <!--
-      Set to SystemTextJson or NewtonsoftJson to automatically add the JSON extension.
+      Set to "System.Text.Json" or "Newtonsoft.Json" to automatically add the JSON extension.
       Any other value, such as None, will not add JSON support to the generated SDK.
     -->
-    <JsonMode Condition=" '$(JsonMode)' == '' ">SystemTextJson</JsonMode>
+    <JsonMode Condition=" '$(JsonMode)' == '' ">System.Text.Json</JsonMode>
 
     <!-- By default embed source files with debug symbols -->
     <EmbedAllSources Condition=" '$(EmbedAllSources)' == '' ">true</EmbedAllSources>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -48,8 +48,8 @@
     Add the JSON tool of choice as an extension, if any.
   -->
   <ItemGroup>
-    <YardarmExtension Include="$(YardarmToolPath)Yardarm.NewtonsoftJson.dll" Condition=" '$(JsonMode)' == 'NewtonsoftJson' " />
-    <YardarmExtension Include="$(YardarmToolPath)Yardarm.SystemTextJson.dll" Condition=" '$(JsonMode)' == 'SystemTextJson' " />
+    <YardarmExtension Include="$(YardarmToolPath)Yardarm.NewtonsoftJson.dll" Condition=" '$(JsonMode)' == 'Newtonsoft.Json' " />
+    <YardarmExtension Include="$(YardarmToolPath)Yardarm.SystemTextJson.dll" Condition=" '$(JsonMode)' == 'System.Text.Json' " />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Motivation
----------
Make the values for the JsonMode property more consistent with what a
developer would expect.

Modifications
-------------
Use "System.Text.Json" instead of "SystemTextJson" and use
"Newtonsoft.Json" instead of "NewtonsoftJson" for the JsonMode values.