### PR TITLE
Split interface and class tag generators

### DIFF
--- a/src/main/Yardarm/Generation/Operation/OperationMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Operation/OperationMethodGenerator.cs
@@ -58,7 +58,7 @@ namespace Yardarm.Generation.Operation
                 .AddVariables(VariableDeclarator("responseMessage")
                     .WithInitializer(EqualsValueClause(
                         SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
-                                SyntaxHelpers.MemberAccess(TagTypeGenerator.HttpClientFieldName, "SendAsync"))
+                                SyntaxHelpers.MemberAccess(TagImplementationTypeGenerator.HttpClientFieldName, "SendAsync"))
                             .AddArgumentListArguments(
                                 Argument(IdentifierName(RequestMessageVariableName)),
                                 Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName))))))));
@@ -79,7 +79,7 @@ namespace Yardarm.Generation.Operation
         protected virtual StatementSyntax GenerateAuthenticatorVariable() =>
             MethodHelpers.LocalVariableDeclarationWithInitializer(AuthenticatorVariableName,
                 InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName(TagTypeGenerator.AuthenticatorsFieldName),
+                        IdentifierName(TagImplementationTypeGenerator.AuthenticatorsFieldName),
                         IdentifierName("SelectAuthenticator")))
                     .AddArgumentListArguments(
                         Argument(IdentifierName(RequestParameterName))));
@@ -89,7 +89,7 @@ namespace Yardarm.Generation.Operation
             MethodHelpers.LocalVariableDeclarationWithInitializer(RequestMessageVariableName,
                 BuildRequestMethodGenerator.InvokeBuildRequest(
                     IdentifierName(RequestParameterName),
-                    IdentifierName(TagTypeGenerator.TypeSerializerRegistryFieldName)));
+                    IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)));
 
         protected virtual ExpressionSyntax GenerateResponse(
             ILocatedOpenApiElement<OpenApiOperation> operation, ExpressionSyntax responseMessage) =>
@@ -106,13 +106,13 @@ namespace Yardarm.Generation.Operation
                                 Context.TypeGeneratorRegistry.Get(p).TypeInfo.Name)
                             .AddArgumentListArguments(
                                 Argument(IdentifierName("responseMessage")),
-                                Argument(IdentifierName(TagTypeGenerator.TypeSerializerRegistryFieldName)))))))
+                                Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))))))
                 .AddArms(SwitchExpressionArm(DiscardPattern(),
                     ObjectCreationExpression(
                         Context.TypeGeneratorRegistry.Get(operation.GetResponseSet().GetUnknownResponse()).TypeInfo.Name)
                         .AddArgumentListArguments(
                             Argument(IdentifierName("responseMessage")),
-                            Argument(IdentifierName(TagTypeGenerator.TypeSerializerRegistryFieldName)))));
+                            Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))));
 
         [Pure]
         private static ExpressionSyntax ParseStatusCode(string statusCodeStr) =>

--- a/src/main/Yardarm/Generation/Tag/TagImplementationCategory.cs
+++ b/src/main/Yardarm/Generation/Tag/TagImplementationCategory.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.OpenApi.Models;
+
+namespace Yardarm.Generation.Tag
+{
+    /// <summary>
+    /// Marks type generators for the concrete class implementation of a <see cref="OpenApiTag"/>.
+    /// </summary>
+    public class TagImplementationCategory
+    {
+        private TagImplementationCategory()
+        {
+        }
+    }
+}

