### PR TITLE
Turn on trim and AOT analysis

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -157,7 +157,8 @@ namespace Yardarm.Client.UnitTests.Serialization
 
             result.Should().Be("03:04:05.1230000");
         }
-            
+
+        [Fact]
         public void Serialize_Guid_ReturnsString()
         {
             // Arrange

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
@@ -7,7 +7,9 @@
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <IsTrimmable>true</IsTrimmable>
+
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -9,6 +9,9 @@
     <IsPackable>false</IsPackable>
 
     <DefineConstants>$(DefineConstants);FORTESTS</DefineConstants>
+
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
We'd like to catch some cases where our client implementations violate trim or NativeAOT principles more easily.

Modifications
-------------
Turn on trim and AOT analysis for STJ and turn on AOT for HTTP ext.

Also fix a missing test attribute.

Results
-------
This won't catch misuse in the generated C# code nor cases that require actual AOT compliation to catch, but should catch some cases of misuse.