### PR TITLE
Upgrade to use System.Text.Json 7.0

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 

--- a/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -21,7 +21,7 @@ namespace Yardarm.SystemTextJson
                     {
                         Name = "System.Text.Json",
                         TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("6.0.0")
+                        VersionRange = VersionRange.Parse("7.0.1")
                     }
                 };
 
@@ -31,7 +31,7 @@ namespace Yardarm.SystemTextJson
                     {
                         Name = "System.Net.Http.Json",
                         TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("6.0.0")
+                        VersionRange = VersionRange.Parse("7.0.0")
                     }
                 };
             }

--- a/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <PackageReference Include="System.Text.Json" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
Modernization and support for built-in polymorphism.

Modifications
-------------
Upgrade the version using in the Yardarm build as well as the version of packages referenced when building the SDK and creating NuGet packages.

Results
-------
New packages will use STJ 7.0.1. This is still compatible with older frameworks such as .NET Standard 2.0.