### PR TITLE
Handle dates and date-times correctly in headers and URLs

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -1,0 +1,300 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using RootNamespace.Serialization;
+using Xunit;
+
+namespace Yardarm.Client.UnitTests.Serialization
+{
+    public class LiteralSerializerTests
+    {
+        #region Serialize
+
+        [Fact]
+        public void Serialize_String_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize("test");
+
+            // Assert
+
+            result.Should().Be("test");
+        }
+
+        [Fact]
+        public void Serialize_Integer_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(105);
+
+            // Assert
+
+            result.Should().Be("105");
+        }
+
+        [Fact]
+        public void Serialize_Long_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(105L);
+
+            // Assert
+
+            result.Should().Be("105");
+        }
+
+        [Fact]
+        public void Serialize_Float_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(1.05f);
+
+            // Assert
+
+            result.Should().Be("1.05");
+        }
+
+        [Fact]
+        public void Serialize_Double_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(1.05);
+
+            // Assert
+
+            result.Should().Be("1.05");
+        }
+
+        [Fact]
+        public void Serialize_True_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(true);
+
+            // Assert
+
+            result.Should().Be("true");
+        }
+
+        [Fact]
+        public void Serialize_False_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(false);
+
+            // Assert
+
+            result.Should().Be("false");
+        }
+
+        [Fact]
+        public void Serialize_DateTime_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5));
+
+            // Assert
+
+            result.Should().Be("2020-01-02T03:04:05.0000000");
+        }
+
+        [Fact]
+        public void Serialize_Date_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5), "date");
+
+            // Assert
+
+            result.Should().Be("2020-01-02");
+        }
+
+        [Fact]
+        public void Serialize_DateTimeOffset_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)));
+
+            // Assert
+
+            result.Should().Be("2020-01-02T03:04:05.0000000-04:00");
+        }
+
+        #endregion
+
+        #region Deserialize
+
+        [Fact]
+        public void Deserialize_String_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Deserialize<string>("test");
+
+            // Assert
+
+            result.Should().Be("test");
+        }
+
+        [Fact]
+        public void Deserialize_Integer_ReturnsString()
+        {
+            // Act
+
+            int result = LiteralSerializer.Instance.Deserialize<int>("105");
+
+            // Assert
+
+            result.Should().Be(105);
+        }
+
+        [Fact]
+        public void Deserialize_Long_ReturnsString()
+        {
+            // Act
+
+            long result = LiteralSerializer.Instance.Deserialize<long>("105");
+
+            // Assert
+
+            result.Should().Be(105L);
+        }
+
+        [Fact]
+        public void Deserialize_Float_ReturnsString()
+        {
+            // Act
+
+            float result = LiteralSerializer.Instance.Deserialize<float>("1.05");
+
+            // Assert
+
+            result.Should().Be(1.05f);
+        }
+
+        [Fact]
+        public void Deserialize_Double_ReturnsString()
+        {
+            // Act
+
+            double result = LiteralSerializer.Instance.Deserialize<double>("1.05");
+
+            // Assert
+
+            result.Should().Be(1.05);
+        }
+
+        [Fact]
+        public void Deserialize_True_ReturnsString()
+        {
+            // Act
+
+            bool result = LiteralSerializer.Instance.Deserialize<bool>("true");
+
+            // Assert
+
+            result.Should().Be(true);
+        }
+
+        [Fact]
+        public void Deserialize_False_ReturnsString()
+        {
+            // Act
+
+            bool result = LiteralSerializer.Instance.Deserialize<bool>("false");
+
+            // Assert
+
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Deserialize_Date_ReturnsString()
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.Deserialize<DateTime>("2020-01-02", "date");
+
+            // Assert
+
+            result.Should().Be(new DateTime(2020, 01, 02));
+        }
+
+        [Fact]
+        public void Deserialize_DateWithUnexpectedTime_FormatException()
+        {
+            // Act/Assert
+
+            var action = () => LiteralSerializer.Instance.Deserialize<DateTime>(
+                "2020-01-02T03:04:05-04:00", "date");
+            action.Should().Throw<FormatException>();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("date-time")]
+        public void Deserialize_DateTimeOffset_ReturnsString(string format)
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.Deserialize<DateTimeOffset>(
+                "2020-01-02T03:04:05-04:00", format);
+
+            // Assert
+
+            result.Should().Be(new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)));
+        }
+
+        #endregion
+
+        #region JoinList
+
+        [Fact]
+        public void JoinList_Date_Serializes()
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.JoinList(",",
+                new[] {new DateTime(2020, 1, 2), new DateTime(2021, 2, 3)},
+                typeof(DateTime), "date");
+
+            // Assert
+
+            result.Should().Be("2020-01-02,2021-02-03");
+        }
+
+        #endregion
+
+        #region JoinListT
+
+        [Fact]
+        public void JoinListT_Date_Serializes()
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.JoinList(",",
+                new[] {new DateTime(2020, 1, 2), new DateTime(2021, 2, 3)},
+                "date");
+
+            // Assert
+
+            result.Should().Be("2020-01-02,2021-02-03");
+        }
+
+        #endregion
+    }
+}

