### PR TITLE
Added author and description to NuGet generation

### DIFF
--- a/docs/generating/README.md
+++ b/docs/generating/README.md
@@ -52,8 +52,8 @@ yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -f net6.0 -o output/director
 # Generate a NuGet package and symbols package, with System.Text.Json and DI support targeting net6.0 and netstandard2.0
 yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 netstandard2.0 --nupkg output/directory/ -x Yardarm.SystemTextJson Yardarm.MicrosoftExtensionsHttp
 
-# Generate a NuGet package and symbols package, with Newtonsoft.Json, DI support targeting net6.0 and author name and description
-yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 --author "Some Name Here" --description "Some description here" --nupkg output/directory/ -x Yardarm.NewtonsoftJson Yardarm.MicrosoftExtensionsHttp
+# Generate a NuGet package and symbols package, with Newtonsoft.Json and DI support targeting net6.0 with author name, owner and description
+yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 --author "Some Name Here" --owner "Some Owner Here" --description "Some description here" --nupkg output/directory/ -x Yardarm.NewtonsoftJson Yardarm.MicrosoftExtensionsHttp
 
 # Note the trailing slash on the output directory. If there is no trailing slash, it is assumed to be a DLL or nupkg file name.
 # Related files will be output beside that file.

--- a/docs/generating/README.md
+++ b/docs/generating/README.md
@@ -52,6 +52,9 @@ yardarm generate -i my-spec.yaml -n MySpec -v 1.0.0 -f net6.0 -o output/director
 # Generate a NuGet package and symbols package, with System.Text.Json and DI support targeting net6.0 and netstandard2.0
 yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 netstandard2.0 --nupkg output/directory/ -x Yardarm.SystemTextJson Yardarm.MicrosoftExtensionsHttp
 
