### PR TITLE
Resolve errors if first project open is in Visual Studio

### DIFF
--- a/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -138,8 +138,12 @@ namespace Yardarm.Packaging.Internal
         {
             var generators = new List<ISourceGenerator>();
 
-            LockFileTarget lockFileTarget = lockFile.Targets
-                .First(p => p.TargetFramework == targetFramework);
+            LockFileTarget? lockFileTarget = lockFile.Targets?
+                .FirstOrDefault(p => p.TargetFramework == targetFramework);
+            if (lockFileTarget is null)
+            {
+                return generators;
+            }
 
             foreach (var directDependency in _packageSpec.Dependencies
                          .Concat(_packageSpec.TargetFrameworks

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -112,18 +112,14 @@
       <Output TaskParameter="PackageDownload" ItemName="PackageDownload" />
     </YardarmCollectDependencies>
 
-    <!--
-      If using the new NuGet central package versioning system, remove the version specified by Yardarm
-      and use the centrally set version instead.
-    -->
-    <ItemGroup Condition=" '$(ManagePackageVersionsCentrally)' == 'true' ">
-      <_YardarmPackageReference Update="@(_YardarmPackageReference)">
-        <Version />
-      </_YardarmPackageReference>
-    </ItemGroup>
-
     <ItemGroup>
-      <PackageReference Include="@(_YardarmPackageReference)" />
+      <!--
+        If using the new NuGet central package versioning system, remove the version specified by Yardarm
+        and use the centrally set version instead.
+      -->
+      <PackageReference Condition=" '$(ManagePackageVersionsCentrally)' == 'true' " Include="@(_YardarmPackageReference)" RemoveMetadata="Version" />
+      <PackageReference Condition=" '$(ManagePackageVersionsCentrally)' != 'true' " Include="@(_YardarmPackageReference)" />
+
       <_YardarmPackageReference Remove="@(_YardarmPackageReference)" />
     </ItemGroup>
   </Target>
@@ -138,6 +134,7 @@
     </CoreCompileDependsOn>
   </PropertyGroup>
   <Target Name="CoreCompile"
+          Condition=" '$(SkipCompilerExecution)' != 'true' "
           Inputs="$(MSBuildAllProjects);@(OpenApiSpec);@(CustomAdditionalCompileInputs)"
           Outputs="@(DocFileItem);
                    @(IntermediateAssembly);


### PR DESCRIPTION
Motivation
----------
If a command-line restore is performed on an SDK project first, there
are no issues. But if Visual Studio opens the project first then the
restore fails and build errors ensue.

Modifications
-------------
- Fully remove the Version metadata from PackageReferences instead of
  blanking if central package version management is enabled.
- Make source generator collection more resilient to incomplete NuGet
  restoration.
- Don't run Yardarm generation if SkipCompilerExecution is true. For
  true C# projects this switch is used to extract the command line args
  for calling csc.exe rather than actually executing it, which in turn
  is used to drive language services in VS for editing C# files. For
  our use case, not running generation is the closest equivalent.