### PR TITLE
Improve handling of nullable schemas

### DIFF
--- a/src/main/Yardarm/Enrichment/Requests/RequiredParameterEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Requests/RequiredParameterEnricher.cs
@@ -11,28 +11,32 @@ namespace Yardarm.Enrichment.Requests
     {
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiParameter> context)
         {
-            return context.Element.Required
-                ? AddRequiredAttribute(syntax, context)
-                : syntax.MakeNullable();
-        }
-
-        private PropertyDeclarationSyntax AddRequiredAttribute<T>(PropertyDeclarationSyntax syntax,
-            OpenApiEnrichmentContext<T> context)
-            where T : IOpenApiElement
-        {
-            bool forInterface = syntax.Parent is InterfaceDeclarationSyntax;
-
-            if (!forInterface)
+            if (!context.Element.Required || context.Element.Schema.Nullable)
             {
+                // If the parameter is optional OR nullable then the property should be nullable
+                // This is because .NET does not have a good way to differentiate between missing and null
+                syntax = syntax.MakeNullable();
+            }
+            else
+            {
+                // The value needs to be initialized to avoid nullable ref type warnings
                 syntax = syntax.MakeNullableOrInitializeIfReferenceType(context.Compilation);
             }
 
-            syntax = syntax
-                .AddAttributeLists(AttributeList().AddAttributes(
-                    Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name))
-                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+            if (context.Element.Required)
+            {
+                // Explicitly annotate as required if the parameter is required
+                // This must be done after any potential call to MakeNullableOrInitializeIfReferenceType to avoid errors
+                syntax = AddRequiredAttribute(syntax);
+            }
 
             return syntax;
         }
+
+        private PropertyDeclarationSyntax AddRequiredAttribute(PropertyDeclarationSyntax syntax) =>
+            syntax.AddAttributeLists(
+                AttributeList(SingletonSeparatedList(
+                        Attribute(WellKnownTypes.System.ComponentModel.DataAnnotations.RequiredAttribute.Name)))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
     }
 }

--- a/src/main/Yardarm/Helpers/PropertyHelpers.cs
+++ b/src/main/Yardarm/Helpers/PropertyHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.Contracts;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -14,6 +15,7 @@ namespace Yardarm.Helpers
         /// </summary>
         /// <param name="property">The <see cref="PropertyDeclarationSyntax"/> to update.</param>
         /// <returns>The mutated property declaration, or the original if no mutation was required.</returns>
+        [Pure]
         public static PropertyDeclarationSyntax MakeNullable(this PropertyDeclarationSyntax property) =>
             property.Type is NullableTypeSyntax
                 ? property // Already nullable
@@ -27,6 +29,7 @@ namespace Yardarm.Helpers
         /// <param name="property">The <see cref="PropertyDeclarationSyntax"/> to update. Must be on a <see cref="SyntaxTree"/>.</param>
         /// <param name="compilation">Current <see cref="CSharpCompilation"/>.</param>
         /// <returns>The mutated property declaration, or the original if no mutation was required.</returns>
+        [Pure]
         public static PropertyDeclarationSyntax MakeNullableOrInitializeIfReferenceType(this PropertyDeclarationSyntax property,
             CSharpCompilation compilation) =>
             MakeNullableOrInitializeIfReferenceType(property, compilation.GetSemanticModel(property.SyntaxTree));
@@ -39,6 +42,7 @@ namespace Yardarm.Helpers
         /// <param name="property">The <see cref="PropertyDeclarationSyntax"/> to update. Must be on a <see cref="SyntaxTree"/>.</param>
         /// <param name="semanticModel"><see cref="SemanticModel"/> used to perform type analysis.</param>
         /// <returns>The mutated property declaration, or the original if no mutation was required.</returns>
+        [Pure]
         public static PropertyDeclarationSyntax MakeNullableOrInitializeIfReferenceType(this PropertyDeclarationSyntax property,
             SemanticModel semanticModel)
         {


### PR DESCRIPTION
Motivation
----------
Nullable schemas and how they interact with required are handled
correctly for properties on other schemas, but not for request
parameters or response headers.

Modifications
-------------
- Bring request parameter and response header handling of nullable in
  alignment with nested properties.
- Refactor RequiredPropertyEnricher to have the same overall layout
  as the new work.

Results
-------
Schema property handling is unchanged. Request parameters and response
headers now have the following paradigm:

- The type is nullable if the value is not required OR the schema is
  nullable
- The property receives the `Required` attribute only if the value is
  required

This results in the following logic:

- The `Required` attribute indicates that some value is required to be
  sent to or received from the server
- If `Required` and nullable, indicates that null may be sent or
  received
- If `Required` and not nullable, indicates that a non-null value must
  be sent or received
- If not `Required` and not nullable the acceptability of null values is
  unclear. However, this is typically interpreted to mean the value
  should not be sent if null.