### PR TITLE
Handle date only JSON properties in Newtonsoft.Json

### DIFF
--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/OpenApiDateConverter.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/OpenApiDateConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Newtonsoft.Json.Converters;
+
+namespace RootNamespace.Serialization.Json
+{
+    /// <summary>
+    /// Handles reading and writing date-only JSON to and from <see cref="DateTime"/> properties.
+    /// </summary>
+    internal class OpenApiDateConverter : IsoDateTimeConverter
+    {
+        public OpenApiDateConverter()
+        {
+            DateTimeFormat = "yyyy-MM-dd";
+        }
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
@@ -9,6 +9,7 @@ namespace Yardarm.NewtonsoftJson
         NameSyntax DynamicAdditionalPropertiesDictionary { get; }
         NameSyntax JsonTypeSerializer { get; }
         NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
+        public NameSyntax OpenApiDateConverter { get; }
 
         TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType);
     }

--- a/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
@@ -12,6 +12,7 @@ namespace Yardarm.NewtonsoftJson.Internal
         public NameSyntax DynamicAdditionalPropertiesDictionary { get; }
         public NameSyntax JsonTypeSerializer { get; }
         public NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
+        public NameSyntax OpenApiDateConverter { get; }
 
         public JsonSerializationNamespace(ISerializationNamespace serializationNamespace)
         {
@@ -39,6 +40,10 @@ namespace Yardarm.NewtonsoftJson.Internal
             NullableDynamicAdditionalPropertiesDictionary = QualifiedName(
                 Name,
                 IdentifierName("NullableDynamicAdditionalPropertiesDictionary"));
+
+            OpenApiDateConverter = QualifiedName(
+                Name,
+                IdentifierName("OpenApiDateConverter"));
         }
 
         public TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType) =>

--- a/src/main/Yardarm.NewtonsoftJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonDateOnlyPropertyEnricher.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Spec;
+using Yardarm.NewtonsoftJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.NewtonsoftJson
+{
+    public class JsonDateOnlyPropertyEnricher : IOpenApiSyntaxNodeEnricher<PropertyDeclarationSyntax, OpenApiSchema>
+    {
+        private readonly IOpenApiElementRegistry _elementRegistry;
+        private readonly IJsonSerializationNamespace _serializationNamespace;
+
+        public JsonDateOnlyPropertyEnricher(IOpenApiElementRegistry elementRegistry, IJsonSerializationNamespace serializationNamespace)
+        {
+            ArgumentNullException.ThrowIfNull(elementRegistry);
+            ArgumentNullException.ThrowIfNull(serializationNamespace);
+
+            _elementRegistry = elementRegistry;
+            _serializationNamespace = serializationNamespace;
+        }
+
+        public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            if (context.Element.Type != "string" || context.Element.Format != "date")
+            {
+                // Only applies to date-only strings
+                return syntax;
+            }
+
+            if (syntax.Parent?.GetElementAnnotation<OpenApiSchema>(_elementRegistry) is null)
+            {
+                // We don't need to apply this to properties of request classes, only schemas
+                return syntax;
+            }
+
+            var model = context.Compilation.GetSemanticModel(context.SyntaxTree);
+            TypeInfo typeInfo = model.GetTypeInfo(syntax.Type);
+            if (!IsDateTime(typeInfo.Type as INamedTypeSymbol))
+            {
+                // Don't apply if some other process has changed the type to something other than System.DateTime
+                return syntax;
+            }
+
+            return AddJsonConverterAttribute(syntax);
+        }
+
+        private PropertyDeclarationSyntax AddJsonConverterAttribute(PropertyDeclarationSyntax syntax) =>
+            syntax
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                    Attribute(NewtonsoftJsonTypes.JsonConverterAttributeName,
+                        AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
+                            SyntaxFactory.TypeOfExpression(_serializationNamespace.OpenApiDateConverter))))))))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed);
+
+        private static bool IsDateTime(INamedTypeSymbol? type)
+        {
+            if (type is null)
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && type.ContainingNamespace.Name == "System" && type.Name == "Nullable")
+            {
+                if (type.TypeArguments.Length == 0)
+                {
+                    return false;
+                }
+
+                return IsDateTime(type.TypeArguments[0] as INamedTypeSymbol);
+            }
+
+            return !type.IsGenericType && type.ContainingNamespace.Name == "System" && type.Name == "DateTime";
+        }
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -19,6 +19,7 @@ namespace Yardarm.NewtonsoftJson
                 .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
 


### PR DESCRIPTION
Motivation
----------
Properties marked as "date" format should only serialize the date portion of the `DateTime` type.

Modifications
-------------
Add a custom converter for this scenario for Newtonsoft.Json.

Results
-------
"date" format strings are now handled correctly when serializing and deserializing with Newtonsoft.Json.

Relates to #147