### PR TITLE
Handle more polymorphism cases for System.Text.Json

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.OpenApi.Models;
 using Yardarm.Generation;
-using Yardarm.Generation.Schema;
 using Yardarm.Spec;
 
 namespace Yardarm.SystemTextJson.Internal
@@ -28,20 +27,16 @@ namespace Yardarm.SystemTextJson.Internal
         {
             var schemas = _document
                 .GetAllSchemas()
-                .Where(schema => schema.Element.OneOf.Count > 0);
+                .Where(schema => schema.Element.Discriminator?.PropertyName is not null);
 
             foreach (var schema in schemas)
             {
-                var schemaGenerator = _schemaTypeGeneratorRegistry.Get(schema);
-                if (schemaGenerator is OneOfSchemaGenerator)
-                {
-                    var converterGenerator = _converterTypeGeneratorRegistry.Get(schema);
+                var converterGenerator = _converterTypeGeneratorRegistry.Get(schema);
 
-                    var syntaxTree = converterGenerator.GenerateSyntaxTree();
-                    if (syntaxTree != null)
-                    {
-                        yield return syntaxTree;
-                    }
+                var syntaxTree = converterGenerator.GenerateSyntaxTree();
+                if (syntaxTree != null)
+                {
+                    yield return syntaxTree;
                 }
             }
         }


### PR DESCRIPTION
Motivation
----------
We are currently only handling oneOf polymorphism with explicitly defined type mappings. There are cases where we should be mapping by default based on schema name. There are also cases we should be handling where anyOf is used for polymorphism instead of oneOf.

Modifications
-------------
Find mappings automatically based on defaults if there are no explicit mappings defined. Also apply a converter to classes used as a base for anyOf polymorphism instead of only applying to oneOf.