### PR TITLE
Normalize BaseIntermediateOutputPath on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches:
+    - main
+    - release-*
 
 jobs:
   build:

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -106,7 +106,7 @@
       RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"
       Extensions="@(YardarmExtension)"
-      BaseIntermediateOutputPath="$(BaseIntermediateOutputPath)"
+      BaseIntermediateOutputPath="$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)'))"
     >
       <Output TaskParameter="PackageReference" ItemName="_YardarmPackageReference" />
       <Output TaskParameter="PackageDownload" ItemName="PackageDownload" />


### PR DESCRIPTION
Motivation
------------
For the restore step only, on Linux the BaseIntermediateOutputPath may have a trailing slash. This confuses the command-line escaping.