--- a/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Tag
+{
+    public class TagImplementationTypeGenerator : TagTypeGeneratorBase
+    {
+        public const string HttpClientFieldName = "_httpClient";
+        public const string TypeSerializerRegistryFieldName = "_typeSerializerRegistry";
+        public const string AuthenticatorsFieldName = "_authenticators";
+
+        private readonly ISerializationNamespace _serializationNamespace;
+        private readonly IAuthenticationNamespace _authenticationNamespace;
+        private readonly IOperationMethodGenerator _operationMethodGenerator;
+
+        public TagImplementationTypeGenerator(ILocatedOpenApiElement<OpenApiTag> tagElement, GenerationContext context,
+            ISerializationNamespace serializationNamespace, IAuthenticationNamespace authenticationNamespace,
+            IOperationMethodGenerator operationMethodGenerator)
+            : base(tagElement, context)
+        {
+            ArgumentNullException.ThrowIfNull(serializationNamespace);
+            ArgumentNullException.ThrowIfNull(authenticationNamespace);
+            ArgumentNullException.ThrowIfNull(operationMethodGenerator);
+
+            _serializationNamespace = serializationNamespace;
+            _authenticationNamespace = authenticationNamespace;
+            _operationMethodGenerator = operationMethodGenerator;
+        }
+
+        protected override YardarmTypeInfo GetTypeInfo() =>
+            new YardarmTypeInfo(
+            QualifiedName(
+                Context.NamespaceProvider.GetNamespace(Element),
+                IdentifierName(GetClassName())),
+                    NameKind.Class);
+
+        public override IEnumerable<MemberDeclarationSyntax> Generate()
+        {
+            string className = GetClassName();
+
+            var baseType = Context.TypeGeneratorRegistry.Get<OpenApiTag>(Element);
+
+            var declaration = ClassDeclaration(className)
+                .AddElementAnnotation(Element, Context.ElementRegistry)
+                .AddBaseListTypes(SimpleBaseType(baseType.TypeInfo.Name))
+                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                .AddMembers(GenerateFields()
+                    .Concat<MemberDeclarationSyntax>(GenerateConstructors(className))
+                    .Concat(
+                        GetOperations()
+                            .SelectMany(GenerateOperationMethodHeader,
+                                (operation, method) => new {operation, method})
+                            .Select(p => p.method
+                                .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.AsyncKeyword))
+                                .WithBody(_operationMethodGenerator.Generate(p.operation))))
+                    .ToArray());
+
+            yield return declaration;
+        }
+
+        protected virtual IEnumerable<FieldDeclarationSyntax> GenerateFields()
+        {
+            yield return FieldDeclaration(VariableDeclaration(WellKnownTypes.System.Net.Http.HttpClient.Name)
+                    .AddVariables(
+                        VariableDeclarator(HttpClientFieldName)))
+                .AddModifiers(
+                    Token(SyntaxKind.PrivateKeyword),
+                    Token(SyntaxKind.ReadOnlyKeyword));
+
+            yield return FieldDeclaration(VariableDeclaration(_serializationNamespace.ITypeSerializerRegistry)
+                    .AddVariables(
+                        VariableDeclarator(TypeSerializerRegistryFieldName)))
+                .AddModifiers(
+                    Token(SyntaxKind.PrivateKeyword),
+                    Token(SyntaxKind.ReadOnlyKeyword));
+
+            yield return FieldDeclaration(VariableDeclaration(_authenticationNamespace.Authenticators)
+                    .AddVariables(
+                        VariableDeclarator(AuthenticatorsFieldName)))
+                .AddModifiers(
+                    Token(SyntaxKind.PrivateKeyword),
+                    Token(SyntaxKind.ReadOnlyKeyword));
+        }
+
+        protected virtual IEnumerable<ConstructorDeclarationSyntax> GenerateConstructors(string className)
+        {
+            yield return ConstructorDeclaration(className)
+                .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                .AddParameterListParameters(
+                    Parameter(Identifier("httpClient"))
+                        .WithType(WellKnownTypes.System.Net.Http.HttpClient.Name),
+                    Parameter(Identifier("typeSerializerRegistry"))
+                        .WithType(_serializationNamespace.ITypeSerializerRegistry),
+                    Parameter(Identifier("authenticators"))
+                        .WithType(_authenticationNamespace.Authenticators))
+                .WithBody(Block(
+                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(HttpClientFieldName),
+                        MethodHelpers.ArgumentOrThrowIfNull("httpClient"))),
+                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(TypeSerializerRegistryFieldName),
+                        MethodHelpers.ArgumentOrThrowIfNull("typeSerializerRegistry"))),
+                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                        IdentifierName(AuthenticatorsFieldName),
+                        MethodHelpers.ArgumentOrThrowIfNull("authenticators")))));
+        }
+
+        private string GetClassName() => Context.NameFormatterSelector.GetFormatter(NameKind.Class).Format(Tag.Name);
+    }
+}

