### PR TITLE
Add `IOperationResponse<TBody>` to responses with a body

### DIFF
--- a/src/main/Yardarm.Client/Responses/IOperationResponse`1.cs
+++ b/src/main/Yardarm.Client/Responses/IOperationResponse`1.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace RootNamespace.Responses
+{
+    /// <summary>
+    /// An operation response with a specific body schema.
+    /// </summary>
+    /// <typeparam name="TBody">The type of the body schema.</typeparam>
+    public interface IOperationResponse<TBody> : IOperationResponse
+    {
+        /// <summary>
+        /// Get the body of the response.
+        /// </summary>
+        /// <returns>The deserialized body.</returns>
+        ValueTask<TBody> GetBodyAsync();
+    }
+}

--- a/src/main/Yardarm/Generation/Response/ResponseTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Response/ResponseTypeGenerator.cs
@@ -91,6 +91,12 @@ namespace Yardarm.Generation.Response
                     GenerateHeaderProperties()
                         .Concat(GenerateBodyField(bodyType))
                         .ToArray());
+
+                if (bodyType is not null)
+                {
+                    // Add the IOperationResponse<TBody> interface for responses with a body
+                    declaration = declaration.AddBaseListTypes(SimpleBaseType(ResponsesNamespace.IOperationResponseTBody(bodyType)));
+                }
             }
 
             (ITypeGenerator? schemaGenerator, bool schemaIsReference) = GetSchemaGenerator();

--- a/src/main/Yardarm/Names/IResponsesNamespace.cs
+++ b/src/main/Yardarm/Names/IResponsesNamespace.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.Names
 {
@@ -9,5 +10,11 @@ namespace Yardarm.Names
         NameSyntax OperationResponse { get; }
         NameSyntax StatusCodeMismatchException { get; }
         NameSyntax UnknownResponse { get; }
+
+        NameSyntax IOperationResponseTBody(TypeSyntax bodyType) =>
+            QualifiedName(
+                Name,
+                GenericName(Identifier("IOperationResponse"),
+                    TypeArgumentList(SingletonSeparatedList(bodyType))));
     }
 }


### PR DESCRIPTION
Motivation
----------
When dealing with abstraction layers wrapping multiple different API calls it is very difficult to gain access to the body as each different response object as a different `GetBodyAsync` method returning a different type.

Modifications
-------------
Add a common `IOperationResponse<TBody>` interface, inherited from `IOperationResponse`, which includes the `GetBodyAsync` method. Include this interface on all response classes which include a body.

Results
-------
Abstraction layers in consumers can use type checking to find the interface they want. This is particularly useful for error handling if the API in question returns all errors with an `Error` schema or similar. You can simply `response as IOperationResponse<Error>` to test and then get the `Error` object from the `GetBodyAsync` method.