### PR TITLE
Don't require a spec file for restore or collect dependencies

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,12 +6,12 @@ mkdir -p ./bin
 curl -sSL https://api.adv.centeredge.io/v1/swagger/api/swagger.json -o ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
-    restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/ -i ./bin/mashtub.json
+    restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
     generate --no-restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --embed --intermediate-dir ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
-    restore -n TestNJ -x src/main/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/  -i ./bin/mashtub.json
+    restore -n TestNJ -x src/main/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
     generate --no-restore -n TestNJ -x src/main/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --embed --intermediate-dir ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
 

--- a/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
+++ b/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
@@ -27,8 +27,6 @@ namespace Yardarm.CommandLine
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var document = await ReadDocumentAsync();
-
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
                 IntermediateOutputPath = _options.IntermediateOutputPath,
@@ -48,7 +46,7 @@ namespace Yardarm.CommandLine
                             .AddSerilog();
                     });
 
-                var generator = new YardarmGenerator(document, settings);
+                var generator = new YardarmProcessor(settings);
                 var packageSpec = await generator.GetPackageSpecAsync(cancellationToken);
 
                 foreach (var dependency in packageSpec.Dependencies.Where(p => !p.AutoReferenced))

--- a/src/main/Yardarm.CommandLine/CommonCommand.cs
+++ b/src/main/Yardarm.CommandLine/CommonCommand.cs
@@ -23,15 +23,6 @@ namespace Yardarm.CommandLine
             _options = options;
         }
 
-        protected async Task<OpenApiDocument> ReadDocumentAsync()
-        {
-            var reader = new OpenApiStreamReader();
-
-            await using var stream = File.OpenRead(_options.InputFile);
-
-            return reader.Read(stream, out _);
-        }
-
         protected void ApplyExtensions(YardarmGenerationSettings settings)
         {
             foreach (string extensionFile in _options.ExtensionFiles)

--- a/src/main/Yardarm.CommandLine/CommonOptions.cs
+++ b/src/main/Yardarm.CommandLine/CommonOptions.cs
@@ -6,9 +6,6 @@ namespace Yardarm.CommandLine
 {
     public class CommonOptions
     {
-        [Option('i', "input", Required = true, HelpText = "OpenAPI 3 files to process")]
-        public string InputFile { get; set; }
-
         [Option('n', "name", Required = true, HelpText = "Generated assembly name")]
         public string AssemblyName { get; set; }
 

--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
 using NuGet.Packaging.Core;
 using Serilog;
 using Serilog.Events;
@@ -118,6 +120,15 @@ namespace Yardarm.CommandLine
                     await stream.DisposeAsync();
                 }
             }
+        }
+
+        protected async Task<OpenApiDocument> ReadDocumentAsync()
+        {
+            var reader = new OpenApiStreamReader();
+
+            await using var stream = File.OpenRead(_options.InputFile);
+
+            return reader.Read(stream, out _);
         }
 
         private void ApplyVersion(YardarmGenerationSettings settings)

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -7,6 +7,9 @@ namespace Yardarm.CommandLine
     [Verb("generate", HelpText = "Generate an assembly")]
     public class GenerateOptions : CommonOptions
     {
+        [Option('i', "input", Required = true, HelpText = "OpenAPI 3 files to process")]
+        public string InputFile { get; set; }
+
         [Option('v', "version", Default = "1.0.0", HelpText = "Generated assembly version")]
         public string Version { get; set; }
 

--- a/src/main/Yardarm.CommandLine/Properties/launchSettings.json
+++ b/src/main/Yardarm.CommandLine/Properties/launchSettings.json
@@ -6,11 +6,11 @@
         },
         "Restore": {
             "commandName": "Project",
-            "commandLineArgs": "restore -n Test.Yardarm -x Yardarm.NewtonsoftJson.dll Yardarm.MicrosoftExtensionsHttp.dll -f net6.0 --intermediate-dir output/obj -i centeredge-cardsystemapi.yaml"
+            "commandLineArgs": "restore -n Test.Yardarm -x Yardarm.NewtonsoftJson.dll Yardarm.MicrosoftExtensionsHttp.dll -f net6.0 --intermediate-dir output/obj"
         },
         "CollectDependencies": {
             "commandName": "Project",
-            "commandLineArgs": "collect-dependencies -n Test -x Yardarm.NewtonsoftJson.dll Yardarm.MicrosoftExtensionsHttp.dll -f net6.0 --intermediate-dir output/obj -i centeredge-cardsystemapi.yaml"
+            "commandLineArgs": "collect-dependencies -n Test -x Yardarm.NewtonsoftJson.dll Yardarm.MicrosoftExtensionsHttp.dll -f net6.0 --intermediate-dir output/obj"
         }
     }
 }

--- a/src/main/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/main/Yardarm.CommandLine/RestoreCommand.cs
@@ -25,8 +25,6 @@ namespace Yardarm.CommandLine
             var stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            var document = await ReadDocumentAsync();
