### PR TITLE
Make STJ discriminators trim and AOT compatible

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+    <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
@@ -30,7 +30,9 @@
     <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
 
     <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <None Include="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <None Include="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>
 
 </Project>

--- a/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -66,6 +66,10 @@ namespace Yardarm.SystemTextJson.Helpers
                 SystemTextJson,
                 IdentifierName("Serialization"));
 
+            public static NameSyntax JsonDerivedTypeAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonDerivedTypeAttribute"));
+
             public static NameSyntax JsonExtensionDataAttributeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonExtensionDataAttribute"));
@@ -73,6 +77,10 @@ namespace Yardarm.SystemTextJson.Helpers
             public static NameSyntax JsonIgnoreAttributeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonIgnoreAttribute"));
+
+            public static NameSyntax JsonPolymorphicAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonPolymorphicAttribute"));
 
             public static class JsonIgnoreCondition
             {

--- a/src/main/Yardarm.SystemTextJson/Internal/SchemaHelper.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/SchemaHelper.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
 using Yardarm.Spec;
 
@@ -43,5 +45,70 @@ namespace Yardarm.SystemTextJson.Internal
 
         private static bool IsJsonMediaType(string mediaType) =>
             mediaType.EndsWith("/json") || mediaType.EndsWith("+json");
+
+        /// <summary>
+        /// Collects a list of all discriminator keys and their relevant C# type.
+        /// </summary>
+        public static IEnumerable<(string key, TypeSyntax typeName)> GetDiscriminatorMappings(GenerationContext context,
+            ILocatedOpenApiElement<OpenApiSchema> element) =>
+            GetMappings(context, element)
+                .Select(p => (p.Key, context.TypeGeneratorRegistry.Get(p.Schema).TypeInfo.Name))
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                .Where(p => p.Item2 != null);
+
+        /// <summary>
+        /// Collects the list of value to schema mappings defined for the type, choosing from the
+        /// best source for various kinds of mappings and polymorphism.
+        /// </summary>
+        /// <remarks>
+        /// The preferred choice is specifically defined mappings on the discriminator. However, when
+        /// missing it will fallback all oneOf's defined on the type. If that is not the case, it will
+        /// look for cases of allOf inheritance from schemas defined in the components section.
+        /// </remarks>
+        private static IEnumerable<(string Key, ILocatedOpenApiElement<OpenApiSchema> Schema)> GetMappings(
+            GenerationContext context,
+            ILocatedOpenApiElement<OpenApiSchema> element)
+        {
+            if (element.Element.Discriminator.Mapping is {Count: > 0})
+            {
+                // Use specifically listed mappings
+                return element.Element.Discriminator.Mapping
+                    .Select(p =>
+                    {
+                        // TODO: We should really be parsing this rather than just checking a prefix, but the OpenAPI parser isn't exposed
+                        if (p.Value.StartsWith("#/components/schemas/"))
+                        {
+                            string schemaName = p.Value.Substring("#/components/schemas/".Length);
+                            if (context.Document.Components.Schemas.TryGetValue(schemaName, out var schema))
+                            {
+                                return (p.Key, Schema: schema.CreateRoot(p.Key));
+                            }
+                        }
+
+                        return (p.Key, Schema: null!);
+                    })
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
+                    .Where(p => p.Schema is not null);
+            }
+
+            if (element.Element.OneOf is {Count: > 0})
+            {
+                // Gather mappings from "oneOf" that get a default mapping based on the schema name
+                return element.Element.OneOf
+                    .Where(p => p.Reference is not null)
+                    .Select(p => (p.Reference.Id, p.CreateRoot(p.Reference.Id)));
+            }
+
+            // Find other schemas that reference this one using allOf. This only applies to base
+            // classes, don't try this with interfaces.
+            return context.Document.Components.Schemas
+                .Where(p =>
+                {
+                    var firstAllOf = p.Value.AllOf?.FirstOrDefault();
+                    return firstAllOf?.Reference is not null &&
+                           firstAllOf.Reference.Id == element.Key;
+                })
+                .Select(p => (p.Key, p.Value.CreateRoot(p.Key)));
+        }
     }
 }

--- a/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/main/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.cs
@@ -146,6 +146,27 @@ namespace Yardarm.Helpers
                 }
             }
 
+            public static class Diagnostics
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    System.Name,
+                    IdentifierName("Diagnostics"));
+
+                public static class CodeAnalysis
+                {
+                    public static NameSyntax Name { get; } = QualifiedName(
+                        Diagnostics.Name,
+                        IdentifierName("CodeAnalysis"));
+
+                    public static class UnconditionalSuppressMessageAttribute
+                    {
+                        public static NameSyntax Name { get; } = QualifiedName(
+                            CodeAnalysis.Name,
+                            IdentifierName("UnconditionalSuppressMessageAttribute"));
+                    }
+                }
+            }
+
             public static class IDisposable
             {
                 public static NameSyntax Name { get; } = QualifiedName(


### PR DESCRIPTION
Motivation
----------
Once we have support for `JsonSerializerContext`, the discriminators should not cause trim or AOT warnings.

We can't currently use all of the built-in polymorphism support because it has requirements that don't match with our needs. Namely:

- The discriminator must be the first attribute in the object being deserialized.
- The discriminator must not be included as a property on the POCO
- Multiple discriminator values can't share the same POCO type

Modifications
-------------
- Use the `JsonPolymorphic` and `JsonDerivedType` attributes to ensure any generated `JsonSerializerContext` always includes the derived types in the metadata.
- Suppress trim and AOT warnings on the generated JSON converters
- Synchronize versions on packages