### PR TITLE
Don't apply STJ attributes to non-JSON schemas

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Internal/SchemaHelper.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/SchemaHelper.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Spec;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    internal static class SchemaHelper
+    {
+        public static bool IsJsonSchema(this IOpenApiElementRegistry elementRegistry,
+            ClassDeclarationSyntax classDeclaration)
+        {
+            var element = classDeclaration.GetElementAnnotation<OpenApiSchema>(elementRegistry);
+            if (element is null)
+            {
+                return false;
+            }
+
+            return element.IsJsonSchema();
+        }
+
+        public static bool IsJsonSchema(this ILocatedOpenApiElement<OpenApiSchema> element)
+        {
+            // Find the top-most schema
+            while (element.Parent is ILocatedOpenApiElement<OpenApiSchema> schemaParent)
+            {
+                element = schemaParent;
+            }
+
+            if (element.Parent is null)
+            {
+                // Assume that shared component schemas may be JSON
+                return true;
+            }
+
+            if (element.Parent is ILocatedOpenApiElement<OpenApiMediaType> mediaTypeElement)
+            {
+                return IsJsonMediaType(mediaTypeElement.Key);
+            }
+
+            // Other cases like headers aren't JSON serialized
+            return false;
+        }
+
+        private static bool IsJsonMediaType(string mediaType) =>
+            mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Spec;
 using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson
@@ -31,6 +32,12 @@ namespace Yardarm.SystemTextJson
             if (context.Element.Type != "string" || context.Element.Format != "date")
             {
                 // Only applies to date-only strings
+                return syntax;
+            }
+
+            if (!context.LocatedElement.IsJsonSchema())
+            {
+                // Don't enrich non-JSON schemas
                 return syntax;
             }
 

--- a/src/main/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDiscriminatorEnricher.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Generation;
 using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson
@@ -24,13 +25,13 @@ namespace Yardarm.SystemTextJson
 
         public InterfaceDeclarationSyntax Enrich(InterfaceDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            context.Element.Discriminator?.PropertyName is not null
+            context.Element.Discriminator?.PropertyName is not null && context.LocatedElement.IsJsonSchema()
                 ? (InterfaceDeclarationSyntax) AddJsonConverter(target, context)
                 : target;
 
         public ClassDeclarationSyntax Enrich(ClassDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            context.Element.Discriminator?.PropertyName is not null
+            context.Element.Discriminator?.PropertyName is not null && context.LocatedElement.IsJsonSchema()
                 ? (ClassDeclarationSyntax) AddJsonConverter(target, context)
                 : target;
 

--- a/src/main/Yardarm.SystemTextJson/JsonEnumEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonEnumEnricher.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
 
 namespace Yardarm.SystemTextJson
 {
@@ -19,7 +20,7 @@ namespace Yardarm.SystemTextJson
 
         public EnumDeclarationSyntax Enrich(EnumDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context) =>
-            context.Element.Type == "string"
+            context.Element.Type == "string" && context.LocatedElement.IsJsonSchema()
                 ? target
                     .AddAttributeLists(SyntaxFactory.AttributeList().AddAttributes(
                         SyntaxFactory.Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName).AddArgumentListArguments(

--- a/src/main/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonOptionalPropertyEnricher.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
 using Yardarm.Spec;
 using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson
@@ -20,6 +21,12 @@ namespace Yardarm.SystemTextJson
 
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
         {
+            if (!context.LocatedElement.IsJsonSchema())
+            {
+                // Don't enrich non-JSON schemas
+                return syntax;
+            }
+
             if (syntax.Parent?.GetElementAnnotation<OpenApiSchema>(_elementRegistry) is null)
             {
                 // We don't need to apply this to properties of request classes, only schemas

--- a/src/main/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonPropertyEnricher.cs
@@ -7,6 +7,7 @@ using Yardarm.Generation;
 using Yardarm.Generation.MediaType;
 using Yardarm.Helpers;
 using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
 
 namespace Yardarm.SystemTextJson
 {
@@ -15,6 +16,12 @@ namespace Yardarm.SystemTextJson
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiSchema> context)
         {
+            if (!context.LocatedElement.IsJsonSchema())
+            {
+                // Don't enrich non-JSON schemas
+                return target;
+            }
+
             if (target.Parent is ClassDeclarationSyntax classDeclaration &&
                 classDeclaration.GetGeneratorAnnotation() == typeof(RequestMediaTypeGenerator))
             {


### PR DESCRIPTION
Motivation
----------
Schemas nested within request or response bodies have a known media type. There is no need to add JSON-related serialization attributes to these schemas as they will never be handled as JSON. Adding the attributes adds other complexities elsewhere and bloats the generated SDK.

Modifications
-------------
Test schemas before adding modifications to ensure the modifications are only applied to schemas which may be serialized or deserialized as JSON.