### PR TITLE
Load source generators from framework references

### DIFF
--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -6,9 +6,9 @@ mkdir -p ./bin
 curl -sSL https://api.adv.centeredge.io/v1/swagger/api/swagger.json -o ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
-    restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/
+    restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 net7.0 --intermediate-dir ./obj/
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
-    generate --no-restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 --embed --intermediate-dir ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
+    generate --no-restore -n TestSTJ -x src/main/Yardarm.SystemTextJson/bin/Release/net6.0/Yardarm.SystemTextJson.dll -f netstandard2.0 net6.0 net7.0 --embed --intermediate-dir ./obj/ --nupkg ./bin/ -v 1.0.0 -i ./bin/mashtub.json
 
 dotnet run --no-build --no-launch-profile -c Release --project src/main/Yardarm.CommandLine -- \
     restore -n TestNJ -x src/main/Yardarm.NewtonsoftJson/bin/Release/net6.0/Yardarm.NewtonsoftJson.dll -f netstandard2.0 net6.0 --intermediate-dir ./obj/

--- a/src/main/Yardarm/Packaging/Internal/NuGetExtensions.cs
+++ b/src/main/Yardarm/Packaging/Internal/NuGetExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NuGet.Commands;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace Yardarm.Packaging.Internal
+{
+    internal static class NuGetExtensions
+    {
+        public static IEnumerable<string> GetFrameworkReferenceDirectories(
+            this TargetFrameworkInformation frameworkInformation, NuGetRestoreInfo restoreInfo) =>
+            frameworkInformation.GetFrameworkReferenceDirectories(restoreInfo.Providers);
+
+        public static IEnumerable<string> GetFrameworkReferenceDirectories(
+            this TargetFrameworkInformation frameworkInformation, RestoreCommandProviders providers) =>
+            frameworkInformation.FrameworkReferences
+                .Select(frameworkReference =>
+                {
+                    string refAssemblyName = $"{frameworkReference.Name}.Ref";
+
+                    var version = frameworkInformation.FrameworkName.Version;
+                    var versionRange = new VersionRange(
+                        new NuGetVersion(version),
+                        maxVersion: new NuGetVersion(version.Major, version.Minor + 1, 0),
+                        includeMaxVersion: false);
+
+                    return providers.GlobalPackages.FindPackagesById(refAssemblyName)
+                        .Where(package => versionRange.Satisfies(package.Version))
+                        .MaxBy(package => package.Version)?.ExpandedPath;
+                })
+                .Where(directory => directory is not null)!;
+    }
+}

--- a/src/main/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
+++ b/src/main/Yardarm/Packaging/Internal/NuGetReferenceGenerator.cs
@@ -62,22 +62,8 @@ namespace Yardarm.Packaging.Internal
                 .First(p => p.FrameworkName == _context.CurrentTargetFramework);
 
             // Collect platform reference assemblies, i.e. .NET 6 assemblies
