### PR TITLE
Drop usage of TypeDescriptor.GetConverter from PlainTextSerializer

### DIFF
--- a/src/main/Yardarm.Client/Internal/ThrowHelper.cs
+++ b/src/main/Yardarm.Client/Internal/ThrowHelper.cs
@@ -6,6 +6,10 @@ namespace Yardarm.Client.Internal
 {
     internal static class ThrowHelper
     {
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException(string? message) =>
+            throw new InvalidOperationException(message);
+
         /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
         /// <param name="argument">The reference type argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>


### PR DESCRIPTION
Motivation
----------
TypeDescriptor.GetConverter isn't trimming compatible.

Modifications
-------------
Only support `string` and plain .NET `object` types for deserialization from `text/plain` content types.

Breaking Change
---------------
Previously types like numbers could be deserialized from `text/plain` content type results. However, this is likely a rare use case.

Support may be added back using `IParsable` in .NET 7, but it would then only be supported in .NET 7 and later targets.