--- a/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using RootNamespace.Serialization;
 using Xunit;
@@ -105,6 +106,54 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be("false");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_SimpleDate_ReturnsString(bool explode)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTime(2020, 1, 2), PathSegmentStyle.Simple, explode, "date");
+
+            // Assert
+
+            result.Should().Be("2020-01-02");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_SimpleDateTime_ReturnsString(bool explode)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTime(2020, 1, 2, 3, 4, 5), PathSegmentStyle.Simple, explode, "date-time");
+
+            // Assert
+
+            result.Should().Be("2020-01-02T03:04:05.0000000");
+        }
+
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(true, null)]
+        [InlineData(false, "date-time")]
+        [InlineData(true, "date-time")]
+        public void Serialize_SimpleDateTimeOffset_ReturnsString(bool explode, string format)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)),
+                PathSegmentStyle.Simple, explode, format);
+
+            // Assert
+
+            result.Should().Be("2020-01-02T03:04:05.0000000-04:00");
         }
 
         [Theory]
@@ -222,6 +271,39 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be(".false");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_LabelDateTime_ReturnsString(bool explode)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTime(2020, 1, 2), PathSegmentStyle.Label, explode, "date");
+
+            // Assert
+
+            result.Should().Be(".2020-01-02");
+        }
+
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(true, null)]
+        [InlineData(false, "date-time")]
+        [InlineData(true, "date-time")]
+        public void Serialize_LabelDateTimeOffset_ReturnsString(bool explode, string format)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)),
+                PathSegmentStyle.Label, explode, format);
+
+            // Assert
+
+            result.Should().Be(".2020-01-02T03:04:05.0000000-04:00");
         }
 
         [Fact]
@@ -350,6 +432,39 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be(";id=false");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Serialize_MatrixDateTime_ReturnsString(bool explode)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTime(2020, 1, 2), PathSegmentStyle.Matrix, explode, "date");
+
+            // Assert
+
+            result.Should().Be(";id=2020-01-02");
+        }
+
+        [Theory]
+        [InlineData(false, null)]
+        [InlineData(true, null)]
+        [InlineData(false, "date-time")]
+        [InlineData(true, "date-time")]
+        public void Serialize_MatrixDateTimeOffset_ReturnsString(bool explode, string format)
+        {
+            // Act
+
+            string result = PathSegmentSerializer.Instance.Serialize("id",
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)),
+                PathSegmentStyle.Matrix, explode, format);
+
+            // Assert
+
+            result.Should().Be(";id=2020-01-02T03:04:05.0000000-04:00");
         }
 
         [Fact]

--- a/src/main/Yardarm.Client.UnitTests/Serialization/QueryStringBuilderTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/QueryStringBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using RootNamespace.Serialization;
 using Xunit;
 
