### PR TITLE
Allow configuration of authenticators in DI

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/ApiFactoryOptions.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/ApiFactoryOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.Extensions.Http;
+using RootNamespace.Authentication;
 
 namespace RootNamespace.Internal
 {
@@ -12,6 +13,8 @@ namespace RootNamespace.Internal
         public List<Action<HttpClient>> HttpClientActions { get; } = new();
 
         public List<Action<HttpMessageHandlerBuilder>> HttpMessageHandlerBuilderActions { get; } = new();
+
+        public List<Action<Authenticators>> AuthenticatorActions { get; } = new();
 
         public TimeSpan HandlerLifetime { get; set; } = s_defaultHandlerLifetime;
 


### PR DESCRIPTION
Motivation
----------
Having the default authenticators live in the DI container isn't very
helpful if there isn't also a way to configure them.

Modifications
-------------
Add `ConfigureAuthenticators` method to `IApiBuilder` with an additional
overload which receives the `IServiceProvider` to allow configuration to
be acquired from the DI container.

Add a similar overload to `ConfigureBaseAddress` which accepts an
`IServiceProvider` for dynamic configuration.