--- a/src/main/Yardarm/Generation/Tag/TagImplementationTypeGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Tag/TagImplementationTypeGeneratorFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Yardarm.Spec;
+
+namespace Yardarm.Generation.Tag
+{
+    public class TagImplementationTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiTag, TagImplementationCategory>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public TagImplementationTypeGeneratorFactory(IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            _serviceProvider = serviceProvider;
+        }
+
+        public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiTag> element, ITypeGenerator? parent) =>
+            ActivatorUtilities.CreateInstance<TagImplementationTypeGenerator>(_serviceProvider, element);
+    }
+}

--- a/src/main/Yardarm/Generation/Tag/TagTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGenerator.cs
@@ -4,41 +4,23 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
-using Yardarm.Generation.Operation;
-using Yardarm.Helpers;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.Generation.Tag
 {
-    public class TagTypeGenerator : TypeGeneratorBase<OpenApiTag>
+    public class TagTypeGenerator : TagTypeGeneratorBase
     {
-        public const string HttpClientFieldName = "_httpClient";
-        public const string TypeSerializerRegistryFieldName = "_typeSerializerRegistry";
-        public const string AuthenticatorsFieldName = "_authenticators";
-
-        private readonly ISerializationNamespace _serializationNamespace;
-        private readonly IAuthenticationNamespace _authenticationNamespace;
         private readonly IApiNamespace _apiNamespace;
-        private readonly IOperationMethodGenerator _operationMethodGenerator;
-
-        protected OpenApiTag Tag => Element.Element;
 
         public TagTypeGenerator(ILocatedOpenApiElement<OpenApiTag> tagElement, GenerationContext context,
-            ISerializationNamespace serializationNamespace, IAuthenticationNamespace authenticationNamespace,
-            IApiNamespace apiNamespace, IOperationMethodGenerator operationMethodGenerator)
-            : base(tagElement, context, null)
+            IApiNamespace apiNamespace)
+            : base(tagElement, context)
         {
-            ArgumentNullException.ThrowIfNull(serializationNamespace);
-            ArgumentNullException.ThrowIfNull(authenticationNamespace);
             ArgumentNullException.ThrowIfNull(apiNamespace);
-            ArgumentNullException.ThrowIfNull(operationMethodGenerator);
 
-            _serializationNamespace = serializationNamespace;
-            _authenticationNamespace = authenticationNamespace;
             _apiNamespace = apiNamespace;
-            _operationMethodGenerator = operationMethodGenerator;
         }
 
         protected override YardarmTypeInfo GetTypeInfo() =>
@@ -51,7 +33,6 @@ namespace Yardarm.Generation.Tag
         public override IEnumerable<MemberDeclarationSyntax> Generate()
         {
             yield return GenerateInterface();
-            yield return GenerateClass();
         }
 
         protected virtual MemberDeclarationSyntax GenerateInterface()
@@ -73,102 +54,6 @@ namespace Yardarm.Generation.Tag
             return declaration;
         }
 