@@ -92,6 +93,23 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void ToString_Date_AddsWithDateFormat()
+        {
+            // Arrange
+
+            var builder = new QueryStringBuilder("base/uri");
+            builder.AppendPrimitive("name", new DateTime(2020, 1, 2), false, "date");
+
+            // Act
+
+            var result = builder.ToString();
+
+            // Assert
+
+            result.Should().Be("base/uri?name=2020-01-02");
+        }
+
+        [Fact]
         public void ToString_NullRefType_Skips()
         {
             // Arrange
@@ -126,12 +144,29 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void ToString_NonNullValueType_Serializes()
+        {
+            // Arrange
+
+            var builder = new QueryStringBuilder("base/uri");
+            builder.AppendPrimitive("name", (long?) 10, false);
+
+            // Act
+
+            var result = builder.ToString();
+
+            // Assert
+
+            result.Should().Be("base/uri?name=10");
+        }
+
+        [Fact]
         public void ToString_ListExplode_MultipleValues()
         {
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2" }, true, ",", false);
+            builder.AppendList("name", new[] { "value1", "value2" }, true, ",", false);
 
             // Act
 
@@ -148,7 +183,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", null, "value2" }, true, ",", false);
+            builder.AppendList("name", new[] { "value1", null, "value2" }, true, ",", false);
 
             // Act
 
@@ -165,7 +200,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2 " }, true, ",", true);
+            builder.AppendList("name", new[] { "value1", "value2 " }, true, ",", true);
 
             // Act
 
@@ -182,7 +217,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2 " }, true, ",", false);
+            builder.AppendList("name", new[] { "value1", "value2 " }, true, ",", false);
 
             // Act
 
@@ -194,12 +229,29 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void ToString_DateListExplode_MultipleValuesWithDateFormat()
+        {
+            // Arrange
+
+            var builder = new QueryStringBuilder("base/uri");
+            builder.AppendList("name", new[] { new DateTime(2020, 1, 2), new DateTime(2021, 3, 4) }, true, ",", false, "date");
+
+            // Act
+
+            var result = builder.ToString();
+
+            // Assert
+
+            result.Should().Be("base/uri?name=2020-01-02&name=2021-03-04");
+        }
+
+        [Fact]
         public void ToString_ListDelimited_Concatenates()
         {
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2" }, false, "%20", false);
+            builder.AppendList("name", new[] { "value1", "value2" }, false, "%20", false);
 
             // Act
 
@@ -216,7 +268,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2 " }, false, "%20", true);
+            builder.AppendList("name", new[] { "value1", "value2 " }, false, "%20", true);
 
             // Act
 
@@ -233,7 +285,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Arrange
 
             var builder = new QueryStringBuilder("base/uri");
-            builder.AppendList("name", new object[] { "value1", "value2 " }, false, "%20", false);
+            builder.AppendList("name", new[] { "value1", "value2 " }, false, "%20", false);
 
             // Act
 
@@ -242,6 +294,23 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be("base/uri?name=value1%20value2%20");
+        }
+
+        [Fact]
+        public void ToString_DateListDelimited_ConcatenatesWithDateFormat()
+        {
+            // Arrange
+
+            var builder = new QueryStringBuilder("base/uri");
+            builder.AppendList("name", new[] { new DateTime(2020, 1, 2), new DateTime(2021, 3, 4) }, false, "%20", false, "date");
+
+            // Act
+
+            var result = builder.ToString();
+
+            // Assert
+
+            result.Should().Be("base/uri?name=2020-01-02%202021-03-04");
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -18,7 +18,7 @@ namespace RootNamespace.Serialization
             _literalSerializer = literalSerializer;
         }
 
-        public string SerializePrimitive<T>(T value)
+        public string SerializePrimitive<T>(T value, string? format = null)
         {
             if (value == null)
             {
@@ -31,20 +31,20 @@ namespace RootNamespace.Serialization
                 return str;
             }
 
-            return _literalSerializer.Serialize(value);
+            return _literalSerializer.Serialize(value, format);
         }
 
-        public string SerializeList<T>(IEnumerable<T>? list)
+        public string SerializeList<T>(IEnumerable<T>? list, string? format = null)
         {
             if (list == null)
             {
                 return "";
             }
 
-            return _literalSerializer.JoinList(",", list);
+            return _literalSerializer.JoinList(",", list, format);
         }
 
-        public T DeserializePrimitive<T>(IEnumerable<string> values)
+        public T DeserializePrimitive<T>(IEnumerable<string> values, string? format = null)
         {
             // Rejoin the values from the header into a simple string
 #if NET6_0_OR_GREATER
@@ -60,14 +60,14 @@ namespace RootNamespace.Serialization
             }
 
             // We're not dealing with a list, so join the values back together
-            return _literalSerializer.Deserialize<T>(value);
+            return _literalSerializer.Deserialize<T>(value, format);
         }
 
-        public List<T> DeserializeList<T>(IEnumerable<string> values)
+        public List<T> DeserializeList<T>(IEnumerable<string> values, string? format = null)
         {
             ThrowHelper.ThrowIfNull(values, nameof(values));
 
-            return _literalSerializer.DeserializeList<T>(values);
+            return _literalSerializer.DeserializeList<T>(values, format);
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -13,34 +15,89 @@ namespace RootNamespace.Serialization
         public static LiteralSerializer Instance { get; } = new LiteralSerializer();
 
         private static readonly MethodInfo s_joinListMethod =
-            ((Func<string, IEnumerable<string>, string>)Instance.JoinList<string>).GetMethodInfo().GetGenericMethodDefinition();
+            ((Func<string, IEnumerable<string>, string, string>)Instance.JoinList<string>).GetMethodInfo().GetGenericMethodDefinition();
 
-        public string Serialize<T>(T value) =>
-            value != null
-                ? value switch {
-                    bool boolean => boolean ? "true" : "false",
-                    _ => TypeDescriptor.GetConverter(typeof(T)).ConvertToString(value) ?? ""
-                }
-                : "";
+        public string Serialize<T>(T value, string? format = null)
+        {
+            if (value is null)
+            {
+                return "";
+            }
+
+            // These if expressions is elided by JIT for value types to be only the specific branch
+            if (typeof(T) == typeof(bool) || typeof(T) == typeof(bool?))
+            {
+                return (bool)(object)value ? "true" : "false";
+            }
+            if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
+            {
+                var dateTime = (DateTime)(object)value;
+
+                return format switch
+                {
+                    "date" => dateTime.ToString("yyyy-MM-dd"),
+                    _ => dateTime.ToString("O")
+                };
+            }
+            if (typeof(T) == typeof(DateTimeOffset) || typeof(T) == typeof(DateTimeOffset?))
+            {
+                var dateTime = (DateTimeOffset)(object)value;
+
+                return format switch
+                {
+                    "date" => dateTime.ToString("yyyy-MM-dd"),
+                    _ => dateTime.ToString("O")
+                };
+            }
+
+            return TypeDescriptor.GetConverter(typeof(T))
+                .ConvertToString(null, CultureInfo.InvariantCulture, value) ?? "";
+        }
 
         [return: NotNullIfNotNull("value")]
-        public T Deserialize<T>(string? value) =>
-            value != null
-                ? (T) TypeDescriptor.GetConverter(typeof(T)).ConvertFromString(value)!
-                : default!;
+        public T Deserialize<T>(string? value, string? format = null)
+        {
+            if (value is null)
+            {
+                return default!;
+            }
 
-        public string JoinList(string separator, object list, Type itemType)
+            // These if expressions is elided by JIT for value types to be only the specific branch
+            if (typeof(T) == typeof(DateTime) || typeof(T) == typeof(DateTime?))
+            {
+                return (T)(object)(format switch
+                {
+                    "date" => DateTime.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    _ => (DateTime) TypeDescriptor.GetConverter(typeof(DateTime))
+                        .ConvertFromString(null, CultureInfo.InvariantCulture, value)!
+                });
+            }
+            if (typeof(T) == typeof(DateTimeOffset) || typeof(T) == typeof(DateTimeOffset?))
+            {
+                return (T)(object)(format switch
+                {
+                    "date" => DateTimeOffset.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    _ => (DateTimeOffset) TypeDescriptor.GetConverter(typeof(DateTimeOffset))
+                        .ConvertFromString(null, CultureInfo.InvariantCulture, value)!
+                });
+            }
+
+            return (T)TypeDescriptor.GetConverter(typeof(T))
+                .ConvertFromString(null, CultureInfo.InvariantCulture, value)!;
+        }
+
+        public string JoinList(string separator, object list, Type itemType, string? format = null)
         {
             MethodInfo joinList = s_joinListMethod.MakeGenericMethod(itemType);
 
-            return (string)joinList.Invoke(this, new object[] {separator, list})!;
+            return (string)joinList.Invoke(this, new object?[] {separator, list, format})!;
         }
 
-        public string JoinList<T>(string separator, IEnumerable<T> list) =>
+        public string JoinList<T>(string separator, IEnumerable<T> list, string? format = null) =>
             string.Join(separator, list
-                .Select(Serialize));
+                .Select(p => Serialize(p, format)));
 
-        public List<T> DeserializeList<T>(IEnumerable<string> values) =>
-            new List<T>(values.Select(Deserialize<T>));
+        public List<T> DeserializeList<T>(IEnumerable<string> values, string? format = null) =>
+            new List<T>(values.Select(p => Deserialize<T>(p, format)));
     }
 }

