### PR TITLE
Add support for "partial-time" string formats

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -105,12 +105,14 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().Be("2020-01-02T03:04:05.0000000");
         }
 
-        [Fact]
-        public void Serialize_Date_ReturnsString()
+        [Theory]
+        [InlineData("date")]
+        [InlineData("full-date")]
+        public void Serialize_Date_ReturnsString(string format)
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5), "date");
+            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5), format);
 
             // Assert
 
@@ -131,6 +133,31 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void Serialize_TimeSpan_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(
+                new TimeSpan(0, 3, 4, 5), "partial-time");
+
+            // Assert
+
+            result.Should().Be("03:04:05");
+        }
+
+        [Fact]
+        public void Serialize_TimeSpanMillis_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Instance.Serialize(
+                new TimeSpan(0, 3, 4, 5, 123), "partial-time");
+
+            // Assert
+
+            result.Should().Be("03:04:05.1230000");
+        }
+            
         public void Serialize_Guid_ReturnsString()
         {
             // Arrange
@@ -246,16 +273,42 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().BeFalse();
         }
 
-        [Fact]
-        public void Deserialize_Date_ReturnsString()
+        [Theory]
+        [InlineData("date")]
+        [InlineData("full-date")]
+        public void Deserialize_Date_ReturnsString(string format)
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<DateTime>("2020-01-02", "date");
+            var result = LiteralSerializer.Instance.Deserialize<DateTime>("2020-01-02", format);
 
             // Assert
 
             result.Should().Be(new DateTime(2020, 01, 02));
+        }
+
+        [Fact]
+        public void Deserialize_TimeSpan_ReturnsString()
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02", "partial-time");
+
+            // Assert
+
+            result.Should().Be(new TimeSpan(0, 13, 1, 2));
+        }
+
+        [Fact]
+        public void Deserialize_TimeSpanWithMillis_ReturnsString()
+        {
+            // Act
+
+            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02.234000", "partial-time");
+
+            // Assert
+
+            result.Should().Be(new TimeSpan(0, 13, 1, 2, 234));
         }
 
         [Fact]

--- a/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -31,7 +32,7 @@ namespace RootNamespace.Serialization
 
                 return format switch
                 {
-                    "date" => dateTime.ToString("yyyy-MM-dd"),
+                    "date" or "full-date" => dateTime.ToString("yyyy-MM-dd"),
                     _ => dateTime.ToString("O")
                 };
             }
@@ -41,9 +42,14 @@ namespace RootNamespace.Serialization
 
                 return format switch
                 {
-                    "date" => dateTime.ToString("yyyy-MM-dd"),
+                    "date" or "full-date" => dateTime.ToString("yyyy-MM-dd"),
                     _ => dateTime.ToString("O")
                 };
+            }
+            if (typeof(T) == typeof(TimeSpan) || typeof(T) == typeof(TimeSpan?))
+            {
+                var timeSpan = (TimeSpan)(object)value;
+                return timeSpan.ToString("c");
             }
 
             if (value is IFormattable formattable)
@@ -115,7 +121,7 @@ namespace RootNamespace.Serialization
             {
                 return (T)(object)(format switch
                 {
-                    "date" => DateTime.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    "date" or "full-date" => DateTime.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
                     _ => DateTime.Parse(value, CultureInfo.InvariantCulture)
                 });
             }
@@ -123,8 +129,16 @@ namespace RootNamespace.Serialization
             {
                 return (T)(object)(format switch
                 {
-                    "date" => DateTimeOffset.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
+                    "date" or "full-date" => DateTimeOffset.ParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture),
                     _ => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture)
+                });
+            }
+            if (typeof(T) == typeof(TimeSpan) || typeof(T) == typeof(TimeSpan?))
+            {
+                return (T)(object)(format switch
+                {
+                    "partial-time" => TimeSpan.ParseExact(value, "c", CultureInfo.InvariantCulture),
+                    _ => TimeSpan.Parse(value, CultureInfo.InvariantCulture)
                 });
             }
             if (typeof(T) == typeof(Guid) || typeof(T) == typeof(Guid?))

--- a/src/main/Yardarm.NewtonsoftJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonDateOnlyPropertyEnricher.cs
@@ -26,7 +26,7 @@ namespace Yardarm.NewtonsoftJson
 
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
         {
-            if (context.Element.Type != "string" || context.Element.Format != "date")
+            if (context.Element.Type != "string" || context.Element.Format is not "date" and not "full-date")
             {
                 // Only applies to date-only strings
                 return syntax;

--- a/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDateOnlyPropertyEnricher.cs
@@ -29,7 +29,7 @@ namespace Yardarm.SystemTextJson
 
         public PropertyDeclarationSyntax Enrich(PropertyDeclarationSyntax syntax, OpenApiEnrichmentContext<OpenApiSchema> context)
         {
-            if (context.Element.Type != "string" || context.Element.Format != "date")
+            if (context.Element.Type != "string" || context.Element.Format is not "date" and not "full-date")
             {
                 // Only applies to date-only strings
                 return syntax;

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -22,7 +22,8 @@ namespace Yardarm.Generation.Schema
             new YardarmTypeInfo(
                 Element.Element.Format switch
                 {
-                    "date" => QualifiedName(IdentifierName("System"), IdentifierName("DateTime")),
+                    "date" or "full-date" => QualifiedName(IdentifierName("System"), IdentifierName("DateTime")),
+                    "partial-time" => QualifiedName(IdentifierName("System"), IdentifierName("TimeSpan")),
                     "date-time" => QualifiedName(IdentifierName("System"), IdentifierName("DateTimeOffset")),
                     "uuid" => QualifiedName(IdentifierName("System"), IdentifierName("Guid")),
                     "uri" => QualifiedName(IdentifierName("System"), IdentifierName("Uri")),


### PR DESCRIPTION
Motivation
----------
This is the standard method OpenAPI specs encode time-only properties.

Modifications
-------------
Treat "partial-time" as a `TimeSpan` and add support to the `LiteralSerializer`. Both JSON libraries have out-of-the-box support.

Also treat "full-date" as the equivalent of "date" per the spec.

Results
-------
"partial-time" is now fully supported as a `TimeSpan`.

Note: This does not address "time" or "time-only" formats, which also encode the time zone.  This is more difficult to represent in .NET, we may need to use `DateTimeOffset`

Closes #204