### PR TITLE
Apply the requested mediaType to STJ request headers

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -30,7 +31,7 @@ namespace RootNamespace.Serialization.Json
         }
 
         public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
-            JsonContent.Create(value, new MediaTypeHeaderValue("application/json"), _options);
+            JsonContent.Create(value, new MediaTypeHeaderValue(mediaType) {CharSet = Encoding.UTF8.WebName}, _options);
 
         public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null)
         {


### PR DESCRIPTION
Motivation
----------
Currently all JSON requests from System.Text.Json generated clients are sent as application/json, even if that isn't one of the allowed content types on the spec.

Modifications
-------------
Send the requested media type, which will be the highest priority JSON content type provided on the spec. Also indicate UTF-8 encoding.

Fixes #200