--- a/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
@@ -7,19 +7,18 @@ namespace RootNamespace.Serialization
 {
     internal class PathSegmentSerializer
     {
-
         public static PathSegmentSerializer Instance { get; } = new PathSegmentSerializer();
 
         public string Serialize<
 #if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
-            T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false) =>
+            T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false, string? format = null) =>
             style switch
             {
-                PathSegmentStyle.Simple => SerializeSimple(value, explode),
-                PathSegmentStyle.Label => SerializeLabel(value, explode),
-                PathSegmentStyle.Matrix => SerializeMatrix(name, value, explode),
+                PathSegmentStyle.Simple => SerializeSimple(value, explode, format),
+                PathSegmentStyle.Label => SerializeLabel(value, explode, format),
+                PathSegmentStyle.Matrix => SerializeMatrix(name, value, explode, format),
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
 
@@ -27,7 +26,7 @@ namespace RootNamespace.Serialization
 #if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
-            T>(T value, bool explode)
+            T>(T value, bool explode, string? format = null)
         {
             if (value == null)
             {
@@ -42,17 +41,17 @@ namespace RootNamespace.Serialization
 
             if (SerializationHelpers.IsEnumerable(typeof(T), out Type? itemType))
             {
-                return LiteralSerializer.Instance.JoinList(",", value, itemType);
+                return LiteralSerializer.Instance.JoinList(",", value, itemType, format);
             }
 
-            return LiteralSerializer.Instance.Serialize(value);
+            return LiteralSerializer.Instance.Serialize(value, format);
         }
 
         private static string SerializeLabel<
 #if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
-            T>(T value, bool explode)
+            T>(T value, bool explode, string? format)
         {
             if (value == null)
             {
@@ -67,17 +66,17 @@ namespace RootNamespace.Serialization
 
             if (SerializationHelpers.IsEnumerable(typeof(T), out Type? itemType))
             {
-                return "." + LiteralSerializer.Instance.JoinList(explode ? "." : ",", value, itemType);
+                return "." + LiteralSerializer.Instance.JoinList(explode ? "." : ",", value, itemType, format);
             }
 
-            return "." + LiteralSerializer.Instance.Serialize(value);
+            return "." + LiteralSerializer.Instance.Serialize(value, format);
         }
 
         private static string SerializeMatrix<
 #if NET6_0_OR_GREATER
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
 #endif
-            T>(string name, T value, bool explode)
+            T>(string name, T value, bool explode, string? format)
         {
             if (value == null)
             {
@@ -94,10 +93,10 @@ namespace RootNamespace.Serialization
             {
                 string prefix = $";{name}=";
 
-                return prefix + LiteralSerializer.Instance.JoinList(explode ? prefix : ",", value, itemType);
+                return prefix + LiteralSerializer.Instance.JoinList(explode ? prefix : ",", value, itemType, format);
             }
 
-            return $";{name}={LiteralSerializer.Instance.Serialize(value)}";
+            return $";{name}={LiteralSerializer.Instance.Serialize(value, format)}";
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/QueryStringBuilder.cs
+++ b/src/main/Yardarm.Client/Serialization/QueryStringBuilder.cs
@@ -25,17 +25,18 @@ namespace RootNamespace.Serialization
         /// <param name="name">Name of the query parameter. Should be URL encoded.</param>
         /// <param name="value">Value to serialize.</param>
         /// <param name="allowReserved">If true, do not URL encode the serialized value.</param>
+        /// <param name="format">Open API format specifier, i.e. "date" or "date-time".</param>
         /// <remarks>
         /// Null values are ignored.
         /// </remarks>
-        public void AppendPrimitive<T>(string name, T value, bool allowReserved)
+        public void AppendPrimitive<T>(string name, T value, bool allowReserved, string? format = null)
         {
             if (value is null)
             {
                 return;
             }
 
-            Append(name, EscapeValue(value, allowReserved));
+            Append(name, EscapeValue(value, allowReserved, format));
         }
 
         /// <summary>
@@ -47,10 +48,11 @@ namespace RootNamespace.Serialization
         /// <param name="explode">If true, add a separate query parameter for each item in the list.</param>
         /// <param name="delimiter">If <paramref name="explode"/> is <c>false</c>, this string separates each value.</param>
         /// <param name="allowReserved">If true, do not URL encode the serialized values.</param>
+        /// <param name="format">Open API format specifier, i.e. "date" or "date-time".</param>
         /// <remarks>
         /// Null values are ignored. Also, <paramref name="delimiter"/> is not url-encoded, special characters should be encoded in advance.
         /// </remarks>
-        public void AppendList<T>(string name, IEnumerable<T>? list, bool explode, string delimiter, bool allowReserved)
+        public void AppendList<T>(string name, IEnumerable<T>? list, bool explode, string delimiter, bool allowReserved, string? format = null)
         {
             if (list is null)
             {
@@ -63,7 +65,7 @@ namespace RootNamespace.Serialization
                 {
                     if (item is not null)
                     {
-                        Append(name, EscapeValue(item, allowReserved));
+                        Append(name, EscapeValue(item, allowReserved, format));
                     }
                 }
             }
@@ -86,7 +88,7 @@ namespace RootNamespace.Serialization
                             _stringBuilder.Append(delimiter);
                         }
 
-                        _stringBuilder.Append(EscapeValue(item, allowReserved));
+                        _stringBuilder.Append(EscapeValue(item, allowReserved, format));
                     }
                 }
             }
@@ -109,9 +111,9 @@ namespace RootNamespace.Serialization
             _stringBuilder.Append(value);
         }
 
-        private static string EscapeValue<T>(T value, bool allowReserved) =>
+        private static string EscapeValue<T>(T value, bool allowReserved, string? format) =>
             allowReserved
-                ? LiteralSerializer.Instance.Serialize(value)
-                : Uri.EscapeDataString(LiteralSerializer.Instance.Serialize(value));
+                ? LiteralSerializer.Instance.Serialize(value, format)
+                : Uri.EscapeDataString(LiteralSerializer.Instance.Serialize(value, format));
     }
 }

