### PR TITLE
Add extensions to register all APIs with DI

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/ApiClientMappingRegistry.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/ApiClientMappingRegistry.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace RootNamespace.Internal
+{
+    // Internal tracking for HTTP Client configuration. This is used to support AddAllOtherApis by
+    // tracking what APIs have been registered previously. The HTTP client factory only prevents registering
+    // the same interface twice if the implementation is different. We need to be stricter because we don't want
+    // to add the same default configurators more than once for the same API. It's bad for performance, and depending
+    // on registration order may unintentionally override API specific configuration that was applied elsewhere.
+    internal static class ApiClientMappingRegistry
+    {
+        private static readonly ConditionalWeakTable<IServiceCollection, HashSet<Type>> s_conditionalWeakTable = new();
+
+        // Attempts to reserve the interface type, returns true if it was successful or false if it was already reserved.
+        public static bool TryReserve(IServiceCollection serviceCollection, Type type)
+        {
+            var set = s_conditionalWeakTable.GetOrCreateValue(serviceCollection);
+
+            return set.Add(type);
+        }
+    }
+}

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
@@ -19,13 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-    We need access to these attributes to compile for testing, but we don't want them included
-    in the SDK because they would be included multiple times. Yardarm.Client should have the only
-    copy that's embedded.
-    -->
-    <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
-
     <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>

--- a/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ApiBuilderExtensionsEnricher.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ApiBuilderExtensionsEnricher.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment.Compilation;
+using Yardarm.Spec;
+using Yardarm.Generation;
+using Yardarm.Generation.Tag;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.MicrosoftExtensionsHttp.Internal
+{
+    /// <summary>
+    /// Adds statements to register all APIs to the "AddAllApisInternal" method.
+    /// </summary>
+    internal class ApiBuilderExtensionsEnricher : IResourceFileEnricher
+    {
+        private readonly OpenApiDocument _document;
+        private readonly ITypeGeneratorRegistry<OpenApiTag> _tagGeneratorRegistry;
+        private readonly ITypeGeneratorRegistry<OpenApiTag, TagImplementationCategory> _tagImplementationGeneratorRegistry;
+
+        public ApiBuilderExtensionsEnricher(OpenApiDocument document,
+            ITypeGeneratorRegistry<OpenApiTag> tagGeneratorRegistry,
+            ITypeGeneratorRegistry<OpenApiTag, TagImplementationCategory> tagImplementationGeneratorRegistry)
+        {
+            ArgumentNullException.ThrowIfNull(document);
+            ArgumentNullException.ThrowIfNull(tagGeneratorRegistry);
+            ArgumentNullException.ThrowIfNull(tagImplementationGeneratorRegistry);
+
+            _document = document;
+            _tagGeneratorRegistry = tagGeneratorRegistry;
+            _tagImplementationGeneratorRegistry = tagImplementationGeneratorRegistry;
+        }
+
+        public bool ShouldEnrich(string resourceName) =>
+            resourceName == "Yardarm.MicrosoftExtensionsHttp.Client.ApiBuilderExtensions.cs";
+
+        public CompilationUnitSyntax Enrich(CompilationUnitSyntax target, ResourceFileEnrichmentContext context)
+        {
+            var method = target
+                .DescendantNodes(node => node is MemberDeclarationSyntax or CompilationUnitSyntax)
+                .OfType<MethodDeclarationSyntax>()
+                .Single(p => p.Identifier.ValueText == "AddAllApisInternal");
+
+            var newMethod = method.WithBody(Block(GenerateApiStatements().ToArray()));
+
+            return target.ReplaceNode(method, newMethod);
+        }
+
+        private IEnumerable<StatementSyntax> GenerateApiStatements()
+        {
+            var tags = _document.Paths.ToLocatedElements()
+                .GetOperations()
+                .GetTags()
+                .Distinct(TagComparer.Instance);
+
+            foreach (var tag in tags)
+            {
+                TypeSyntax interfaceName = _tagGeneratorRegistry.Get(tag).TypeInfo.Name;
+                TypeSyntax implementationName = _tagImplementationGeneratorRegistry.Get(tag).TypeInfo.Name;
+
+                yield return ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("builder"),
+                            GenericName(
+                                Identifier("AddApi"),
+                                TypeArgumentList(SeparatedList(new[]
+                                {
+                                    interfaceName,
+                                    implementationName
+                                })))),
+                        ArgumentList(SeparatedList(new[]
+                        {
+                            Argument(IdentifierName("configureClient")),
+                            Argument(IdentifierName("skipIfAlreadyRegistered"))
+                        }))),
+                    Token(SyntaxKind.SemicolonToken))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed);
+            }
+        }
+    }
+}

--- a/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
@@ -13,7 +13,8 @@ namespace Yardarm.MicrosoftExtensionsHttp
             services
                 .AddSingleton<IDependencyGenerator, DependencyInjectionDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
-                .AddResourceFileEnricher<ServiceCollectionExtensionsEnricher>();
+                .AddResourceFileEnricher<ServiceCollectionExtensionsEnricher>()
+                .AddResourceFileEnricher<ApiBuilderExtensionsEnricher>();
 
             return services;
         }

--- a/src/main/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
@@ -30,7 +30,8 @@ namespace Yardarm.Enrichment.Compilation
             typeof(VersionAssemblyInfoEnricher),
             typeof(SyntaxTreeCompilationEnricher),
             typeof(DefaultTypeSerializersEnricher),
-            typeof(OpenApiCompilationEnricher)
+            typeof(OpenApiCompilationEnricher),
+            typeof(ResourceFileCompilationEnricher)
         };
 
         public FormatCompilationEnricher(YardarmGenerationSettings settings,
@@ -67,10 +68,11 @@ namespace Yardarm.Enrichment.Compilation
 
             workspace.TryApplyChanges(solution);
 
-            // Exclude resource files (already formatted) or files with no path (won't be embedded)
+            // Exclude files with no path (won't be embedded)
+            // We still format resource files, which are typically already formatted, because they may have
+            // been mutated by other enrichers.
             IEnumerable<SyntaxTree> treesToBeFormatted = target.SyntaxTrees
-                .Where(static p => p.FilePath != "" && p.HasCompilationUnitRoot &&
-                                   p.GetCompilationUnitRoot().GetResourceNameAnnotation() is null);
+                .Where(static p => p.FilePath != "" && p.HasCompilationUnitRoot);
 
             // Process formatting in parallel, this gives a slight perf boost
             object lockObj = new();


### PR DESCRIPTION
Motivation
----------
Especially with large SDKs it may be cumbersome to register all the API
types one by one.

Modifications
-------------
- Add `AddAllApis` and `AddAllOtherApis` extensions to `IApiBuilder`.
- Add `ApiClientMappingRegistry' to prevent double registration of the
  same API.
- Apply source formatting to resource file syntax trees.

Results
-------
- Consumers may call `.AddAllApis()` to add all APIs. This method fails
  if there are any manual registrations.
- Consumers may call `.AddAllOtherApis()` to register just the APIs that
  have not been manually registered.
- Both methods accept a configuration action which allows configuration
  of the IHttpClientBuilder. The first parameter to this action is the
  API interface type which allows variation of behaviors by API.
- Since we added InternalsVisibleTo for the client extensions, we can
  remove the ref to NullableAttributes from the project.