### PR TITLE
Make STJ converters compatible with trimming

### DIFF
--- a/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
@@ -3,4 +3,5 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Yardarm.Client.UnitTests")]
 [assembly: InternalsVisibleTo("Yardarm.MicrosoftExtensionsHttp.Client")]
+[assembly: InternalsVisibleTo("Yardarm.SystemTextJson.Client")]
 #endif

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonDateConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonDateConverter.cs
@@ -16,7 +16,10 @@ namespace RootNamespace.Serialization.Json
         private const int FormatLength = 10;
         private const int MaxEscapedFormatLength = FormatLength * 6;
 
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            Read(ref reader);
+
+        public static DateTime Read(ref Utf8JsonReader reader)
         {
             if (reader.TokenType != JsonTokenType.String)
             {
@@ -47,6 +50,9 @@ namespace RootNamespace.Serialization.Json
         }
 
         public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+            => Write(writer, value);
+
+        public static void Write(Utf8JsonWriter writer, DateTime value)
         {
 #if NET6_0_OR_GREATER
             Span<char> buffer = stackalloc char[FormatLength];

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonHelpers.cs
@@ -68,7 +68,7 @@ namespace RootNamespace.Serialization.Json
         }
 
         [DoesNotReturn]
-        private static void ThrowJsonException()
+        public static void ThrowJsonException()
         {
             throw new JsonException();
         }

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonNullableDateConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonNullableDateConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RootNamespace.Serialization.Json
+{
+    // This variant is only required until https://github.com/dotnet/runtime/issues/81833
+    // has been fixed.
+
+    /// <summary>
+    /// Handles reading and writing date-only JSON to and from nullable <see cref="DateTime"/> properties.
+    /// </summary>
+    internal sealed class JsonNullableDateConverter : JsonConverter<DateTime?>
+    {
+        public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            return JsonDateConverter.Read(ref reader);
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                JsonDateConverter.Write(writer, value.Value);
+            }
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonStringEnumConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
@@ -8,8 +9,8 @@ using System.Text.Json.Serialization;
 
 namespace RootNamespace.Serialization.Json
 {
-    internal class JsonStringEnumConverter<T> : JsonConverter<T>
-        where T : Enum
+    internal class JsonStringEnumConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T> : JsonConverter<T>
+        where T : struct, Enum
     {
         private static readonly TypeCode _enumTypeCode = Type.GetTypeCode(typeof(T));
 
@@ -33,7 +34,7 @@ namespace RootNamespace.Serialization.Json
             }
         }
 
-        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             switch (reader.TokenType)
             {
@@ -98,10 +99,11 @@ namespace RootNamespace.Serialization.Json
                             break;
                     }
 
-                    throw new JsonException();
+                    break;
             }
 
-            return default;
+            JsonHelpers.ThrowJsonException();
+            return default!; // unreachable
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
@@ -139,7 +141,8 @@ namespace RootNamespace.Serialization.Json
                     writer.WriteNumberValue(Unsafe.As<T, sbyte>(ref value));
                     break;
                 default:
-                    throw new JsonException();
+                    JsonHelpers.ThrowJsonException();
+                    break;
             }
         }
     }

--- a/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
@@ -6,6 +6,7 @@ namespace Yardarm.SystemTextJson
     {
         NameSyntax Name { get; }
         NameSyntax JsonDateConverter { get; }
+        NameSyntax JsonNullableDateConverter { get; }
         NameSyntax JsonTypeSerializer { get; }
 
         TypeSyntax JsonStringEnumConverter(TypeSyntax valueType);

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
@@ -10,6 +10,7 @@ namespace Yardarm.SystemTextJson.Internal
     {
         public NameSyntax Name { get; }
         public NameSyntax JsonDateConverter { get; }
+        public NameSyntax JsonNullableDateConverter { get; }
         public NameSyntax JsonTypeSerializer { get; }
         public NameSyntax JsonHelpers { get; }
 
@@ -27,6 +28,10 @@ namespace Yardarm.SystemTextJson.Internal
             JsonDateConverter = QualifiedName(
                 Name,
                 IdentifierName("JsonDateConverter"));
+
+            JsonNullableDateConverter = QualifiedName(
+                Name,
+                IdentifierName("JsonNullableDateConverter"));
 
             JsonTypeSerializer = QualifiedName(
                 Name,

--- a/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
@@ -63,7 +63,9 @@ namespace Yardarm.SystemTextJson
                 .AddAttributeLists(AttributeList(SingletonSeparatedList(
                     Attribute(SystemTextJsonTypes.Serialization.JsonConverterAttributeName,
                         AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
-                            SyntaxFactory.TypeOfExpression(_serializationNamespace.JsonDateConverter))))))))
+                            TypeOfExpression(syntax.Type is NullableTypeSyntax
+                                ? _serializationNamespace.JsonNullableDateConverter
+                                : _serializationNamespace.JsonDateConverter))))))))
                     .WithTrailingTrivia(ElasticCarriageReturnLineFeed);
 
         private static bool IsDateTime(INamedTypeSymbol? type)


### PR DESCRIPTION
- Implement a nullable variant of the JsonDateConverter to work around a limitation with source generation
- Cleanup JsonStringEnumConverter and add trimming annotations