--- a/src/main/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
@@ -84,7 +84,11 @@ namespace Yardarm.Enrichment.Responses
                             _serializationNamespace.HeaderSerializerInstance,
                             GenericName("DeserializeList")
                                 .AddTypeArgumentListArguments(typeName)),
-                        ArgumentList(SingletonSeparatedList(Argument(valuesName))));
+                        ArgumentList(SeparatedList(new []
+                        {
+                            Argument(valuesName),
+                            Argument(SyntaxHelpers.StringLiteral(schemaElement.Element.Format))
+                        })));
                 }
                 else
                 {
@@ -92,7 +96,10 @@ namespace Yardarm.Enrichment.Responses
                             _serializationNamespace.HeaderSerializerInstance,
                             GenericName("DeserializePrimitive")
                                 .AddTypeArgumentListArguments(typeName)),
-                        ArgumentList(SingletonSeparatedList(Argument(valuesName))));
+                        ArgumentList(SeparatedList(new [] {
+                            Argument(valuesName),
+                            Argument(SyntaxHelpers.StringLiteral(schemaElement.Element.Format))
+                        })));
                 }
 
                 yield return IfStatement(

--- a/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -85,7 +85,11 @@ namespace Yardarm.Generation.Request
                             SyntaxKind.SimpleMemberAccessExpression,
                             SerializationNamespace.HeaderSerializerInstance,
                             IdentifierName("SerializeList")),
