### PR TITLE
Handle date only JSON properties in System.Text.Json

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonDateConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonDateConverter.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RootNamespace.Serialization.Json
+{
+    /// <summary>
+    /// Handles reading and writing date-only JSON to and from <see cref="DateTime"/> properties.
+    /// </summary>
+    internal sealed class JsonDateConverter : JsonConverter<DateTime>
+    {
+        private const string DateOnlyFormat = "yyyy-MM-dd";
+        private const int FormatLength = 10;
+        private const int MaxEscapedFormatLength = FormatLength * 6;
+
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType != JsonTokenType.String)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot get the value of a token type '{reader.TokenType}' as a string.");
+            }
+
+            int valueLength = reader.HasValueSequence
+                ? checked((int)reader.ValueSequence.Length)
+                : reader.ValueSpan.Length;
+
+            if (!IsInRangeInclusive(valueLength, FormatLength, MaxEscapedFormatLength))
+            {
+                throw new FormatException("The JSON value is not in a supported date format.");
+            }
+
+            // This isn't as optimal as parsing directly from bytes, but given the possibility of escaping and how
+            // some of the System.Text.Json internals aren't available to us this is far simpler.
+            string str = reader.GetString()!;
+
+            if (!DateTime.TryParseExact(str, DateOnlyFormat, CultureInfo.InvariantCulture, DateTimeStyles.None,
+                    out var value))
+            {
+                throw new FormatException("The JSON value is not in a supported date format.");
+            }
+
+            return value;
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+#if NET6_0_OR_GREATER
+            Span<char> buffer = stackalloc char[FormatLength];
+
+            bool success = value.TryFormat(buffer, out int charsWritten, DateOnlyFormat, CultureInfo.InvariantCulture);
+            Debug.Assert(success, "Unable to write to date to buffer.");
+
+            writer.WriteStringValue(buffer.Slice(0, charsWritten));
+#else
+            writer.WriteStringValue(value.ToString(DateOnlyFormat));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsInRangeInclusive(int value, int lowerBound, int upperBound)
+            => (uint)(value - lowerBound) <= (uint)(upperBound - lowerBound);
+    }
+}