-
             var settings = new YardarmGenerationSettings(_options.AssemblyName)
             {
                 RootNamespace = _options.RootNamespace ?? _options.AssemblyName,
@@ -47,7 +45,7 @@ namespace Yardarm.CommandLine
                             .AddSerilog();
                     });
 
-                var generator = new YardarmGenerator(document, settings);
+                var generator = new YardarmProcessor(settings);
                 await generator.RestoreAsync(cancellationToken);
 
                 stopwatch.Stop();

--- a/src/main/Yardarm/GenerationContext.cs
+++ b/src/main/Yardarm/GenerationContext.cs
@@ -9,7 +9,7 @@ using Yardarm.Spec;
 
 namespace Yardarm
 {
-    public class GenerationContext
+    public class GenerationContext : YardarmContext
     {
         private readonly Lazy<OpenApiDocument> _openApiDocument;
         private readonly Lazy<IOpenApiElementRegistry> _elementRegistry;
@@ -17,27 +17,17 @@ namespace Yardarm
         private readonly Lazy<INameFormatterSelector> _nameFormatterSelector;
         private readonly Lazy<ITypeGeneratorRegistry> _typeGeneratorRegistry;
 
-        public YardarmGenerationSettings Settings { get; }
         public OpenApiDocument Document => _openApiDocument.Value;
         public IOpenApiElementRegistry ElementRegistry => _elementRegistry.Value;
-        public IServiceProvider GenerationServices { get; }
         public INamespaceProvider NamespaceProvider => _namespaceProvider.Value;
         public INameFormatterSelector NameFormatterSelector => _nameFormatterSelector.Value;
 
-        /// <summary>
-        /// Details about the NuGet restore operation, once it is completed.
-        /// </summary>
-        public NuGetRestoreInfo? NuGetRestoreInfo { get; set; }
+        public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
 
         public NuGetFramework CurrentTargetFramework { get; set; } = NuGetFramework.UnsupportedFramework;
 
-        public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
-
-        public GenerationContext(IServiceProvider serviceProvider)
+        public GenerationContext(IServiceProvider serviceProvider) : base(serviceProvider)
         {
-            GenerationServices = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-            Settings = serviceProvider.GetRequiredService<YardarmGenerationSettings>();
-
             _openApiDocument = new Lazy<OpenApiDocument>(serviceProvider.GetRequiredService<OpenApiDocument>);
             _elementRegistry = new Lazy<IOpenApiElementRegistry>(serviceProvider.GetRequiredService<IOpenApiElementRegistry>);
             _namespaceProvider = new Lazy<INamespaceProvider>(serviceProvider.GetRequiredService<INamespaceProvider>);

--- a/src/main/Yardarm/YardarmContext.cs
+++ b/src/main/Yardarm/YardarmContext.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using NuGet.Frameworks;
+using Yardarm.Generation;
+using Yardarm.Names;
+using Yardarm.Packaging;
+using Yardarm.Spec;
+
+namespace Yardarm
+{
+    public class YardarmContext
+    {
+        public YardarmGenerationSettings Settings { get; }
+        public IServiceProvider GenerationServices { get; }
+
+        /// <summary>
+        /// Details about the NuGet restore operation, once it is completed.
+        /// </summary>
+        public NuGetRestoreInfo? NuGetRestoreInfo { get; set; }
+
+        public YardarmContext(IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            GenerationServices = serviceProvider;
+            Settings = serviceProvider.GetRequiredService<YardarmGenerationSettings>();
+        }
+    }
+}

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -112,7 +112,7 @@ namespace Yardarm
             RootNamespace = assemblyName;
         }
 
-        public IServiceProvider BuildServiceProvider(OpenApiDocument document)
+        public IServiceProvider BuildServiceProvider(OpenApiDocument? document)
         {
             IServiceCollection services = new ServiceCollection()
                 .AddLogging(builder =>

--- a/src/main/Yardarm/YardarmProcessor.cs
+++ b/src/main/Yardarm/YardarmProcessor.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NuGet.ProjectModel;
+using Yardarm.Packaging;
+using Yardarm.Packaging.Internal;
+
+namespace Yardarm
+{
+    /// <summary>
+    /// Basic processor which performs actions without an OpenApiDocument.
+    /// </summary>
+    public class YardarmProcessor
+    {
+        protected YardarmGenerationSettings Settings { get; }
+        protected IServiceProvider ServiceProvider { get; }
+
+        public YardarmProcessor(YardarmGenerationSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+
+            Settings = settings;
+            ServiceProvider = settings.BuildServiceProvider(null);
+        }
+
+        private protected YardarmProcessor(YardarmGenerationSettings settings, IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            Settings = settings;
+            ServiceProvider = serviceProvider;
+        }
+
+        public Task<PackageSpec> GetPackageSpecAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ServiceProvider.GetRequiredService<PackageSpec>());
+        }
+
+        public async Task<NuGetRestoreInfo> RestoreAsync(CancellationToken cancellationToken = default)
+        {
+            var context = ServiceProvider.GetRequiredService<YardarmContext>();
+
+            await PerformRestoreAsync(context, false, cancellationToken);
+
+            return context.NuGetRestoreInfo!;
+        }
+
+        protected async Task PerformRestoreAsync(YardarmContext context, bool readLockFileOnly, CancellationToken cancellationToken = default)
+        {
+            // Perform the NuGet restore
+            var restoreProcessor = context.GenerationServices.GetRequiredService<NuGetRestoreProcessor>();
+            context.NuGetRestoreInfo = await restoreProcessor.ExecuteAsync(readLockFileOnly, cancellationToken).ConfigureAwait(false);
+
+            if (context.Settings.TargetFrameworkMonikers.Length == 0)
+            {
+                throw new InvalidOperationException("No target framework monikers provided.");
+            }
+        }
+    }
+}

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -82,6 +82,9 @@
   <!-- Extension point for dynamically generating/collecting OpenApiSpec items -->
   <Target Name="CollectOpenApiSpecs" />
 
+  <!-- Extension point for dynamically generating/collecting YardarmExtension items -->
+  <Target Name="CollectYardarmExtensions" />
+
   <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
   <Target Name="CompileDesignTime" />
 </Project>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -98,14 +98,13 @@
   <Target Name="YardarmCollectDependencies"
           Condition=" '$(TargetFramework)' != '' "
           BeforeTargets="CollectPackageReferences;CollectPackageDownloads"
-          DependsOnTargets="_VerifyOpenApiSpecs"
+          DependsOnTargets="CollectYardarmExtensions"
           Returns="@(PackageReference);@(PackageDownload)">
     <YardarmCollectDependencies
       ToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
       RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"
-      SpecFile="@(OpenApiSpec)"
       Extensions="@(YardarmExtension)"
       BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
     >
@@ -131,7 +130,8 @@
   <PropertyGroup>
     <CoreCompileDependsOn>
       $(CoreCompileDependsOn);
-      _VerifyOpenApiSpecs
+      _VerifyOpenApiSpecs;
+      CollectYardarmExtensions
     </CoreCompileDependsOn>
   </PropertyGroup>
   <Target Name="CoreCompile"

--- a/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 using Microsoft.Build.Framework;
 
 namespace Yardarm.Build.Tasks
@@ -19,17 +18,10 @@ namespace Yardarm.Build.Tasks
 
         public string? BaseIntermediateOutputPath { get; set; }
 
-        public ITaskItem[]? SpecFile { get; set; }
         public ITaskItem[]? Extensions { get; set; }
 
         protected override bool ValidateParameters()
         {
-            if (SpecFile is null || SpecFile.Length != 1)
-            {
-                Log.LogError("Must supply a single SpecFile.");
-                return false;
-            }
-
             if (string.IsNullOrWhiteSpace(AssemblyName))
             {
                 Log.LogError("AssemblyName is required.");
@@ -57,8 +49,6 @@ namespace Yardarm.Build.Tasks
             builder.AppendFormat(" -n {0}", AssemblyName);
             builder.AppendFormat(" --root-namespace {0}", RootNamespace);
             builder.AppendFormat(" -f {0}", TargetFramework);
-
-            builder.AppendFormat(" -i {0}", SpecFile![0].ItemSpec);
 
             if (!string.IsNullOrEmpty(BaseIntermediateOutputPath))
             {

--- a/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using System.Text;
 using Microsoft.Build.Framework;
 
 namespace Yardarm.Build.Tasks;
@@ -23,12 +21,19 @@ public class YardarmGenerate : YardarmCommonTask
     public string? DelaySign { get; set; }
     public string? PublicSign { get; set; }
 
+    public ITaskItem[]? SpecFile { get; set; }
     public ITaskItem[]? References { get; set; }
 
     protected override bool ValidateParameters()
     {
         if (!base.ValidateParameters())
         {
+            return false;
+        }
+
+        if (SpecFile is null || SpecFile.Length != 1)
+        {
+            Log.LogError("Must supply a single SpecFile.");
             return false;
         }
 
@@ -44,6 +49,8 @@ public class YardarmGenerate : YardarmCommonTask
     protected override void AppendAdditionalArguments(StringBuilder builder)
     {
         builder.AppendFormat(" --no-restore"); // Restore is performed by MSBuild
+
+        builder.AppendFormat(" -i {0}", SpecFile![0].ItemSpec);
 
         if (!string.IsNullOrEmpty(Version))
         {


### PR DESCRIPTION
Motivation
----------
The spec file isn't actually used for restore or collect dependencies
currently. Requiring it is causing complications in Yardarm SDK projects
where the spec is being dynamically collected. The restore step and the
compilation step often both run the collection process.

Modifications
-------------
- Remove the input file parameter from restore and collect-dependencies
  and from their related MSBuild tasks
- Split YardarmGenerator into YardarmProcessor and YardarmGenerator,
  where the latter is only for generation and requires a spec file
- Similarly split GenerationContext into YardarmContext and
  GenerationContext
- Remove the dependency on CollectOpenApiSpecs from the
  YardarmCollectDependencies target
- Add an extra customizable target CollectYardarmExtensions. This may be
  used to dynamically add extensions since CollectOpenApiSpecs is no
  longer useful for that purpose.