-                        ArgumentList(SingletonSeparatedList(Argument(IdentifierName(propertyName)))));
+                        ArgumentList(SeparatedList(new[]
+                        {
+                            Argument(IdentifierName(propertyName)),
+                            Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
+                        })));
                 }
                 else
                 {
@@ -94,7 +98,11 @@ namespace Yardarm.Generation.Request
                             SyntaxKind.SimpleMemberAccessExpression,
                             SerializationNamespace.HeaderSerializerInstance,
                             IdentifierName("SerializePrimitive")),
-                        ArgumentList(SingletonSeparatedList(Argument(IdentifierName(propertyName)))));
+                        ArgumentList(SeparatedList(new []
+                        {
+                            Argument(IdentifierName(propertyName)),
+                            Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
+                        })));
                 }
 
                 StatementSyntax statement = ExpressionStatement(InvocationExpression(

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -70,7 +70,8 @@ namespace Yardarm.Generation.Request
                             Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
                             Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
                             Argument(GetStyleExpression(parameter)),
-                            Argument(GetExplodeExpression(parameter)));
+                            Argument(GetExplodeExpression(parameter)),
+                            Argument(SyntaxHelpers.StringLiteral(parameter.Schema?.Format)));
                 });
 
             OpenApiParameter[] queryParameters = operation.Element.Parameters
