### PR TITLE
Remove TypeDescriptor.GetConverter from LiteralSerializer

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using RootNamespace.Serialization;
 using Xunit;
@@ -134,6 +130,34 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().Be("2020-01-02T03:04:05.0000000-04:00");
         }
 
+        [Fact]
+        public void Serialize_Guid_ReturnsString()
+        {
+            // Arrange
+
+            var guid = Guid.NewGuid();
+
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(guid);
+
+            // Assert
+
+            result.Should().Be(guid.ToString());
+        }
+
+        [Fact]
+        public void Serialize_Enum_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(StringComparison.Ordinal);
+
+            // Assert
+
+            result.Should().Be("Ordinal");
+        }
+
         #endregion
 
         #region Deserialize
@@ -257,6 +281,33 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be(new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)));
+        }
+
+        [Fact]
+        public void Deserialize_Guid_ReturnsValue()
+        {
+            // Range
+
+            const string guid = "00000001-0002-0003-0004-000000000005";
+            // Act
+
+            Guid result = LiteralSerializer.Instance.Deserialize<Guid>(guid);
+
+            // Assert
+
+            result.Should().Be(Guid.Parse(guid));
+        }
+
+        [Fact]
+        public void Deserialize_Enum_ReturnsValue()
+        {
+            // Act
+
+            StringComparison result = LiteralSerializer.Instance.Deserialize<StringComparison>("Ordinal");
+
+            // Assert
+
+            result.Should().Be(StringComparison.Ordinal);
         }
 
         #endregion

--- a/src/main/Yardarm.Client/Internal/ThrowHelper.cs
+++ b/src/main/Yardarm.Client/Internal/ThrowHelper.cs
@@ -7,6 +7,10 @@ namespace Yardarm.Client.Internal
     internal static class ThrowHelper
     {
         [DoesNotReturn]
+        public static void ThrowFormatException(string? message, Exception? innerException = null) =>
+            throw new FormatException(message, innerException);
+
+        [DoesNotReturn]
         public static void ThrowInvalidOperationException(string? message) =>
             throw new InvalidOperationException(message);
 
@@ -15,7 +19,7 @@ namespace Yardarm.Client.Internal
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
         public static void ThrowIfNull([NotNull] object? argument,
 #if NET6_0_OR_GREATER
-            [CallerArgumentExpression("argument")]
+            [CallerArgumentExpression(nameof(argument))]
 #endif
             string? paramName = null)
         {


### PR DESCRIPTION
Motivation
----------
TypeDescriptor.GetConverter doesn't have a great performance profile (boxing, etc) and isn't trim compatible.

Modifications
-------------
Switch to using `IFormattable` or just `ToString` for serialization.

For deserialization check for all known types currently supported by Yardarm and directly parse them.

Breaking Changes
----------------
The parsing routines being used may be slightly more strict (i.e. not allowing leading/trailing whitespace). However, this is better aligned with the expected formats from the specification.