-        protected virtual MemberDeclarationSyntax GenerateClass()
-        {
-            string className = GetClassName();
-
-            var declaration = ClassDeclaration(className)
-                .AddElementAnnotation(Element, Context.ElementRegistry)
-                .AddBaseListTypes(SimpleBaseType(TypeInfo.Name))
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddMembers(GenerateFields()
-                    .Concat<MemberDeclarationSyntax>(GenerateConstructors(className))
-                    .Concat(
-                        GetOperations()
-                            .SelectMany(GenerateOperationMethodHeader,
-                                (operation, method) => new {operation, method})
-                            .Select(p => p.method
-                                .AddModifiers(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.AsyncKeyword))
-                                .WithBody(_operationMethodGenerator.Generate(p.operation))))
-                    .ToArray());
-
-            return declaration;
-        }
-
-        protected virtual IEnumerable<FieldDeclarationSyntax> GenerateFields()
-        {
-            yield return FieldDeclaration(VariableDeclaration(WellKnownTypes.System.Net.Http.HttpClient.Name)
-                    .AddVariables(
-                        VariableDeclarator(HttpClientFieldName)))
-                .AddModifiers(
-                    Token(SyntaxKind.PrivateKeyword),
-                    Token(SyntaxKind.ReadOnlyKeyword));
-
-            yield return FieldDeclaration(VariableDeclaration(_serializationNamespace.ITypeSerializerRegistry)
-                    .AddVariables(
-                        VariableDeclarator(TypeSerializerRegistryFieldName)))
-                .AddModifiers(
-                    Token(SyntaxKind.PrivateKeyword),
-                    Token(SyntaxKind.ReadOnlyKeyword));
-
-            yield return FieldDeclaration(VariableDeclaration(_authenticationNamespace.Authenticators)
-                    .AddVariables(
-                        VariableDeclarator(AuthenticatorsFieldName)))
-                .AddModifiers(
-                    Token(SyntaxKind.PrivateKeyword),
-                    Token(SyntaxKind.ReadOnlyKeyword));
-        }
-
-        protected virtual IEnumerable<ConstructorDeclarationSyntax> GenerateConstructors(string className)
-        {
-            yield return ConstructorDeclaration(className)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddParameterListParameters(
-                    Parameter(Identifier("httpClient"))
-                        .WithType(WellKnownTypes.System.Net.Http.HttpClient.Name),
-                    Parameter(Identifier("typeSerializerRegistry"))
-                        .WithType(_serializationNamespace.ITypeSerializerRegistry),
-                    Parameter(Identifier("authenticators"))
-                        .WithType(_authenticationNamespace.Authenticators))
-                .WithBody(Block(
-                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(HttpClientFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("httpClient"))),
-                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(TypeSerializerRegistryFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("typeSerializerRegistry"))),
-                    ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                        IdentifierName(AuthenticatorsFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("authenticators")))));
-        }
-
-        protected virtual IEnumerable<MethodDeclarationSyntax> GenerateOperationMethodHeader(
-            ILocatedOpenApiElement<OpenApiOperation> operation)
-        {
-            TypeSyntax requestType = Context.TypeGeneratorRegistry.Get(operation).TypeInfo.Name;
-            TypeSyntax responseType = WellKnownTypes.System.Threading.Tasks.TaskT.Name(
-                Context.TypeGeneratorRegistry.Get(operation.GetResponseSet()).TypeInfo.Name);
-
-            string methodName = Context.NameFormatterSelector.GetFormatter(NameKind.AsyncMethod)
-                .Format(operation.Element.OperationId);
-
-            var methodDeclaration = MethodDeclaration(responseType, methodName)
-                .AddElementAnnotation(operation, Context.ElementRegistry)
-                .AddParameterListParameters(
-                    Parameter(Identifier(OperationMethodGenerator.RequestParameterName))
-                        .WithType(requestType),
-                    MethodHelpers.DefaultedCancellationTokenParameter());
-
-            yield return methodDeclaration;
-        }
-
         private string GetInterfaceName() => Context.NameFormatterSelector.GetFormatter(NameKind.Interface).Format(Tag.Name);
-
-        private string GetClassName() => Context.NameFormatterSelector.GetFormatter(NameKind.Class).Format(Tag.Name);
-
-        private IEnumerable<ILocatedOpenApiElement<OpenApiOperation>> GetOperations() =>
-            Context.Document.Paths.ToLocatedElements()
-                .GetOperations()
-                .Where(p => p.Element.Tags.Any(q => q.Name == Tag.Name));
     }
 }

