### PR TITLE
Upgrade to Roslyn 4.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
-          '6.0.x'
-          '7.0.x'
+          6.0.x
+          7.0.x
 
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,17 +16,19 @@ jobs:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
+        dotnet-version: |
+          '6.0.x'
+          '7.0.x'
 
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.13
+      uses: gittools/actions/gitversion/setup@v0.9.15
       with:
         versionSpec: "5.10.3"
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.13
+      uses: gittools/actions/gitversion/execute@v0.9.15
       with:
         useConfigFile: true
         configFilePath: "GitVersion.yml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG VERSION=0.1.0-local
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+# Use 7.0 for build to get LangVersion 11 support
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ARG VERSION
 WORKDIR /app
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,5 +6,7 @@
     <Copyright>Copyright © 2020 Pathfinder Software, LLC D/B/A CenterEdge Software. All Rights Reserved.</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/CenterEdge/Yardarm</PackageProjectUrl>
+
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 </Project>

--- a/src/main/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/main/Yardarm.Client/Yardarm.Client.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>
   </PropertyGroup>

--- a/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.3.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/main/Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
 
     <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>

--- a/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -61,7 +61,7 @@ namespace Yardarm.Generation
 
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(rawText, Encoding.UTF8),
                 CSharpParseOptions.Default
-                    .WithLanguageVersion(LanguageVersion.CSharp10)
+                    .WithLanguageVersion(LanguageVersion.CSharp11)
                     .WithPreprocessorSymbols(preprocessorSymbols),
                 path: PathHelpers.Combine(
                     GenerationContext.Settings.BasePath,

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
 
     <Nullable>enable</Nullable>
-    <LangVersion>10</LangVersion>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -13,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />


### PR DESCRIPTION
Motivation
----------
Stay modern and get C# 11 language features.

Modifications
-------------
- Upgrade Roslyn packages
- Upgrade the LangVersion used by resource files
- Move local build LangVersion to 11 across all projects
- Include .NET 6 and 7 in CI builds (6 for unit tests, 7 for C# version)
- Select source generators more intelligently based on Roslyn version