@@ -109,7 +110,8 @@ namespace Yardarm.Generation.Request
                                     ParameterStyle.PipeDelimited => SyntaxHelpers.StringLiteral("|"),
                                     _ => SyntaxHelpers.StringLiteral(",")
                                 }),
-                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression))
+                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
+                                Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
                             }))));
                     }
                     else
@@ -122,7 +124,8 @@ namespace Yardarm.Generation.Request
                             {
                                 Argument(SyntaxHelpers.StringLiteral(Uri.EscapeDataString(queryParameter.Name))),
                                 Argument(IdentifierName(propertyNameFormatter.Format(queryParameter.Name))),
-                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression))
+                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
+                                Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
                             }))));
                     }
                 }

--- a/src/main/Yardarm/Helpers/SyntaxHelpers.cs
+++ b/src/main/Yardarm/Helpers/SyntaxHelpers.cs
@@ -64,8 +64,10 @@ namespace Yardarm.Helpers
                     (agg, current) =>
                         MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, agg, IdentifierName(current)));
 
-        public static LiteralExpressionSyntax StringLiteral(string value) =>
-            LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value));
+        public static LiteralExpressionSyntax StringLiteral(string? value) =>
+            value is not null
+                ? LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value))
+                : LiteralExpression(SyntaxKind.NullLiteralExpression);
 
         public static ExpressionSyntax ParameterWithNullCheck(string parameterName) =>
             BinaryExpression(SyntaxKind.CoalesceExpression,


### PR DESCRIPTION
Motivation
----------
We're not currently correctly respecting "format" requirements on header, path, and query string parameters for dates and date times.

Modifications
-------------
- Pass the "format" specifier from OpenAPI to the various serializers and deserializers
- Use some tricks respected by JIT to efficiently provide alternate code paths for DateTime, DateTimeOffset, and boolean serialization and deserialization.
- Fix some tests that weren't properly using the right generic params

This is the last piece of the puzzle to close #147.

Fixes #147