### PR TITLE
Allow root namespace configuration via the command line

### DIFF
--- a/src/main/Yardarm.CommandLine/CommonOptions.cs
+++ b/src/main/Yardarm.CommandLine/CommonOptions.cs
@@ -12,6 +12,9 @@ namespace Yardarm.CommandLine
         [Option('n', "name", Required = true, HelpText = "Generated assembly name")]
         public string AssemblyName { get; set; }
 
+        [Option("root-namespace", HelpText = "Root namespace of the generated assembly")]
+        public string RootNamespace { get; set; }
+
         [Option('f', "frameworks", HelpText = "List of target framework monikers. Must be a single item unless outputting a NuGet package.")]
         public IEnumerable<string> TargetFrameworks { get; set; }
 

--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -36,6 +36,7 @@ namespace Yardarm.CommandLine
 
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
+                RootNamespace = _options.RootNamespace ?? _options.AssemblyName,
                 // For deterministic builds, BasePath must start with "/_x", where x is a number. This is consistent
                 // with how deterministic source paths are generated on CI servers for regular C# projects when the
                 // DeterministicSourcePaths property is set to true.

--- a/src/main/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/main/Yardarm.CommandLine/RestoreCommand.cs
@@ -29,6 +29,7 @@ namespace Yardarm.CommandLine
 
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
+                RootNamespace = _options.RootNamespace ?? _options.AssemblyName,
                 IntermediateOutputPath = _options.IntermediateOutputPath,
             };
 

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -103,6 +103,7 @@
     <YardarmCollectDependencies
       ToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
+      RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"
       SpecFile="@(OpenApiSpec)"
       Extensions="@(YardarmExtension)"
@@ -147,6 +148,7 @@
     <YardarmGenerate
       ToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
+      RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"
       Version="$(Version)"
       SpecFile="@(OpenApiSpec)"

--- a/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
@@ -8,7 +8,11 @@ namespace Yardarm.Build.Tasks
     {
         protected abstract string Verb { get; }
 
+        [Required]
         public string? AssemblyName { get; set; }
+
+        [Required]
+        public string? RootNamespace { get; set; }
 
         [Required]
         public string? TargetFramework { get; set; }
@@ -26,6 +30,18 @@ namespace Yardarm.Build.Tasks
                 return false;
             }
 
+            if (string.IsNullOrWhiteSpace(AssemblyName))
+            {
+                Log.LogError("AssemblyName is required.");
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(RootNamespace))
+            {
+                Log.LogError("RootNamespace is required.");
+                return false;
+            }
+
             if (string.IsNullOrWhiteSpace(TargetFramework))
             {
                 Log.LogError("TargetFramework is required.");
@@ -38,7 +54,8 @@ namespace Yardarm.Build.Tasks
         protected override string GenerateCommandLineCommands()
         {
             var builder = new StringBuilder(Verb);
-            builder.AppendFormat(" -n {0}", string.IsNullOrEmpty(AssemblyName) ? "YardarmSdk" : AssemblyName);
+            builder.AppendFormat(" -n {0}", AssemblyName);
+            builder.AppendFormat(" --root-namespace {0}", RootNamespace);
             builder.AppendFormat(" -f {0}", TargetFramework);
 
             builder.AppendFormat(" -i {0}", SpecFile![0].ItemSpec);


### PR DESCRIPTION
Motivation
----------
Make it easy to support alternate root namespaces via the command line
and SDK projects.

Modifications
-------------
- Add an optional `--root-namespace` command-line option.
- Wire this option to the `RootNamespace` MSBuild property.