### PR TITLE
Apply trimming attrs to all target frameworks

### DIFF
--- a/src/main/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
+++ b/src/main/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
@@ -7,11 +7,7 @@ using System.Reflection;
 
 namespace RootNamespace.Authentication.Internal
 {
-    internal class SecuritySchemeSetRegistry<
-#if NET6_0_OR_GREATER
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
-#endif
-        T>
+    internal class SecuritySchemeSetRegistry<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>
     {
         private static readonly Dictionary<Type, PropertyInfo> _schemes =
             typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
@@ -8,11 +8,7 @@ namespace RootNamespace.Serialization
 {
     internal class PathSegmentSerializer
     {
-        public static string Serialize<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, string? format = null) =>
+        public static string Serialize<T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, string? format = null) =>
             style switch
             {
                 PathSegmentStyle.Simple => SerializeSimple(value, format),
@@ -21,11 +17,7 @@ namespace RootNamespace.Serialization
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
 
-        public static string SerializeList<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(string name, IEnumerable<T> values, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false, string? format = null) =>
+        public static string SerializeList<T>(string name, IEnumerable<T> values, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false, string? format = null) =>
             style switch
             {
                 PathSegmentStyle.Simple => LiteralSerializer.Instance.JoinList(",", values,  format),
@@ -35,11 +27,7 @@ namespace RootNamespace.Serialization
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
 
-        private static string SerializeSimple<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(T value, string? format = null)
+        private static string SerializeSimple<T>(T value, string? format = null)
         {
             if (value is null)
             {
@@ -55,11 +43,7 @@ namespace RootNamespace.Serialization
             return LiteralSerializer.Instance.Serialize(value, format);
         }
 
-        private static string SerializeLabel<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(T value, string? format)
+        private static string SerializeLabel<T>(T value, string? format)
         {
             if (value is null)
             {
@@ -75,11 +59,7 @@ namespace RootNamespace.Serialization
             return "." + LiteralSerializer.Instance.Serialize(value, format);
         }
 
-        private static string SerializeMatrix<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            T>(string name, T value, string? format)
+        private static string SerializeMatrix<T>(string name, T value, string? format)
         {
             if (value is null)
             {

--- a/src/main/Yardarm.Client/Serialization/SerializationHelpers.cs
+++ b/src/main/Yardarm.Client/Serialization/SerializationHelpers.cs
@@ -9,10 +9,7 @@ namespace RootNamespace.Serialization
     internal static class SerializationHelpers
     {
         public static bool IsEnumerable(
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-#endif
-            Type type,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type type,
             [NotNullWhen(true)] out Type? itemType)
         {
             itemType = null;

--- a/src/main/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
+++ b/src/main/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
@@ -32,29 +32,18 @@ namespace RootNamespace.Serialization
             return typeSerializerRegistry;
         }
 
-        public static ITypeSerializerRegistry Add<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            T>(this ITypeSerializerRegistry typeSerializerRegistry,
-            IEnumerable<string> mediaTypes)
+        public static ITypeSerializerRegistry Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+            this ITypeSerializerRegistry typeSerializerRegistry, IEnumerable<string> mediaTypes)
             where T : ITypeSerializer =>
             typeSerializerRegistry.Add<T>(mediaTypes, null);
 
-        public static ITypeSerializerRegistry Add<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            T>(this ITypeSerializerRegistry typeSerializerRegistry,
-            IEnumerable<Type> schemaTypes)
+        public static ITypeSerializerRegistry Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+            this ITypeSerializerRegistry typeSerializerRegistry, IEnumerable<Type> schemaTypes)
             where T : ITypeSerializer =>
             typeSerializerRegistry.Add<T>(null, schemaTypes);
 
-        internal static ITypeSerializerRegistry Add<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            T>(this ITypeSerializerRegistry typeSerializerRegistry,
+        internal static ITypeSerializerRegistry Add<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(
+            this ITypeSerializerRegistry typeSerializerRegistry,
             IEnumerable<string>? mediaTypes = null,
             IEnumerable<Type>? schemaTypes = null)
             where T : ITypeSerializer

--- a/src/main/Yardarm.Client/Trimming/DynamicDependencyAttribute.cs
+++ b/src/main/Yardarm.Client/Trimming/DynamicDependencyAttribute.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// States a dependency that one member has on another.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to inform tooling of a dependency that is otherwise not evident purely from
+    /// metadata and IL, for example a member relied on via reflection.
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Method,
+        AllowMultiple = true, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class DynamicDependencyAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified signature of a member on the same type as the consumer.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        public DynamicDependencyAttribute(string memberSignature)
+        {
+            MemberSignature = memberSignature;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified signature of a member on a <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        /// <param name="type">The <see cref="System.Type"/> containing <paramref name="memberSignature"/>.</param>
+        public DynamicDependencyAttribute(string memberSignature, Type type)
+        {
+            MemberSignature = memberSignature;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified signature of a member on a type in an assembly.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        /// <param name="typeName">The full name of the type containing the specified member.</param>
+        /// <param name="assemblyName">The assembly name of the type containing the specified member.</param>
+        public DynamicDependencyAttribute(string memberSignature, string typeName, string assemblyName)
+        {
+            MemberSignature = memberSignature;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified types of members on a <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="memberTypes">The types of members depended on.</param>
+        /// <param name="type">The <see cref="System.Type"/> containing the specified members.</param>
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, Type type)
+        {
+            MemberTypes = memberTypes;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified types of members on a type in an assembly.
+        /// </summary>
+        /// <param name="memberTypes">The types of members depended on.</param>
+        /// <param name="typeName">The full name of the type containing the specified members.</param>
+        /// <param name="assemblyName">The assembly name of the type containing the specified members.</param>
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName)
+        {
+            MemberTypes = memberTypes;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Gets the signature of the member depended on.
+        /// </summary>
+        /// <remarks>
+        /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
+        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// </remarks>
+        public string? MemberSignature { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members depended on.
+        /// </summary>
+        /// <remarks>
+        /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
+        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// </remarks>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+
+        /// <summary>
+        /// Gets the <see cref="System.Type"/> containing the specified member.
+        /// </summary>
+        /// <remarks>
+        /// If neither <see cref="Type"/> nor <see cref="TypeName"/> are specified,
+        /// the type of the consumer is assumed.
+        /// </remarks>
+        public Type? Type { get; }
+
+        /// <summary>
+        /// Gets the full name of the type containing the specified member.
+        /// </summary>
+        /// <remarks>
+        /// If neither <see cref="Type"/> nor <see cref="TypeName"/> are specified,
+        /// the type of the consumer is assumed.
+        /// </remarks>
+        public string? TypeName { get; }
+
+        /// <summary>
+        /// Gets the assembly name of the specified type.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AssemblyName"/> is only valid when <see cref="TypeName"/> is specified.
+        /// </remarks>
+        public string? AssemblyName { get; }
+
+        /// <summary>
+        /// Gets or sets the condition in which the dependency is applicable, e.g. "DEBUG".
+        /// </summary>
+        public string? Condition { get; set; }
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Trimming/DynamicallyAccessedMemberTypes.cs
+++ b/src/main/Yardarm.Client/Trimming/DynamicallyAccessedMemberTypes.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Trimming/DynamicallyAccessedMembersAttribute.cs
+++ b/src/main/Yardarm.Client/Trimming/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    ///
+    /// When this attribute is applied to a class, interface, or struct, the members specified
+    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Trimming/RequiresDynamicCodeAttribute.cs
+++ b/src/main/Yardarm.Client/Trimming/RequiresDynamicCodeAttribute.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET7_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the specified method requires the ability to generate new code at runtime,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which methods are unsafe to call when compiling ahead of time.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class RequiresDynamicCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresDynamicCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of dynamic code.
+        /// </param>
+        public RequiresDynamicCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of dynamic code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires dynamic code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Trimming/RequiresUnreferencedCodeAttribute.cs
+++ b/src/main/Yardarm.Client/Trimming/RequiresUnreferencedCodeAttribute.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the specified method requires dynamic access to code that is not referenced
+    /// statically, for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which methods are unsafe to call when removing unreferenced
+    /// code from an application.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+        sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of unreferenced code.
+        /// </param>
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of unreferenced code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires unreferenced code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string? Url { get; set; }
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Trimming/UnconditionalSuppressMessageAttribute.cs
+++ b/src/main/Yardarm.Client/Trimming/UnconditionalSuppressMessageAttribute.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string? Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string? MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string? Justification { get; set; }
+    }
+}
+
+#endif

--- a/src/main/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/main/Yardarm.Client/Yardarm.Client.csproj
@@ -1,12 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>RootNamespace</RootNamespace>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
+
     <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>
   </PropertyGroup>
 

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/ApiBuilderExtensions.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/ApiBuilderExtensions.cs
@@ -71,11 +71,8 @@ namespace RootNamespace
         /// <typeparamref name="TClient"/> as the service type.
         /// </para>
         /// </remarks>
-        public static IApiBuilder AddApi<TClient,
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            TImplementation>(this IApiBuilder builder,
+        public static IApiBuilder AddApi<TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            this IApiBuilder builder,
             Action<IHttpClientBuilder>? configureClient = null)
             where TClient : class, IApi
             where TImplementation : class, TClient
@@ -111,11 +108,8 @@ namespace RootNamespace
         /// can be retrieved from <see cref="IHttpClientFactory" /> by providing the <paramref name="name"/>.
         /// </para>
         /// </remarks>
-        public static IApiBuilder AddApi<
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            TClient>(this IApiBuilder builder,
+        public static IApiBuilder AddApi<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TClient>(
+            this IApiBuilder builder,
             string name,
             Action<IHttpClientBuilder>? configureClient = null)
             where TClient : class
@@ -142,11 +136,8 @@ namespace RootNamespace
         }
 
         // Internal implementation used by AddAllApisInternal
-        private static void AddApi<TClient,
-#if NET6_0_OR_GREATER
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
-#endif
-            TImplementation>(this IApiBuilder builder,
+        private static void AddApi<TClient, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(
+            this IApiBuilder builder,
             Action<Type, IHttpClientBuilder>? configureClient,
             bool skipIfAlreadyRegistered)
             where TClient : class, IApi

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
@@ -7,6 +7,7 @@
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some authors may want to only generate a netstandard2.0 target but would like it to be consumed by a net6.0 or net7.0 target that is trimmed. This will allow that use case.