### PR TITLE
Support SDK compiles in paths with spaces

### DIFF
--- a/src/sdk/Yardarm.Sdk/StringBuilderExtensions.cs
+++ b/src/sdk/Yardarm.Sdk/StringBuilderExtensions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Yardarm.Build.Tasks
+{
+    internal static class StringBuilderExtensions
+    {
+        private static readonly char[] CharsToEscape = {'\\', '"'};
+
+        /// <summary>
+        /// Appends wrapped in quotes, escaping any backslashes or double quotes.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="str"></param>
+        public static void AppendQuoted(this StringBuilder builder, string? str)
+        {
+            if (str is null)
+            {
+                builder.Append("\"\"");
+                return;
+            }
+
+            builder.EnsureCapacity(builder.Length + str.Length + 2);
+
+            builder.Append('"');
+
+            int searchStart = 0;
+            while (searchStart < str.Length)
+            {
+                int index = str.IndexOfAny(CharsToEscape, searchStart);
+                if (index >= searchStart)
+                {
+                    if (index > searchStart)
+                    {
+                        builder.Append(str, searchStart, index - searchStart);
+                    }
+
+                    builder.Append('\\');
+                    builder.Append(str[index]);
+
+                    searchStart = index + 1;
+                }
+                else
+                {
+                    builder.Append(str, searchStart, str.Length - searchStart);
+                    searchStart = str.Length;
+                }
+            }
+
+            builder.Append('"');
+        }
+    }
+}

--- a/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
@@ -52,7 +52,8 @@ namespace Yardarm.Build.Tasks
 
             if (!string.IsNullOrEmpty(BaseIntermediateOutputPath))
             {
-                builder.AppendFormat(" --intermediate-dir {0}", BaseIntermediateOutputPath);
+                builder.Append(" --intermediate-dir ");
+                builder.AppendQuoted(BaseIntermediateOutputPath);
             }
 
             if (Extensions is {Length: > 0})
@@ -61,7 +62,7 @@ namespace Yardarm.Build.Tasks
                 foreach (var extension in Extensions)
                 {
                     builder.Append(' ');
-                    builder.Append(extension.ItemSpec);
+                    builder.AppendQuoted(extension.ItemSpec);
                 }
             }
 

--- a/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmGenerate.cs
@@ -50,7 +50,8 @@ public class YardarmGenerate : YardarmCommonTask
     {
         builder.AppendFormat(" --no-restore"); // Restore is performed by MSBuild
 
-        builder.AppendFormat(" -i {0}", SpecFile![0].ItemSpec);
+        builder.Append(" -i ");
+        builder.AppendQuoted(SpecFile![0].ItemSpec);
 
         if (!string.IsNullOrEmpty(Version))
         {
@@ -59,29 +60,36 @@ public class YardarmGenerate : YardarmCommonTask
 
         if (EmbedAllSources)
         {
-            builder.AppendFormat(" --embed");
+            builder.Append(" --embed");
         }
 
-        builder.AppendFormat(" -o {0}", OutputAssembly);
+        builder.Append(" -o ");
+        builder.AppendQuoted(OutputAssembly);
+
         if (!string.IsNullOrEmpty(OutputRefAssembly))
         {
-            builder.AppendFormat(" --ref {0}", OutputRefAssembly);
+            builder.Append(" --ref ");
+            builder.AppendQuoted(OutputRefAssembly);
         }
         if (!string.IsNullOrEmpty(OutputDebugSymbols))
         {
-            builder.AppendFormat(" --pdb {0}", OutputDebugSymbols);
+            builder.Append(" --pdb ");
+            builder.AppendQuoted(OutputDebugSymbols);
         }
         if (!string.IsNullOrEmpty(OutputXmlDocumentation))
         {
-            builder.AppendFormat(" --xml {0}", OutputXmlDocumentation);
+            builder.Append(" --xml ");
+            builder.AppendQuoted(OutputXmlDocumentation);
         }
         if (!string.IsNullOrEmpty(KeyFile))
         {
-            builder.AppendFormat(" --keyfile {0}", KeyFile);
+            builder.Append(" --keyfile ");
+            builder.AppendQuoted(KeyFile);
         }
         if (!string.IsNullOrEmpty(KeyContainerName))
         {
-            builder.AppendFormat(" --keycontainername {0}", KeyContainerName);
+            builder.Append(" --keycontainername ");
+            builder.AppendQuoted(KeyContainerName);
         }
         if (DelaySign == "true")
         {
@@ -104,7 +112,8 @@ public class YardarmGenerate : YardarmCommonTask
                     referencePath = reference.ItemSpec;
                 }
 
-                builder.AppendFormat(" \"{0}\"", referencePath);
+                builder.Append(' ');
+                builder.AppendQuoted(referencePath);
             }
         }
     }


### PR DESCRIPTION
Motivation
----------
SDK projects which are nested within paths that contain spaces currently fail to execute because parameters are not wrapped in quotes.

Modifications
-------------
Wrap all path-like command-line parameters in quotes. Escape backslashes and quotes within these parameters.

Fixes #150