+# Generate a NuGet package and symbols package, with Newtonsoft.Json, DI support targeting net6.0 and author name and description
+yardarm generate -i my-spec.json -n MySpec -v 1.0.0 -f net6.0 --author "Some Name Here" --description "Some description here" --nupkg output/directory/ -x Yardarm.NewtonsoftJson Yardarm.MicrosoftExtensionsHttp
+
 # Note the trailing slash on the output directory. If there is no trailing slash, it is assumed to be a DLL or nupkg file name.
 # Related files will be output beside that file.
 ```

--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -334,6 +334,7 @@ namespace Yardarm.CommandLine
 
             settings.Author = _options.Author;
             settings.Description= _options.Description;
+            settings.Owner = _options.Owner;
         }
 
         // Holds a temporary file which will eventually be persisted to a final file.

--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -331,6 +331,9 @@ namespace Yardarm.CommandLine
                     new RepositoryMetadata(_options.RepositoryType, _options.RepositoryUrl, _options.RepositoryBranch,
                         _options.RepositoryCommit);
             }
+
+            settings.Author = _options.Author;
+            settings.Description= _options.Description;
         }
 
         // Holds a temporary file which will eventually be persisted to a final file.

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -61,10 +61,10 @@ namespace Yardarm.CommandLine
 
         #region NuGet
 
-        [Option("author", HelpText = "Author to show in the generation of the .nupkg package file.", SetName = "nuget")]
+        [Option("author", HelpText = "Author to show for the .nupkg/.snupkg package file", SetName = "nuget")]
         public string Author { get; set; }
 
-        [Option("description", HelpText = "Description to show in the generation of the .nupkg package file.", SetName = "nuget")]
+        [Option("description", HelpText = "Description to show for the .nupkg/.snupkg package file", SetName = "nuget")]
         public string Description { get; set; }
 
         [Option("nupkg", HelpText = "Output directory or .nupkg package file. Indicate a directory with a trailing slash.", SetName = "nuget")]

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -64,6 +64,9 @@ namespace Yardarm.CommandLine
         [Option("author", HelpText = "Author to show for the .nupkg/.snupkg package file", SetName = "nuget")]
         public string Author { get; set; }
 
+        [Option("owner", HelpText = "Owner to show for the .nupkg/.snupkg package file", SetName = "nuget")]
+        public string Owner { get; set; }
+
         [Option("description", HelpText = "Description to show for the .nupkg/.snupkg package file", SetName = "nuget")]
         public string Description { get; set; }
 

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -61,6 +61,12 @@ namespace Yardarm.CommandLine
 
         #region NuGet
 
+        [Option("author", HelpText = "Author to show in the generation of the .nupkg package file.", SetName = "nuget")]
+        public string Author { get; set; }
+
+        [Option("description", HelpText = "Description to show in the generation of the .nupkg package file.", SetName = "nuget")]
+        public string Description { get; set; }
+
         [Option("nupkg", HelpText = "Output directory or .nupkg package file. Indicate a directory with a trailing slash.", SetName = "nuget")]
         public string OutputPackageFile { get; set; }
 

--- a/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
@@ -34,7 +34,7 @@ namespace Yardarm.Generation.Tag
             // is missing the name attribute in the OpenAPI spec, the MethodDeclaration step will fail
             if (string.IsNullOrEmpty(methodName))
             {
-                throw new NullReferenceException($"{nameof(GenerateOperationMethodHeader)} ran into an error. Please ensure the method at the path {operation.Key} {operation} is decorated correctly.");
+                throw new NullReferenceException($"{nameof(GenerateOperationMethodHeader)} ran into an error. Please ensure the method at the path {operation.Key} {operation} is decorated correctly with the OperationId present.");
             }
 
             var methodDeclaration = MethodDeclaration(responseType, methodName)

--- a/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
@@ -34,7 +34,7 @@ namespace Yardarm.Generation.Tag
             // is missing the name attribute in the OpenAPI spec, the MethodDeclaration step will fail
             if (string.IsNullOrEmpty(methodName))
             {
-                throw new NullReferenceException($"{nameof(GenerateOperationMethodHeader)} ran into an error. Please ensure all methods are decorated correctly in the operation {operation.Key} {operation}.");
+                throw new NullReferenceException($"{nameof(GenerateOperationMethodHeader)} ran into an error. Please ensure the method at the path {operation.Key} {operation} is decorated correctly.");
             }
 
             var methodDeclaration = MethodDeclaration(responseType, methodName)

--- a/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGeneratorBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -28,6 +29,13 @@ namespace Yardarm.Generation.Tag
 
             string methodName = Context.NameFormatterSelector.GetFormatter(NameKind.AsyncMethod)
                 .Format(operation.Element.OperationId);
+
+            // This is here to show a useful error that there is an error with the Spec provided. If the operation
+            // is missing the name attribute in the OpenAPI spec, the MethodDeclaration step will fail
+            if (string.IsNullOrEmpty(methodName))
+            {
+                throw new NullReferenceException($"{nameof(GenerateOperationMethodHeader)} ran into an error. Please ensure all methods are decorated correctly in the operation {operation.Key} {operation}.");
+            }
 
             var methodDeclaration = MethodDeclaration(responseType, methodName)
                 .AddElementAnnotation(operation, Context.ElementRegistry)

--- a/src/main/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/main/Yardarm/Packaging/NuGetPacker.cs
@@ -43,6 +43,7 @@ namespace Yardarm.Packaging
                 Description = _settings.Description ?? _settings.AssemblyName,
                 Summary = _document.Info.Description,
                 Authors = {_settings.Author},
+                Owners = {_settings.Owner},
                 Repository = _settings.Repository
             };
 
@@ -90,7 +91,8 @@ namespace Yardarm.Packaging
                 },
                 Description = _settings.Description ?? _settings.AssemblyName,
                 Summary = _document.Info.Description,
-                Authors = { _settings.Author }
+                Authors = {_settings.Author},
+                Owners = {_settings.Owner},
             };
 
             builder.Files.AddRange(compilationResults

--- a/src/main/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/main/Yardarm/Packaging/NuGetPacker.cs
@@ -40,7 +40,7 @@ namespace Yardarm.Packaging
                 Version = new NuGetVersion(_settings.Version,
                     _settings.VersionSuffix?.TrimStart('-').Split(new[] {'.'}, StringSplitOptions.RemoveEmptyEntries),
                     null, null),
-                Description = _settings.AssemblyName,
+                Description = _settings.Description ?? _settings.AssemblyName,
                 Summary = _document.Info.Description,
                 Authors = {_settings.Author},
                 Repository = _settings.Repository
@@ -88,7 +88,7 @@ namespace Yardarm.Packaging
                 {
                     PackageType.SymbolsPackage
                 },
-                Description = _settings.AssemblyName,
+                Description = _settings.Description ?? _settings.AssemblyName,
                 Summary = _document.Info.Description,
                 Authors = { _settings.Author }
             };

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -29,6 +29,7 @@ namespace Yardarm
         public Version Version { get; set; } = new Version(1, 0, 0);
         public string? VersionSuffix { get; set; }
         public string Author { get; set; } = "anonymous";
+        public string Description { get; set; }
         public RepositoryMetadata? Repository { get; set; }
 
         /// <summary>

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -29,6 +29,7 @@ namespace Yardarm
         public Version Version { get; set; } = new Version(1, 0, 0);
         public string? VersionSuffix { get; set; }
         public string Author { get; set; } = "anonymous";
+        public string Owner { get; set; } = "anonymous";
         public string Description { get; set; }
         public RepositoryMetadata? Repository { get; set; }
 


### PR DESCRIPTION
# Why
I have added these changes to support adding of a custom description and author for packing NuGet packages and symbols to give more flexibility and control to the user. I have also added a small convenient error message when method name is null as this initially cost me several hours of trying to figure out what may or may not have been wrong with my own OpenAPI spec.

# Changes
- Added author to the Generate Options and Yardarm Generation Settings
- Added description to the Generate Options and Yardarm Generation Settings
- Added owner to the Generate Options and Yardarm Generation Settings
- Assign author, description and owner from Generation Options to Yardarm Generation Settings
- Modify logic on selecting description for NuGet packaging by introducing Description but allowing to use AssemlyName if null and introducing Owner
- Added a friendly error message to TagTypeGeneratorBase to assist a user finding an error with their OpenAPI spec and prevents and unhandled exception from being thrown due to a null value
- Updated the generation README.md to include an example of providing author and description as part of generating a NuGet using Yardarm.CommandLine

# Result
NuGet and symbols packages are generated with a custom Author and Custom description. This description does not overwrite the description within the Spec.
![image](https://user-images.githubusercontent.com/42809999/211822930-ef25b1d2-ebb0-4038-bcf3-f7639792620e.png)

# Passing Tests
![image](https://user-images.githubusercontent.com/42809999/211761288-7c7da2ff-4d7e-4ac2-bc7c-c7e6932fb469.png)
