### PR TITLE
Use strong typing for header serialization

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/HeaderSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/HeaderSerializerTests.cs
@@ -7,115 +7,103 @@ namespace Yardarm.Client.UnitTests.Serialization
 {
     public class HeaderSerializerTests
     {
-        #region Serialize
+        #region SerializePrimitive
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_String_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_String_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize("test", explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive("test");
 
             // Assert
 
             result.Should().Be("test");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_Integer_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_Integer_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(105, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(105);
 
             // Assert
 
             result.Should().Be("105");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_Long_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_Long_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(105L, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(105L);
 
             // Assert
 
             result.Should().Be("105");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_Float_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_Float_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(1.05f, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(1.05f);
 
             // Assert
 
             result.Should().Be("1.05");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_Double_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_Double_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(1.05, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(1.05);
 
             // Assert
 
             result.Should().Be("1.05");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_True_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_True_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(true, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(true);
 
             // Assert
 
             result.Should().Be("true");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_False_ReturnsString(bool explode)
+        [Fact]
+        public void SerializePrimitive_False_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(false, explode);
+            string result = HeaderSerializer.Instance.SerializePrimitive(false);
 
             // Assert
 
             result.Should().Be("false");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Serialize_List_ReturnsCommaDelimitedString(bool explode)
+        #endregion
+
+        #region SerializeList
+
+        [Fact]
+        public void SerializeList_List_ReturnsCommaDelimitedString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Serialize(
-                new List<string> { "abc", "def", "ghi" }, explode);
+            string result = HeaderSerializer.Instance.SerializeList(
+                new List<string> { "abc", "def", "ghi" });
 
             // Assert
 
@@ -124,152 +112,136 @@ namespace Yardarm.Client.UnitTests.Serialization
 
         #endregion
 
-        #region Serialize
+        #region DeserializePrimitive
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_String_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_String_ReturnsString()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Deserialize<string>(
-                new [] {"test"}, explode);
+            string result = HeaderSerializer.Instance.DeserializePrimitive<string>(
+                new [] {"test"});
 
             // Assert
 
             result.Should().Be("test");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_MultipleStrings_ReturnsJoined(bool explode)
+        [Fact]
+        public void DeserializePrimitive_MultipleStrings_ReturnsJoined()
         {
             // Act
 
-            string result = HeaderSerializer.Instance.Deserialize<string>(
-                new [] {"test", "value"}, explode);
+            string result = HeaderSerializer.Instance.DeserializePrimitive<string>(
+                new [] {"test", "value"});
 
             // Assert
 
             result.Should().Be("test,value");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_Integer_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_Integer_ReturnsString()
         {
             // Act
 
-            int result = HeaderSerializer.Instance.Deserialize<int>(
-                new [] {"105"}, explode);
+            int result = HeaderSerializer.Instance.DeserializePrimitive<int>(
+                new [] {"105"});
 
             // Assert
 
             result.Should().Be(105);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_Long_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_Long_ReturnsString()
         {
             // Act
 
-            long result = HeaderSerializer.Instance.Deserialize<long>(
-                new [] {"105"}, explode);
+            long result = HeaderSerializer.Instance.DeserializePrimitive<long>(
+                new [] {"105"});
 
             // Assert
 
             result.Should().Be(105L);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_Float_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_Float_ReturnsString()
         {
             // Act
 
-            float result = HeaderSerializer.Instance.Deserialize<float>(
-                new [] {"1.05"}, explode);
+            float result = HeaderSerializer.Instance.DeserializePrimitive<float>(
+                new [] {"1.05"});
 
             // Assert
 
             result.Should().Be(1.05f);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_Double_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_Double_ReturnsString()
         {
             // Act
 
-            double result = HeaderSerializer.Instance.Deserialize<double>(
-                new [] {"1.05"}, explode);
+            double result = HeaderSerializer.Instance.DeserializePrimitive<double>(
+                new [] {"1.05"});
 
             // Assert
 
             result.Should().Be(1.05);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_True_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_True_ReturnsString()
         {
             // Act
 
-            bool result = HeaderSerializer.Instance.Deserialize<bool>(
-                new [] {"true"}, explode);
+            bool result = HeaderSerializer.Instance.DeserializePrimitive<bool>(
+                new [] {"true"});
 
             // Assert
 
             result.Should().Be(true);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_False_ReturnsString(bool explode)
+        [Fact]
+        public void DeserializePrimitive_False_ReturnsString()
         {
             // Act
 
-            bool result = HeaderSerializer.Instance.Deserialize<bool>(
-                new[] {"false"}, explode);
+            bool result = HeaderSerializer.Instance.DeserializePrimitive<bool>(
+                new[] {"false"});
 
             // Assert
 
             result.Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_ListOfStrings_ReturnsCommaDelimitedString(bool explode)
+        #endregion
+
+        #region DeserializeList
+
+        [Fact]
+        public void DeserializeList_ListOfStrings_ReturnsStrings()
         {
             // Act
 
-            List<string> result = HeaderSerializer.Instance.Deserialize<List<string>>(
-                new[] { "abc", "def", "ghi" }, explode);
+            List<string> result = HeaderSerializer.Instance.DeserializeList<string>(
+                new[] { "abc", "def", "ghi" });
 
             // Assert
 
             result.Should().BeEquivalentTo("abc", "def", "ghi");
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Deserialize_ListOfIntegers_ReturnsCommaDelimitedString(bool explode)
+        [Fact]
+        public void DeserializeList_ListOfIntegers_ReturnsIntegers()
         {
             // Act
 
-            List<int> result = HeaderSerializer.Instance.Deserialize<List<int>>(
-                new[] { "1", "3", "5" }, explode);
+            List<int> result = HeaderSerializer.Instance.DeserializeList<int>(
+                new[] { "1", "3", "5" });
 
             // Assert
 

--- a/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
@@ -46,7 +47,11 @@ namespace RootNamespace.Serialization
         public T DeserializePrimitive<T>(IEnumerable<string> values)
         {
             // Rejoin the values from the header into a simple string
+#if NET6_0_OR_GREATER
             string value = string.Join(',', values);
+#else
+            string value = string.Join(",", values);
+#endif
 
             if (typeof(T) == typeof(string))
             {

--- a/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -1,19 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Generic;
+using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
 {
     public class HeaderSerializer
     {
-        public static HeaderSerializer Instance { get; } = new HeaderSerializer();
+        public static HeaderSerializer Instance { get; } = new(LiteralSerializer.Instance);
 
-        public string Serialize<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(T value, bool explode)
+        private readonly LiteralSerializer _literalSerializer;
+
+        public HeaderSerializer(LiteralSerializer literalSerializer)
+        {
+            ThrowHelper.ThrowIfNull(literalSerializer, nameof(literalSerializer));
+
+            _literalSerializer = literalSerializer;
+        }
+
+        public string SerializePrimitive<T>(T value)
         {
             if (value == null)
             {
@@ -26,34 +30,39 @@ namespace RootNamespace.Serialization
                 return str;
             }
 
-            if (SerializationHelpers.IsEnumerable(typeof(T), out Type? itemType))
-            {
-                return LiteralSerializer.Instance.JoinList(",", value, itemType);
-            }
-
-            return LiteralSerializer.Instance.Serialize(value);
+            return _literalSerializer.Serialize(value);
         }
 
-        public T Deserialize<T>(IEnumerable<string> values, bool explode)
+        public string SerializeList<T>(IEnumerable<T>? list)
         {
+            if (list == null)
+            {
+                return "";
+            }
+
+            return _literalSerializer.JoinList(",", list);
+        }
+
+        public T DeserializePrimitive<T>(IEnumerable<string> values)
+        {
+            // Rejoin the values from the header into a simple string
+            string value = string.Join(',', values);
+
             if (typeof(T) == typeof(string))
             {
                 // Short-circuit for strings
-                return (T)(object)string.Join(",", values);;
-            }
-
-            if (values == null)
-            {
-                throw new ArgumentNullException(nameof(values));
-            }
-
-            if (SerializationHelpers.IsList(typeof(T), out Type? itemType))
-            {
-                return (T) LiteralSerializer.Instance.DeserializeList(values, itemType);
+                return (T)(object)value;
             }
 
             // We're not dealing with a list, so join the values back together
-            return LiteralSerializer.Instance.Deserialize<T>(string.Join(",", values));
+            return _literalSerializer.Deserialize<T>(value);
+        }
+
+        public List<T> DeserializeList<T>(IEnumerable<string> values)
+        {
+            ThrowHelper.ThrowIfNull(values, nameof(values));
+
+            return _literalSerializer.DeserializeList<T>(values);
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -15,9 +15,6 @@ namespace RootNamespace.Serialization
         private static readonly MethodInfo s_joinListMethod =
             ((Func<string, IEnumerable<string>, string>)Instance.JoinList<string>).GetMethodInfo().GetGenericMethodDefinition();
 
-        private static readonly MethodInfo s_deserializeListMethod =
-            ((Func<IEnumerable<string>, List<string>>)Instance.DeserializeList<string>).GetMethodInfo().GetGenericMethodDefinition();
-
         public string Serialize<T>(T value) =>
             value != null
                 ? value switch {
@@ -39,20 +36,11 @@ namespace RootNamespace.Serialization
             return (string)joinList.Invoke(this, new object[] {separator, list})!;
         }
 
-        public object DeserializeList(IEnumerable<string> values, Type itemType)
-        {
-            MethodInfo deserializeList = s_deserializeListMethod.MakeGenericMethod(itemType);
-
-            return deserializeList.Invoke(this, new object[] {values})!;
-        }
-
-        // ReSharper disable once UnusedMember.Local
-        private string JoinList<T>(string separator, IEnumerable<T> list) =>
+        public string JoinList<T>(string separator, IEnumerable<T> list) =>
             string.Join(separator, list
                 .Select(Serialize));
 
-        // ReSharper disable once UnusedMember.Local
-        private List<T> DeserializeList<T>(IEnumerable<string> values) =>
+        public List<T> DeserializeList<T>(IEnumerable<string> values) =>
             new List<T>(values.Select(Deserialize<T>));
     }
 }

--- a/src/main/Yardarm.Client/Serialization/SerializationHelpers.cs
+++ b/src/main/Yardarm.Client/Serialization/SerializationHelpers.cs
@@ -27,18 +27,5 @@ namespace RootNamespace.Serialization
             itemType = interfaceType.GetGenericArguments()[0];
             return true;
         }
-
-        public static bool IsList(Type type,
-            [NotNullWhen(true)] out Type? itemType)
-        {
-            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
-            {
-                itemType = type.GetGenericArguments()[0];
-                return true;
-            }
-
-            itemType = null;
-            return false;
-        }
     }
 }


### PR DESCRIPTION
Motivation
----------
Eliminate the use of reflection when serializing and deserializing headers.

Modifications
-------------
Split header serialization into Primitive and List methods and call the correct method based on the schema type rather than determining at runtime using reflection.

Results
-------
Compatibility is the same, but performance and trimming should be better. Still doesn't support object serialization at this time.