-            dependencies.AddRange(frameworkInformation.FrameworkReferences
-                .Select(frameworkReference =>
-                {
-                    string refAssemblyName = $"{frameworkReference.Name}.Ref";
-
-                    var version = frameworkInformation.FrameworkName.Version;
-                    var versionRange = new VersionRange(
-                        new NuGetVersion(version),
-                        maxVersion: new NuGetVersion(version.Major, version.Minor + 1, 0),
-                        includeMaxVersion: false);
-
-                    return _context.NuGetRestoreInfo!.Providers.GlobalPackages.FindPackagesById(refAssemblyName)
-                        .Where(package => versionRange.Satisfies(package.Version))
-                        .MaxBy(package => package.Version)?.ExpandedPath;
-                })
-                .Where(directory => directory is not null)
+            dependencies.AddRange(frameworkInformation
+                .GetFrameworkReferenceDirectories(_context.NuGetRestoreInfo!)
                 .SelectMany(directory =>
                     Directory.GetFiles(directory!, "*.dll", new EnumerationOptions
                     {

--- a/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -1,25 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.Loader;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Logging;
 using NuGet.Commands;
 using NuGet.Configuration;
-using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.Packaging.Signing;
 using NuGet.ProjectModel;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Repositories;
-using NuGet.Versioning;
 using Yardarm.Generation.Internal;
 
 namespace Yardarm.Packaging.Internal
@@ -133,161 +123,6 @@ namespace Yardarm.Packaging.Internal
                 {
                     Directory.Delete(intermediatePath, true);
                 }
-            }
-        }
-
-        // Collect C# source generators from the direct NuGet dependencies (ignores transitive dependencies)
-        public IEnumerable<ISourceGenerator> GetSourceGenerators(RestoreCommandProviders dependencyProviders, LockFile lockFile,
-            NuGetFramework targetFramework, AssemblyLoadContext assemblyLoadContext)
-        {
-            LockFileTarget? lockFileTarget = lockFile.Targets?
-                .FirstOrDefault(p => p.TargetFramework == targetFramework);
-            if (lockFileTarget is null)
-            {
-                yield break;
-            }
-
-            TargetFrameworkInformation? frameworkInformation = _packageSpec.TargetFrameworks
-                .FirstOrDefault(p => p.FrameworkName == targetFramework);
-
-            foreach (LibraryDependency directDependency in _packageSpec.Dependencies
-                         .Concat(frameworkInformation?.Dependencies ?? Enumerable.Empty<LibraryDependency>()))
-            {
-                // Get the exact version we restored
-                NuGetVersion? version = lockFileTarget.Libraries
-                    .FirstOrDefault(p => string.Equals(p.Name, directDependency.Name, StringComparison.OrdinalIgnoreCase))?
-                    .Version;
-                if (version is not null)
-                {
-                    NuGet.Repositories.LocalPackageInfo localPackageInfo =
-                        dependencyProviders.GlobalPackages.FindPackage(directDependency.Name, version);
-
-                    foreach (ISourceGenerator generator in GetSourceGenerators(localPackageInfo.ExpandedPath, localPackageInfo.Files, assemblyLoadContext))
-                    {
-                        yield return generator;
-                    }
-                }
-            }
-
-            if (frameworkInformation is not null)
-            {
-                foreach (string frameworkDirectory in frameworkInformation.GetFrameworkReferenceDirectories(
-                             dependencyProviders))
-                {
-                    string[] files = Directory.GetFiles(frameworkDirectory, "*.dll",
-                        new EnumerationOptions {IgnoreInaccessible = true, RecurseSubdirectories = true});
-
-                    IEnumerable<string> relativeFilePaths = files.Select(
-                        p => Path.GetRelativePath(frameworkDirectory, p));
-
-                    foreach (ISourceGenerator generator in GetSourceGenerators(frameworkDirectory, relativeFilePaths, assemblyLoadContext))
-                    {
-                        yield return generator;
-                    }
-                }
-            }
-        }
-
-        private static IEnumerable<ISourceGenerator> GetSourceGenerators(string basePath, IEnumerable<string> files,
-            AssemblyLoadContext assemblyLoadContext)
-        {
-            // Find the highest version of Roslyn listed in the package that is less than equal to
-            // the version of Roslyn we are using. Failing that, fallback to include unversioned
-            // analyzers.
-
-            // Determine the version of Roslyn we are using
-            Version roslynVersion = typeof(CSharpCompilation).Assembly.GetName().Version!;
-
-            IEnumerable<Match> analyzerFiles = files
-                .Select(p => Regex.Match(p, @"^(analyzers[/\\]dotnet[/\\](?:roslyn(\d+\.\d+)[/\\])?cs[/\\][^/\\]+\.dll$)"))
-                .Where(p => p.Success);
-
-            var filesGroupedByVersion = analyzerFiles
-                .Select(p =>
-                {
-                    if (p.Groups[2].Success)
-                    {
-                        Version.TryParse(p.Groups[2].Value, out Version? parsedVersion);
-
-                        return (Version: parsedVersion, File: p.Groups[1].Value);
-                    }
-                    else
-                    {
-                        return (Version: new Version(0, 0), File: p.Groups[1].Value);
-                    }
-                })
-                .Where(p => p.Version is not null)
-                .GroupBy(p => p.Version!)
-                .OrderByDescending(p => p.Key);
-
-            var bestMatch = filesGroupedByVersion
-                .FirstOrDefault(p => p.Key <= roslynVersion);
-
-            if (bestMatch is not null)
-            {
-                foreach (ISourceGenerator generator in bestMatch
-                             .SelectMany(p => GetSourceGenerators(
-                                 Path.Join(basePath, p.File),
-                                 assemblyLoadContext)))
-                {
-                    yield return generator;
-                }
-            }
-        }
-
-        // Instantiate source generators from an analyzer assembly
-        private static IEnumerable<ISourceGenerator> GetSourceGenerators(string file, AssemblyLoadContext assemblyLoadContext)
-        {
-            using var resolver = new PathAssemblyResolver(assemblyLoadContext, Path.GetDirectoryName(file)!);
-
-            var assembly = assemblyLoadContext.LoadFromAssemblyPath(file);
-
-            var generatorTypes = assembly.ExportedTypes.Where(p =>
-                p.IsClass && !p.IsGenericTypeDefinition && !p.IsAbstract
-                && p.GetCustomAttribute<GeneratorAttribute>() != null);
-
-            foreach (var generatorType in generatorTypes)
-            {
-                switch (Activator.CreateInstance(generatorType))
-                {
-                    case ISourceGenerator sourceGenerator:
-                        yield return sourceGenerator;
-                        break;
-
-                    case IIncrementalGenerator incrementalGenerator:
-                        yield return incrementalGenerator.AsSourceGenerator();
-                        break;
-                }
-            }
-        }
-
-        private class PathAssemblyResolver : IDisposable
-        {
-            private readonly AssemblyLoadContext _assemblyLoadContext;
-            private readonly string _basePath;
-
-            public PathAssemblyResolver(AssemblyLoadContext assemblyLoadContext, string basePath)
-            {
-                _assemblyLoadContext = assemblyLoadContext;
-                _basePath = basePath;
-
-                _assemblyLoadContext.Resolving += Resolving;
-            }
-
-            private Assembly? Resolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
-            {
-                string fileName = Path.Combine(_basePath, $"{assemblyName.Name}.dll");
-                if (File.Exists(fileName))
-                {
-                    return assemblyLoadContext.LoadFromAssemblyPath(fileName);
-                }
-
-                return null;
-            }
-
-            public void Dispose()
-            {
-                _assemblyLoadContext.Resolving -= Resolving;
             }
         }
     }

--- a/src/main/Yardarm/Packaging/Internal/SourceGeneratorLoadContext.cs
+++ b/src/main/Yardarm/Packaging/Internal/SourceGeneratorLoadContext.cs
@@ -1,0 +1,205 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using NuGet.Commands;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+
+namespace Yardarm.Packaging.Internal
+{
+    internal class SourceGeneratorLoadContext : IDisposable
+    {
+        private readonly RestoreCommandProviders _dependencyProviders;
+        private readonly AssemblyLoadContext _assemblyLoadContext = new(null, true);
+        private string? _loadBasePath;
+        private bool _disposed;
+
+        public SourceGeneratorLoadContext(RestoreCommandProviders dependencyProviders)
+        {
+            ArgumentNullException.ThrowIfNull(dependencyProviders);
+            _dependencyProviders = dependencyProviders;
+
+            _assemblyLoadContext.Resolving += Resolving;
+        }
+
+        // Collect C# source generators from the direct NuGet dependencies (ignores transitive dependencies)
+        public IEnumerable<ISourceGenerator> GetSourceGenerators(PackageSpec packageSpec, LockFile lockFile, NuGetFramework targetFramework)
+        {
+            LockFileTarget? lockFileTarget = lockFile.Targets?
+                .FirstOrDefault(p => p.TargetFramework == targetFramework);
+            if (lockFileTarget is null)
+            {
+                yield break;
+            }
+
+            TargetFrameworkInformation? frameworkInformation = packageSpec.TargetFrameworks
+                .FirstOrDefault(p => p.FrameworkName == targetFramework);
+
+            foreach (LibraryDependency directDependency in packageSpec.Dependencies
+                         .Concat(frameworkInformation?.Dependencies ?? Enumerable.Empty<LibraryDependency>()))
+            {
+                // Get the exact version we restored
+                NuGetVersion? version = lockFileTarget.Libraries
+                    .FirstOrDefault(p => string.Equals(p.Name, directDependency.Name, StringComparison.OrdinalIgnoreCase))?
+                    .Version;
+                if (version is not null)
+                {
+                    NuGet.Repositories.LocalPackageInfo localPackageInfo =
+                        _dependencyProviders.GlobalPackages.FindPackage(directDependency.Name, version);
+
+                    foreach (ISourceGenerator generator in GetSourceGenerators(localPackageInfo.ExpandedPath, localPackageInfo.Files))
+                    {
+                        yield return generator;
+                    }
+                }
+            }
+
+            // Load analyzers built into the target framework. Note that we load these second in case a NuGet package
+            // is overriding one with a newer version.
+            if (frameworkInformation is not null)
+            {
+                foreach (string frameworkDirectory in frameworkInformation.GetFrameworkReferenceDirectories(
+                             _dependencyProviders))
+                {
+                    string[] files = Directory.GetFiles(frameworkDirectory, "*.dll",
+                        new EnumerationOptions {IgnoreInaccessible = true, RecurseSubdirectories = true});
+
+                    IEnumerable<string> relativeFilePaths = files.Select(
+                        p => Path.GetRelativePath(frameworkDirectory, p));
+
+                    foreach (ISourceGenerator generator in GetSourceGenerators(frameworkDirectory, relativeFilePaths))
+                    {
+                        yield return generator;
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<ISourceGenerator> GetSourceGenerators(string basePath, IEnumerable<string> files)
+        {
+            // Find the highest version of Roslyn listed in the package that is less than equal to
+            // the version of Roslyn we are using. Failing that, fallback to include unversioned
+            // analyzers.
+
+            // Determine the version of Roslyn we are using
+            Version roslynVersion = typeof(CSharpCompilation).Assembly.GetName().Version!;
+
+            IEnumerable<Match> analyzerFiles = files
+                .Select(p => Regex.Match(p, @"^(analyzers[/\\]dotnet[/\\](?:roslyn(\d+\.\d+)[/\\])?cs[/\\][^/\\]+\.dll$)"))
+                .Where(p => p.Success);
+
+            var filesGroupedByVersion = analyzerFiles
+                .Select(p =>
+                {
+                    if (p.Groups[2].Success)
+                    {
+                        Version.TryParse(p.Groups[2].Value, out Version? parsedVersion);
+
+                        return (Version: parsedVersion, File: p.Groups[1].Value);
+                    }
+                    else
+                    {
+                        return (Version: new Version(0, 0), File: p.Groups[1].Value);
+                    }
+                })
+                .Where(p => p.Version is not null)
+                .GroupBy(p => p.Version!)
+                .OrderByDescending(p => p.Key);
+
+            var bestMatch = filesGroupedByVersion
+                .FirstOrDefault(p => p.Key <= roslynVersion);
+
+            if (bestMatch is not null)
+            {
+                foreach (ISourceGenerator generator in bestMatch
+                             .SelectMany(p => GetSourceGenerators(
+                                 Path.Join(basePath, p.File))))
+                {
+                    yield return generator;
+                }
+            }
+        }
+
+        // Instantiate source generators from an analyzer assembly
+        private IEnumerable<ISourceGenerator> GetSourceGenerators(string file)
+        {
+            if (_assemblyLoadContext.Assemblies.Any(p => p.GetName().Name == Path.GetFileNameWithoutExtension(file)))
+            {
+                // Don't reload the same assembly, just keep the first version we load
+                yield break;
+            }
+
+            _loadBasePath = Path.GetDirectoryName(file)!;
+            try
+            {
+                var assembly = _assemblyLoadContext.LoadFromAssemblyPath(file);
+
+                var generatorTypes = assembly.ExportedTypes.Where(p =>
+                    p.IsClass && !p.IsGenericTypeDefinition && !p.IsAbstract
+                    && p.GetCustomAttribute<GeneratorAttribute>() != null);
+
+                foreach (var generatorType in generatorTypes)
+                {
+                    switch (Activator.CreateInstance(generatorType))
+                    {
+                        case ISourceGenerator sourceGenerator:
+                            yield return sourceGenerator;
+                            break;
+
+                        case IIncrementalGenerator incrementalGenerator:
+                            yield return incrementalGenerator.AsSourceGenerator();
+                            break;
+                    }
+                }
+            }
+            finally
+            {
+                _loadBasePath = null;
+            }
+        }
+
+        private Assembly? Resolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
+        {
+            // Try to load missing dependencies from the same directory as the file we're currently loading.
+            if (_loadBasePath is not null)
+            {
+                string fileName = Path.Combine(_loadBasePath, $"{assemblyName.Name}.dll");
+                if (File.Exists(fileName))
+                {
+                    return assemblyLoadContext.LoadFromAssemblyPath(fileName);
+                }
+            }
+
+            return null;
+        }
+
+        ~SourceGeneratorLoadContext()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                _assemblyLoadContext.Resolving -= Resolving;
+                _assemblyLoadContext.Unload();
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/main/Yardarm/YardarmGenerator.cs
+++ b/src/main/Yardarm/YardarmGenerator.cs
@@ -133,7 +133,8 @@ namespace Yardarm
             {
                 var sourceGenerators = context.GenerationServices.GetRequiredService<NuGetRestoreProcessor>()
                     .GetSourceGenerators(context.NuGetRestoreInfo!.Providers, context.NuGetRestoreInfo!.LockFile,
-                        targetFramework, assemblyLoadContext);
+                        targetFramework, assemblyLoadContext)
+                    .ToList();
 
                 // Execute the source generators
                 compilation = ExecuteSourceGenerators(compilation,


### PR DESCRIPTION
Motivation
----------
Source generators built into .NET 7 aren't being loaded when targeting .NET 7.

Modifications
-------------
- Move some logic from NuGetReferenceGenerator into a shared extension
- Split source generation loading into a separate class
- Load source generators from framework references
- Prevent duplicate loads from packages and framework references
- When loading source generators also allow them to resolve additional assemblies from the same directory (required for loading Microsoft.Interop.SourceGeneration.dll)