### PR TITLE
Add IsTrimmable annotation

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/MicrosoftDiExtension.cs
@@ -18,5 +18,7 @@ namespace Yardarm.MicrosoftExtensionsHttp
 
             return services;
         }
+
+        public override bool IsOutputTrimmable(GenerationContext context) => true;
     }
 }

--- a/src/main/Yardarm.sln.DotSettings
+++ b/src/main/Yardarm.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=referenceable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=referenceable/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Trimmable/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/main/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Yardarm.Enrichment.Compilation
             services
                 .AddAssemblyInfoEnricher<TargetRuntimeAssemblyInfoEnricher>()
                 .AddAssemblyInfoEnricher<VersionAssemblyInfoEnricher>()
+                .AddAssemblyInfoEnricher<IsTrimmableAssemblyInfoEnricher>()
                 .AddCompilationEnricher<ReferenceCompilationEnricher>()
                 .AddCompilationEnricher<ResourceFileCompilationEnricher>()
                 .AddCompilationEnricher<SyntaxTreeCompilationEnricher>()

--- a/src/main/Yardarm/Enrichment/Compilation/IsTrimmableAssemblyInfoEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/IsTrimmableAssemblyInfoEnricher.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Yardarm.Helpers;
+using Yardarm.Packaging;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Enrichment.Compilation
+{
+    public class IsTrimmableAssemblyInfoEnricher : IAssemblyInfoEnricher
+    {
+        private readonly GenerationContext _context;
+
+        public IsTrimmableAssemblyInfoEnricher(GenerationContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            _context = context;
+        }
+
+        public CompilationUnitSyntax Enrich(CompilationUnitSyntax target)
+        {
+            if (_context.CurrentTargetFramework.Framework != NuGetFrameworkConstants.NetCoreApp
+                || _context.CurrentTargetFramework.Version.Major < 6)
+            {
+                // Only .NET 6 and later targets include the required trimming attributes
+                return target;
+            }
+
+            if (_context.Settings.Extensions.Any(p => !p.IsOutputTrimmable(_context)))
+            {
+                // If any extension produces output that is not compatible with trimming
+                // we should not apply the attribute.
+                return target;
+            }
+
+            return target.AddAttributeLists(
+                AttributeList(
+                        AttributeTargetSpecifier(Token(SyntaxKind.AssemblyKeyword)),
+                        SingletonSeparatedList(Attribute(
+                            ParseName("System.Reflection.AssemblyMetadata"),
+                            AttributeArgumentList(SeparatedList(new[]
+                            {
+                                AttributeArgument(SyntaxHelpers.StringLiteral("IsTrimmable")),
+                                AttributeArgument(SyntaxHelpers.StringLiteral("True"))
+                            })))))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+        }
+    }
+}

--- a/src/main/Yardarm/YardarmExtension.cs
+++ b/src/main/Yardarm/YardarmExtension.cs
@@ -5,5 +5,15 @@ namespace Yardarm
     public abstract class YardarmExtension
     {
         public abstract IServiceCollection ConfigureServices(IServiceCollection services);
+
+        /// <summary>
+        /// Returns true if the work done by this extension is trimmable.
+        /// </summary>
+        /// <remarks>
+        /// If all extensions return true the output SDK will be marked as trimmable.
+        /// The default is false, extensions which produce trimmable output should
+        /// override this property to return true.
+        /// </remarks>
+        public virtual bool IsOutputTrimmable(GenerationContext context) => false;
     }
 }

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -31,6 +31,8 @@ namespace Yardarm
         public string Author { get; set; } = "anonymous";
         public RepositoryMetadata? Repository { get; set; }
 
+        public IReadOnlyList<YardarmExtension> Extensions => _extensions;
+
         /// <summary>
         /// Base path for generated source files. Files are not persisted to this path,
         /// but it is used within Roslyn to uniquely identify source files.


### PR DESCRIPTION
Motivation
----------
When trim-compatible constructs are used we should mark the generated assembly as trim-compatible.

Modifications
-------------
Automatically mark generated assemblies as trim compatible when:

- The target is .NET 6 or higher
- All extensions used are trim compatible, or no extensions are used

For now, only the MicrosoftExtensionsHttp extension produces trim-compatible code.

Results
-------
Assemblies produced without JSON serialization are trim-compatible. Further work will need to be done to make System.Text.Json compatible.