--- a/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Tag
+{
+    public abstract class TagTypeGeneratorBase : TypeGeneratorBase<OpenApiTag>
+    {
+        protected OpenApiTag Tag => Element.Element;
+
+        protected TagTypeGeneratorBase(ILocatedOpenApiElement<OpenApiTag> tagElement, GenerationContext context)
+            : base(tagElement, context, null)
+        {
+        }
+
+        protected virtual IEnumerable<MethodDeclarationSyntax> GenerateOperationMethodHeader(
+            ILocatedOpenApiElement<OpenApiOperation> operation)
+        {
+            TypeSyntax requestType = Context.TypeGeneratorRegistry.Get(operation).TypeInfo.Name;
+            TypeSyntax responseType = WellKnownTypes.System.Threading.Tasks.TaskT.Name(
+                Context.TypeGeneratorRegistry.Get(operation.GetResponseSet()).TypeInfo.Name);
+
+            string methodName = Context.NameFormatterSelector.GetFormatter(NameKind.AsyncMethod)
+                .Format(operation.Element.OperationId);
+
+            var methodDeclaration = MethodDeclaration(responseType, methodName)
+                .AddElementAnnotation(operation, Context.ElementRegistry)
+                .AddParameterListParameters(
+                    Parameter(Identifier(OperationMethodGenerator.RequestParameterName))
+                        .WithType(requestType),
+                    MethodHelpers.DefaultedCancellationTokenParameter());
+
+            yield return methodDeclaration;
+        }
+
+        protected IEnumerable<ILocatedOpenApiElement<OpenApiOperation>> GetOperations() =>
+            Context.Document.Paths.ToLocatedElements()
+                .GetOperations()
+                .Where(p => p.Element.Tags.Any(q => q.Name == Tag.Name));
+    }
+}

--- a/src/main/Yardarm/Spec/TagComparer.cs
+++ b/src/main/Yardarm/Spec/TagComparer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+
+namespace Yardarm.Spec
+{
+    public class TagComparer : IEqualityComparer<ILocatedOpenApiElement<OpenApiTag>>
+    {
+        public static TagComparer Instance { get; } = new();
+
+        private TagComparer()
+        {
+        }
+
+        public bool Equals(ILocatedOpenApiElement<OpenApiTag>? x, ILocatedOpenApiElement<OpenApiTag>? y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+
+            if (y == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            return x.Element.Name == y.Element.Name;
+        }
+
+        public int GetHashCode(ILocatedOpenApiElement<OpenApiTag> obj) => obj.Element.Name.GetHashCode();
+    }
+}

--- a/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ namespace Yardarm
             services.TryAddTypeGeneratorFactory<OpenApiOperation, RequestTypeGeneratorFactory>();
             services.TryAddTypeGeneratorFactory<OpenApiParameter, ParameterTypeGeneratorFactory>();
             services.TryAddTypeGeneratorFactory<OpenApiTag, TagTypeGeneratorFactory>();
+            services.TryAddTypeGeneratorFactory<OpenApiTag, TagImplementationCategory, TagImplementationTypeGeneratorFactory>();
             services.TryAddTypeGeneratorFactory<OpenApiUnknownResponse, UnknownResponseTypeGeneratorFactory>();
 
             services.AddSingleton<IRequestMemberGenerator, AddHeadersMethodGenerator>();


### PR DESCRIPTION
Motivation
----------
There is not currently a means for extensions to determine the name of
the API implementation class, only the API interface.

Modifications
-------------
- Split the generation of the implementation out to a new category of
  generator and new implementation.
- Move some common logic into a shared abstract class.
- Move the TagComparer out to a shared public instance.

Results
-------
Extensions may use the TypeGeneratorRegistry for OpenApiTag with the
TagImplementationCategory to get the TypeInfo, etc, for the
implementation class.

They may also use the TagComparer instance to get a distinct list of
tags.