--- a/src/main/Yardarm.SystemTextJson.UnitTests/Client/JsonDateConverterTests.cs
+++ b/src/main/Yardarm.SystemTextJson.UnitTests/Client/JsonDateConverterTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using RootNamespace.Serialization.Json;
+using Xunit;
+
+namespace Yardarm.SystemTextJson.UnitTests.Client
+{
+    public class JsonDateConverterTests
+    {
+        private static readonly UTF8Encoding NoBom = new(false);
+
+        [Fact]
+        public void Write_DateTime_WritesOnlyDate()
+        {
+            // Arrange
+
+            var converter = new JsonDateConverter();
+
+            var stream = new MemoryStream(128);
+            var writer = new Utf8JsonWriter(stream);
+
+            // Act
+
+            converter.Write(writer, new DateTime(2022, 12, 31, 14, 02, 01), new JsonSerializerOptions());
+            writer.Flush();
+
+            // Assert
+
+            var str = Encoding.UTF8.GetString(stream.ToArray());
+            str.Should().Be("\"2022-12-31\"");
+        }
+
+        [Fact]
+        public void Read_DateTime_ReadsOnlyDate()
+        {
+            // Arrange
+
+            const string value = "\"2022-12-31\"";
+
+            var converter = new JsonDateConverter();
+
+            var reader = new Utf8JsonReader(NoBom.GetBytes(value));
+            reader.Read();
+
+            // Act
+
+            var result = converter.Read(ref reader, typeof(DateTime), new JsonSerializerOptions());
+
+            // Assert
+
+            result.Should().Be(new DateTime(2022, 12, 31));
+        }
+
+        [Fact]
+        public void Read_Null_InvalidOperationException()
+        {
+            // Arrange
+
+            const string value = "null";
+
+            var converter = new JsonDateConverter();
+
+
+            // Act/Assert
+
+            var action = () =>
+            {
+                var reader = new Utf8JsonReader(NoBom.GetBytes(value));
+                reader.Read();
+
+                return converter.Read(ref reader, typeof(DateTime), new JsonSerializerOptions());
+            };
+
+            action.Should().Throw<InvalidOperationException>();
+        }
+
+        [Theory]
+        [InlineData("\"2022-12-32\"")]
+        [InlineData("\"2022-12-31T12:00:00Z\"")]
+        public void Read_InvalidDate_FormatException(string value)
+        {
+            // Arrange
+
+            var converter = new JsonDateConverter();
+
+
+            // Act/Assert
+
+            var action = () =>
+            {
+                var reader = new Utf8JsonReader(NoBom.GetBytes(value));
+                reader.Read();
+
+                return converter.Read(ref reader, typeof(DateTime), new JsonSerializerOptions());
+            };
+
+            action.Should().Throw<FormatException>();
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
@@ -5,6 +5,7 @@ namespace Yardarm.SystemTextJson
     public interface IJsonSerializationNamespace
     {
         NameSyntax Name { get; }
+        NameSyntax JsonDateConverter { get; }
         NameSyntax JsonTypeSerializer { get; }
 
         TypeSyntax JsonStringEnumConverter(TypeSyntax valueType);

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
@@ -9,6 +9,7 @@ namespace Yardarm.SystemTextJson.Internal
     internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationNamespace
     {
         public NameSyntax Name { get; }
+        public NameSyntax JsonDateConverter { get; }
         public NameSyntax JsonTypeSerializer { get; }
         public NameSyntax JsonHelpers { get; }
 
@@ -22,6 +23,10 @@ namespace Yardarm.SystemTextJson.Internal
             Name = QualifiedName(
                 serializationNamespace.Name,
                 IdentifierName("Json"));
+
+            JsonDateConverter = QualifiedName(
+                Name,
+                IdentifierName("JsonDateConverter"));
 
             JsonTypeSerializer = QualifiedName(
                 Name,

--- a/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Spec;
+using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    public class JsonDateOnlyPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly IOpenApiElementRegistry _elementRegistry;
+        private readonly IJsonSerializationNamespace _serializationNamespace;
+
+        public JsonDateOnlyPropertyEnricher(IOpenApiElementRegistry elementRegistry, IJsonSerializationNamespace serializationNamespace)
+        {
+            ArgumentNullException.ThrowIfNull(elementRegistry);
+            ArgumentNullException.ThrowIfNull(serializationNamespace);
+
+            _elementRegistry = elementRegistry;
+            _serializationNamespace = serializationNamespace;
+        }
+
+        public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (context.Element.Type != "string" || context.Element.Format != "date")
+            {
+                // Only applies to date-only strings
+                return syntax;
+            }
+
+            if (syntax.Parent?.GetElementAnnotation<OpenApiSchema>(_elementRegistry) is null)
+            {
+                // We don't need to apply this to properties of request classes, only schemas
+                return syntax;
+            }
+
+            var model = context.Compilation.GetSemanticModel(context.SyntaxTree);
+            TypeInfo typeInfo = model.GetTypeInfo(syntax.Type);
+            if (!IsDateTime(typeInfo.Type as INamedTypeSymbol))
+            {
+                // Don't apply if some other process has changed the type to something other than System.DateTime
+                return syntax;
+            }
+
+            return AddJsonConverterAttribute(syntax);
+        }
+
+        private PropertyDeclarationSyntax AddJsonConverterAttribute(PropertyDeclarationSyntax syntax) =>
+            syntax
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                    Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName,
+                        AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
+                            SyntaxFactory.TypeOfExpression(_serializationNamespace.JsonDateConverter))))))))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed);
+
+        private static bool IsDateTime(INamedTypeSymbol? type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && type.ContainingNamespace.Name == "System" && type.Name == "Nullable")
+            {
+                if (type.TypeArguments.Length == 0)
+                {
+                    return false;
+                }
+
+                return IsDateTime(type.TypeArguments[0] as INamedTypeSymbol);
+            }
+
+            return !type.IsGenericType && type.ContainingNamespace.Name == "System" && type.Name == "DateTime";
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -22,6 +22,7 @@ namespace Yardarm.SystemTextJson
                 .AddOpenApiSyntaxNodeEnricher<JsonNodeEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, DiscriminatorConverterGenerator>()


### PR DESCRIPTION
Motivation
----------
Properties marked as "date" format should only serialize the date portion of the `DateTime` type.

Modifications
-------------
Add a custom converter for this scenario for System.Text.Json.

Results
-------
"date" format strings are now handled correctly when serializing and deserializing with System.Text.Json. Support for Newtonsoft.Json will come in a separate PR.

Relates to #147