### PR TITLE
Add a base interface for all APIs

### DIFF
--- a/src/main/Yardarm.Client/Api/IApi.cs
+++ b/src/main/Yardarm.Client/Api/IApi.cs
@@ -1,0 +1,6 @@
+﻿namespace RootNamespace.Api
+{
+    public interface IApi
+    {
+    }
+}

--- a/src/main/Yardarm/Generation/Tag/TagTypeGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGeneratorFactory.cs
@@ -1,29 +1,22 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Yardarm.Generation.Operation;
-using Yardarm.Names;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Tag
 {
     public class TagTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiTag>
     {
-        private readonly GenerationContext _context;
-        private readonly IOperationMethodGenerator _operationMethodGenerator;
-        private readonly ISerializationNamespace _serializationNamespace;
-        private readonly IAuthenticationNamespace _authenticationNamespace;
+        private readonly IServiceProvider _serviceProvider;
 
-        public TagTypeGeneratorFactory(GenerationContext context, IOperationMethodGenerator operationMethodGenerator,
-            ISerializationNamespace serializationNamespace, IAuthenticationNamespace authenticationNamespace)
+        public TagTypeGeneratorFactory(IServiceProvider serviceProvider)
         {
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _operationMethodGenerator = operationMethodGenerator ??
-                                        throw new ArgumentNullException(nameof(operationMethodGenerator));
-            _serializationNamespace = serializationNamespace ?? throw new ArgumentNullException(nameof(serializationNamespace));
-            _authenticationNamespace = authenticationNamespace ?? throw new ArgumentNullException(nameof(authenticationNamespace));
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            _serviceProvider = serviceProvider;
         }
 
         public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiTag> element, ITypeGenerator? parent) =>
-            new TagTypeGenerator(element, _context, _serializationNamespace, _authenticationNamespace, _operationMethodGenerator);
+            ActivatorUtilities.CreateInstance<TagTypeGenerator>(_serviceProvider, element);
     }
 }

--- a/src/main/Yardarm/Names/DefaultNamespaceProvider.cs
+++ b/src/main/Yardarm/Names/DefaultNamespaceProvider.cs
@@ -11,26 +11,27 @@ namespace Yardarm.Names
         private readonly IResponsesNamespace _responsesNamespace;
         private readonly IRequestsNamespace _requestsNamespace;
         private readonly IAuthenticationNamespace _authenticationNamespace;
+        private readonly IApiNamespace _apiNamespace;
 
-        private readonly NameSyntax _apiNamespace;
         private readonly NameSyntax _headersNamespace;
         private readonly NameSyntax _modelsNamespace;
         private readonly NameSyntax _parametersNamespace;
 
         public DefaultNamespaceProvider(IRootNamespace rootNamespace, IResponsesNamespace responsesNamespace,
-            IAuthenticationNamespace authenticationNamespace, IRequestsNamespace requestsNamespace)
+            IAuthenticationNamespace authenticationNamespace, IRequestsNamespace requestsNamespace,
+            IApiNamespace apiNamespace)
         {
-            if (rootNamespace == null)
-            {
-                throw new ArgumentNullException(nameof(rootNamespace));
-            }
+            ArgumentNullException.ThrowIfNull(rootNamespace);
+            ArgumentNullException.ThrowIfNull(responsesNamespace);
+            ArgumentNullException.ThrowIfNull(authenticationNamespace);
+            ArgumentNullException.ThrowIfNull(requestsNamespace);
+            ArgumentNullException.ThrowIfNull(apiNamespace);
 
-            _responsesNamespace = responsesNamespace ?? throw new ArgumentNullException(nameof(responsesNamespace));
-            _authenticationNamespace = authenticationNamespace ??
-                                       throw new ArgumentNullException(nameof(authenticationNamespace));
-            _requestsNamespace = requestsNamespace ?? throw new ArgumentNullException(nameof(requestsNamespace));
+            _responsesNamespace = responsesNamespace;
+            _authenticationNamespace = authenticationNamespace;
+            _requestsNamespace = requestsNamespace;
+            _apiNamespace = apiNamespace;
 
-            _apiNamespace = SyntaxFactory.QualifiedName(rootNamespace.Name, SyntaxFactory.IdentifierName("Api"));
             _headersNamespace = SyntaxFactory.QualifiedName(_responsesNamespace.Name, SyntaxFactory.IdentifierName("Headers"));
             _modelsNamespace = SyntaxFactory.QualifiedName(rootNamespace.Name, SyntaxFactory.IdentifierName("Models"));
             _parametersNamespace = SyntaxFactory.QualifiedName(_requestsNamespace.Name, SyntaxFactory.IdentifierName("Parameters"));
@@ -77,7 +78,7 @@ namespace Yardarm.Names
             _authenticationNamespace.Name;
 
         protected virtual NameSyntax GetTagNamespace(ILocatedOpenApiElement<OpenApiTag> tag) =>
-            _apiNamespace;
+            _apiNamespace.Name;
 
         protected virtual NameSyntax GetUnknownResponseNamespace(ILocatedOpenApiElement<OpenApiUnknownResponse> responses) =>
             _responsesNamespace.Name;

--- a/src/main/Yardarm/Names/IApiNamespace.cs
+++ b/src/main/Yardarm/Names/IApiNamespace.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Yardarm.Names
+{
+    // ReSharper disable InconsistentNaming
+    public interface IApiNamespace : IKnownNamespace
+    {
+        NameSyntax IApi { get; }
+    }
+}

--- a/src/main/Yardarm/Names/Internal/ApiNamespace.cs
+++ b/src/main/Yardarm/Names/Internal/ApiNamespace.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Names.Internal
+{
+    // ReSharper disable InconsistentNaming
+    internal class ApiNamespace : IApiNamespace
+    {
+        public NameSyntax Name { get; }
+        public NameSyntax IApi { get; }
+
+        public ApiNamespace(IRootNamespace rootNamespace)
+        {
+            if (rootNamespace == null)
+            {
+                throw new ArgumentNullException(nameof(rootNamespace));
+            }
+
+            Name = QualifiedName(rootNamespace.Name, IdentifierName("Api"));
+
+            IApi = QualifiedName(
+                Name,
+                IdentifierName("IApi"));
+        }
+    }
+}

--- a/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ namespace Yardarm
             services.TryAddSingleton<INameConverterRegistry>(_ => NameConverterRegistry.CreateDefaultRegistry());
             services.TryAddSingleton<IHttpResponseCodeNameProvider, HttpResponseCodeNameProvider>();
             services.TryAddSingleton<IRootNamespace, RootNamespace>();
+            services.TryAddSingleton<IApiNamespace, ApiNamespace>();
             services.TryAddSingleton<IAuthenticationNamespace, AuthenticationNamespace>();
             services.TryAddSingleton<IRequestsNamespace, RequestsNamespace>();
             services.TryAddSingleton<IResponsesNamespace, ResponsesNamespace>();


### PR DESCRIPTION
Motivation
----------
Having a base interface for all APIs will all type constraints to
limit generic methods so they only apply to APIs from this client.
This will be useful for DI registration methods.

Modifications
-------------
Move the .Api namespace to a well known namespace and add an empty
`IApi` interface.

Add this as the base type for all interfaces generated from tags.