### PR TITLE
Use the assembly name to derive the DI extension method name

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ServiceCollectionExtensionsEnricher.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ServiceCollectionExtensionsEnricher.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Yardarm.Enrichment.Compilation;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.MicrosoftExtensionsHttp.Internal
+{
+    internal class ServiceCollectionExtensionsEnricher : IResourceFileEnricher
+    {
+        private readonly YardarmGenerationSettings _settings;
+
+        public ServiceCollectionExtensionsEnricher(YardarmGenerationSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            _settings = settings;
+        }
+
+        public bool ShouldEnrich(string resourceName) =>
+            resourceName == "Yardarm.MicrosoftExtensionsHttp.Client.ApiServiceCollectionExtensions.cs";
+
+        public CompilationUnitSyntax Enrich(CompilationUnitSyntax target, ResourceFileEnrichmentContext context)
+        {
+            SyntaxToken newName = Identifier($"Add{_settings.AssemblyName.Replace(".", "")}Apis");
+
+            var nodes = target
+                .DescendantNodes(node => node is MemberDeclarationSyntax or CompilationUnitSyntax)
+                .OfType<MethodDeclarationSyntax>()
+                .Where(p => p.Identifier.ValueText == "AddApis");
+
+            return target.ReplaceNodes(
+                nodes,
+                (_, node) => node.WithIdentifier(newName));
+        }
+    }
+}

--- a/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Yardarm.Enrichment.Compilation;
 using Yardarm.Generation;
 using Yardarm.MicrosoftExtensionsHttp.Internal;
 using Yardarm.Packaging;
@@ -11,7 +12,8 @@ namespace Yardarm.MicrosoftExtensionsHttp
         {
             services
                 .AddSingleton<IDependencyGenerator, DependencyInjectionDependencyGenerator>()
-                .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
+                .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
+                .AddResourceFileEnricher<ServiceCollectionExtensionsEnricher>();
 
             return services;
         }


### PR DESCRIPTION
Motivation
----------
Using the name `AddApis` for an extension method will cause a lot of
confusion for consumers adding multiple Yardarm generated SDKs.

Modifications
-------------
Derive the name `AddXXXApis` for the extension method from the generated
assembly name. For example, `Project.Client` becomes
`AddProjectClientApis`.