### PR TITLE
Allow assembly name to end in ".Yardarm"

### DIFF
--- a/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿#if FORTESTS
+using System.Runtime.CompilerServices;
 
-#if FORTESTS
 [assembly: InternalsVisibleTo("Yardarm.Client.UnitTests")]
 #endif

--- a/src/main/Yardarm.Client/Serialization/MultipartFieldDetails.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartFieldDetails.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace RootNamespace.Serialization
+﻿namespace RootNamespace.Serialization
 {
     /// <summary>
     /// Provides additional details about the value of a multipart encoded field.

--- a/src/main/Yardarm/Helpers/WellKnownTypes.Yardarm.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.Yardarm.cs
@@ -10,7 +10,9 @@ namespace Yardarm.Helpers
     {
         public static class Yardarm
         {
-            public static NameSyntax Name { get; } = IdentifierName("Yardarm");
+            public static NameSyntax Name { get; } = AliasQualifiedName(
+                IdentifierName(Token(SyntaxKind.GlobalKeyword)),
+                IdentifierName("Yardarm"));
 
             public static class Client
             {


### PR DESCRIPTION
Motivation
----------
We currently receive compilation errors if the target assembly name ends
in .Yardarm.

Modifications
-------------
Include a "global::" alias on references to any internal "Yardarm..."
types to avoid naming conflicts.

Fix a couple of low-level warning messages that were not displayed.