### PR TITLE
Add back missing JsonExtensionData attribute

### DIFF
--- a/src/main/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonAdditionalPropertiesEnricher.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+using Yardarm.Enrichment;
+using Yardarm.Enrichment.Schema;
+using Yardarm.Generation;
+using Yardarm.Spec;
+using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    /// <summary>
+    /// Updates additional properties members with the <see cref="JsonExtensionDataAttribute" />.
+    /// </summary>
+    public class JsonAdditionalPropertiesEnricher : IOpenApiSyntaxNodeEnricher<CompilationUnitSyntax, OpenApiSchema>
+    {
+        public Type[] ExecuteAfter { get; } =
+        {
+            typeof(AdditionalPropertiesEnricher)
+        };
+
+        private readonly IOpenApiElementRegistry _elementRegistry;
+
+        public JsonAdditionalPropertiesEnricher(IOpenApiElementRegistry elementRegistry)
+        {
+            ArgumentNullException.ThrowIfNull(elementRegistry);
+            _elementRegistry = elementRegistry;
+        }
+
+        public CompilationUnitSyntax Enrich(CompilationUnitSyntax target,
+            OpenApiEnrichmentContext<OpenApiSchema> context)
+        {
+            var members = target
+                .GetSpecialMembers(SpecialMembers.AdditionalProperties)
+                .OfType<PropertyDeclarationSyntax>()
+                .Where(p => p.Parent is ClassDeclarationSyntax classDeclaration && _elementRegistry.IsJsonSchema(classDeclaration))
+                .ToArray();
+
+            if (members.Length == 0)
+            {
+                return target;
+            }
+
+            target = target.TrackNodes((IEnumerable<PropertyDeclarationSyntax>) members);
+
+            return members.Aggregate(target,
+                (current, member) => current.ReplaceNode(current.GetCurrentNode(member)!, AddAttribute(member)));
+        }
+
+        private PropertyDeclarationSyntax AddAttribute(PropertyDeclarationSyntax property)
+        {
+            var dictionaryType = property.Type;
+
+            if (dictionaryType is QualifiedNameSyntax qualifiedName)
+            {
+                dictionaryType = qualifiedName.Right;
+            }
+
+            if (dictionaryType is not GenericNameSyntax genericName)
+            {
+                // Don't mutate
+                return property;
+            }
+
+            return property
+                // We must have a setter for JsonExtensionData to work with System.Text.Json
+                .WithAccessorList(AccessorList(property.AccessorList!.Accessors.Add(
+                    AccessorDeclaration(
+                        SyntaxKind.SetAccessorDeclaration,
+                        default,
+                        default,
+                        Token(SyntaxKind.SetKeyword),
+                        null,
+                        null,
+                        Token(SyntaxKind.SemicolonToken)))))
+                // Add the JsonExtensionData attribute
+                .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                Attribute(SystemTextJsonTypes.Serialization.JsonExtensionDataAttributeName)))
+                    .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -20,6 +20,7 @@ namespace Yardarm.SystemTextJson
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonNodeEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()

--- a/src/main/Yardarm/Enrichment/Schema/AdditionalPropertiesEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Schema/AdditionalPropertiesEnricher.cs
@@ -111,13 +111,24 @@ namespace Yardarm.Enrichment.Schema
         private MemberDeclarationSyntax GenerateAdditionalPropertiesMembers(TypeSyntax dictionaryType, TypeSyntax interfaceType,
             string propertyName, bool isShadowing)
         {
-            var property = PropertyDeclaration(interfaceType, Identifier(propertyName))
-                .AddSpecialMemberAnnotation(SpecialMembers.AdditionalProperties)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)))
-                .WithInitializer(EqualsValueClause(ObjectCreationExpression(dictionaryType)));
+            var property = PropertyDeclaration(
+                    default,
+                    TokenList(Token(SyntaxKind.PublicKeyword)),
+                    interfaceType,
+                    null,
+                    Identifier(propertyName),
+                    AccessorList(SingletonList(AccessorDeclaration(
+                        SyntaxKind.GetAccessorDeclaration,
+                        default,
+                        default,
+                        Token(SyntaxKind.GetKeyword),
+                        null,
+                        null,
+                        Token(SyntaxKind.SemicolonToken)))),
+                    null,
+                    EqualsValueClause(ObjectCreationExpression(dictionaryType, ArgumentList(), null)),
+                    Token(SyntaxKind.SemicolonToken))
+                .AddSpecialMemberAnnotation(SpecialMembers.AdditionalProperties);
 
             if (isShadowing)
             {


### PR DESCRIPTION
This was accidentally removed when we removed dynamic, we should have only removed the dynamic to object replacement not the attribute.