### PR TITLE
Suppress CS1702 warning

### DIFF
--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -99,7 +99,8 @@ namespace Yardarm
                 .WithSpecificDiagnosticOptions(new KeyValuePair<string, ReportDiagnostic>[]
                 {
                     // Don't warn for binding redirects
-                    new("CS1701", ReportDiagnostic.Suppress)
+                    new("CS1701", ReportDiagnostic.Suppress),
+                    new("CS1702", ReportDiagnostic.Suppress)
                 });
 
         public YardarmGenerationSettings()


### PR DESCRIPTION
Motivation
----------
We suppress CS1701 already, but the 1702 binding redirect warnings is also unnecessary. This is triggered in some more advance SDK configurations.