### PR TITLE
Add support for response body streaming

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Authentication/Internal/SecuritySchemeSetRegistryTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Authentication/Internal/SecuritySchemeSetRegistryTests.cs
@@ -223,12 +223,14 @@ namespace Yardarm.Client.UnitTests.Authentication.Internal
         public class NoSchemesRequest : IOperationRequest
         {
             public IAuthenticator Authenticator { get; set; }
+            public bool EnableResponseStreaming { get; set; }
         }
 
         [SecuritySchemeSet(typeof(TestAuth1))]
         public class OneSchemeRequest : IOperationRequest
         {
             public IAuthenticator Authenticator { get; set; }
+            public bool EnableResponseStreaming { get; set; }
         }
 
         [SecuritySchemeSet(typeof(TestAuth1))]
@@ -236,12 +238,14 @@ namespace Yardarm.Client.UnitTests.Authentication.Internal
         public class TwoSchemesRequest : IOperationRequest
         {
             public IAuthenticator Authenticator { get; set; }
+            public bool EnableResponseStreaming { get; set; }
         }
 
         [SecuritySchemeSet(typeof(TestAuth1), typeof(TestAuth2))]
         public class JoinedSchemesRequest : IOperationRequest
         {
             public IAuthenticator Authenticator { get; set; }
+            public bool EnableResponseStreaming { get; set; }
         }
 
         #endregion

--- a/src/main/Yardarm.Client/Requests/IOperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/IOperationRequest.cs
@@ -1,4 +1,5 @@
 ﻿using RootNamespace.Authentication;
+using RootNamespace.Responses;
 
 namespace RootNamespace.Requests
 {
@@ -8,5 +9,20 @@ namespace RootNamespace.Requests
         /// Optionally override the default authenticator for this request.
         /// </summary>
         public IAuthenticator? Authenticator { get; set; }
+
+        /// <summary>
+        /// If true, the request will return after response headers are received and the response body will be streamed.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is particularly useful for large response bodies. However, when using response streaming the response body
+        /// will not be buffered and may only be read once.
+        /// </para>
+        /// <para>
+        /// Additionally, it is imperative that <see cref="IOperationResponse.Dispose" /> be called when the response is no
+        /// longer needed to avoid leaking connections. This is particularly important for .NET 4.x consumers.
+        /// </para>
+        /// </remarks>
+        public bool EnableResponseStreaming { get; set; }
     }
 }

--- a/src/main/Yardarm.Client/Requests/OperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/OperationRequest.cs
@@ -9,5 +9,8 @@ namespace RootNamespace.Requests
     {
         /// <inheritdoc />
         public IAuthenticator? Authenticator { get; set; }
+
+        /// <inheritdoc />
+        public bool EnableResponseStreaming { get; set; }
     }
 }

--- a/src/main/Yardarm/Helpers/WellKnownTypes.Http.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.Http.cs
@@ -71,6 +71,21 @@ namespace Yardarm.Helpers
                             IdentifierName("HttpClient"));
                     }
 
+                    public static class HttpCompletionOption
+                    {
+                        public static NameSyntax Name { get; } = QualifiedName(
+                            Http.Name,
+                            IdentifierName("HttpCompletionOption"));
+
+                        public static NameSyntax ResponseContentRead { get; } = QualifiedName(
+                            Name,
+                            IdentifierName("ResponseContentRead"));
+
+                        public static NameSyntax ResponseHeadersRead { get; } = QualifiedName(
+                            Name,
+                      IdentifierName("ResponseHeadersRead"));
+                    }
+
                     public static class HttpContent
                     {
                         public static NameSyntax Name { get; } = QualifiedName(


### PR DESCRIPTION
Motivation
----------
Allow large response bodies to be streamed rather than buffering the entire response.

Modifications
-------------
- Add an `EnableResponseStreaming` property to `IOperationRequest`
- Use this property to affect parameters pased to `HttpClient.SendAsync`

Results
-------
If the consumer sets `EnableResponseStreaming` to `true` then the response will be returned as soon as headers are received and the body will be streamed to the deserializer rather than buffered.

Resolves #197