### PR TITLE
Normalize embedded source file paths

### DIFF
--- a/src/main/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
+++ b/src/main/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Yardarm.Enrichment;
 using Yardarm.Enrichment.Compilation;
+using Yardarm.Helpers;
 
 namespace Yardarm.Generation.Internal
 {
@@ -27,7 +28,7 @@ namespace Yardarm.Generation.Internal
                 SyntaxFactory.CompilationUnit()
                     .Enrich(_enrichers)
                     .NormalizeWhitespace(),
-                path: Path.Combine(_context.Settings.BasePath, "Properties", "AssemblyInfo.cs"),
+                path: PathHelpers.Combine(_context.Settings.BasePath, "Properties", "AssemblyInfo.cs"),
                 encoding: Encoding.UTF8);
         }
     }

--- a/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -63,7 +63,7 @@ namespace Yardarm.Generation
                 CSharpParseOptions.Default
                     .WithLanguageVersion(LanguageVersion.CSharp10)
                     .WithPreprocessorSymbols(preprocessorSymbols),
-                path: Path.Combine(
+                path: PathHelpers.Combine(
                     GenerationContext.Settings.BasePath,
                     "Resources",
                     PathHelpers.NormalizePath(resourceName)));

--- a/src/main/Yardarm/Helpers/PathHelpers.cs
+++ b/src/main/Yardarm/Helpers/PathHelpers.cs
@@ -41,15 +41,59 @@ namespace Yardarm.Helpers
             {
                 char ch = builder[i];
 
-                if (Path.DirectorySeparatorChar != '/' && ch == '/')
+                if (Path.DirectorySeparatorChar != '/' && ch == Path.DirectorySeparatorChar)
                 {
-                    builder[i] = Path.DirectorySeparatorChar;
+                    builder[i] = '/';
                 }
                 else if (s_invalidPathChars.Contains(ch))
                 {
                     builder[i] = '_';
                 }
             }
+        }
+
+        /// <summary>
+        /// Combine paths in an OS-agnostic manner, always using a "/" separator.
+        /// </summary>
+        public static string Combine(string path1, string path2)
+        {
+            ArgumentNullException.ThrowIfNull(path1);
+            ArgumentNullException.ThrowIfNull(path2);
+
+            if (path1 == "")
+            {
+                return path2;
+            }
+
+            if (path2 == "")
+            {
+                return "";
+            }
+
+            if (path1[^1] == '/' && path2[0] == '/')
+            {
+                return $"{path1}{path2[1..]}";
+            }
+
+            if (path1[^1] != '/' && path2[0] != '/')
+            {
+                return $"{path1}/{path2}";
+            }
+
+            return $"{path1}{path2}";
+        }
+
+        /// <summary>
+        /// Combine paths in an OS-agnostic manner, always using a "/" separator.
+        /// </summary>
+        public static string Combine(string path1, string path2, string path3)
+        {
+            ArgumentNullException.ThrowIfNull(path1);
+            ArgumentNullException.ThrowIfNull(path2);
+            ArgumentNullException.ThrowIfNull(path3);
+
+            string temp = Combine(path1, path2);
+            return Combine(temp, path3);
         }
     }
 }

--- a/src/main/Yardarm/Helpers/StringBuilderCache.cs
+++ b/src/main/Yardarm/Helpers/StringBuilderCache.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Text;
+
+namespace Yardarm.Helpers
+{
+    /// <summary>Provide a cached reusable instance of stringbuilder per thread.</summary>
+    internal static class StringBuilderCache
+    {
+        // The value 360 was chosen in discussion with performance experts as a compromise between using
+        // as little memory per thread as possible and still covering a large part of short-lived
+        // StringBuilder creations on the startup path of VS designers.
+        internal const int MaxBuilderSize = 360;
+        private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity
+
+        [ThreadStatic]
+        private static StringBuilder? t_cachedInstance;
+
+        /// <summary>Get a StringBuilder for the specified capacity.</summary>
+        /// <remarks>If a StringBuilder of an appropriate size is cached, it will be returned and the cache emptied.</remarks>
+        public static StringBuilder Acquire(int capacity = DefaultCapacity)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                StringBuilder? sb = t_cachedInstance;
+                if (sb != null)
+                {
+                    // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                    // when the requested size is larger than the current capacity
+                    if (capacity <= sb.Capacity)
+                    {
+                        t_cachedInstance = null;
+                        sb.Clear();
+                        return sb;
+                    }
+                }
+            }
+
+            return new StringBuilder(capacity);
+        }
+
+        /// <summary>Place the specified builder in the cache if it is not too big.</summary>
+        public static void Release(StringBuilder sb)
+        {
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                t_cachedInstance = sb;
+            }
+        }
+
+        /// <summary>ToString() the stringbuilder, Release it to the cache, and return the resulting string.</summary>
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            string result = sb.ToString();
+            Release(sb);
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
The current paths are convoluted and difficult to read in error
messages and stack traces. Also, since tag elements now generate two
files only one gets included in the PDB and linked to both the
interface and the class. Finally, the source paths are not deterministic
between Windows and Linux builds.

Modifications
-------------
- For element-based source files, use the namespace and type name to
  determine the file name. This should still guarantee uniqueness.
- For resource files and the assembly info file, use forward slashes
  instead of back slashes for OS consistency.