### PR TITLE
Use ThrowHelper.ThrowIfNull to validate args in generated code

### DIFF
--- a/src/main/Yardarm.Client/Authentication/Authenticators.cs
+++ b/src/main/Yardarm.Client/Authentication/Authenticators.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using RootNamespace.Authentication.Internal;
 using RootNamespace.Requests;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Authentication
 {
@@ -18,10 +19,7 @@ namespace RootNamespace.Authentication
 
         public IAuthenticator? SelectAuthenticator(IOperationRequest request)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
+            ThrowHelper.ThrowIfNull(request);
 
             return request.Authenticator ?? _securitySchemeSetRegistry.SelectAuthenticator(request.GetType());
         }

--- a/src/main/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
+++ b/src/main/Yardarm.Client/Authentication/Internal/SecuritySchemeSetRegistry.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Authentication.Internal
 {
@@ -24,15 +25,14 @@ namespace RootNamespace.Authentication.Internal
 
         public SecuritySchemeSetRegistry(T authenticators)
         {
-            _authenticators = authenticators ?? throw new ArgumentNullException(nameof(authenticators));
+            ThrowHelper.ThrowIfNull(authenticators);
+
+            _authenticators = authenticators;
         }
 
         public IAuthenticator? SelectAuthenticator(Type operationType)
         {
-            if (operationType == null)
-            {
-                throw new ArgumentNullException(nameof(operationType));
-            }
+            ThrowHelper.ThrowIfNull(operationType);
 
             return SelectAuthenticator(_cache.GetOrAdd(operationType, GetSecuritySchemeSets));
         }
@@ -60,10 +60,7 @@ namespace RootNamespace.Authentication.Internal
 
         private IAuthenticator? SelectAuthenticator(PropertyInfo[][] sets)
         {
-            if (sets == null)
-            {
-                throw new ArgumentNullException(nameof(sets));
-            }
+            ThrowHelper.ThrowIfNull(sets);
 
             foreach (PropertyInfo[] set in sets)
             {

--- a/src/main/Yardarm.Client/Authentication/MultiAuthenticator.cs
+++ b/src/main/Yardarm.Client/Authentication/MultiAuthenticator.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Authentication
 {
@@ -22,10 +23,7 @@ namespace RootNamespace.Authentication
 
         public MultiAuthenticator(IEnumerable<IAuthenticator> authenticators)
         {
-            if (authenticators == null)
-            {
-                throw new ArgumentNullException(nameof(authenticators));
-            }
+            ThrowHelper.ThrowIfNull(authenticators);
 
             Authenticators = new ReadOnlyCollection<IAuthenticator>(authenticators.ToArray());
         }

--- a/src/main/Yardarm.Client/Authentication/SecuritySchemeSetAttribute.cs
+++ b/src/main/Yardarm.Client/Authentication/SecuritySchemeSetAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Authentication
 {
@@ -10,12 +11,19 @@ namespace RootNamespace.Authentication
         public Type[] SecuritySchemes
         {
             get => _securitySchemes;
-            set => _securitySchemes = value ?? throw new ArgumentNullException(nameof(value));
+            set
+            {
+                ThrowHelper.ThrowIfNull(value);
+
+                _securitySchemes = value;
+            }
         }
 
         public SecuritySchemeSetAttribute(params Type[] types)
         {
-            _securitySchemes = types ?? throw new ArgumentNullException(nameof(types));
+            ThrowHelper.ThrowIfNull(types);
+
+            _securitySchemes = types;
         }
     }
 }

--- a/src/main/Yardarm.Client/Internal/CallerArgumentExpressionAttribute.netstandard.cs
+++ b/src/main/Yardarm.Client/Internal/CallerArgumentExpressionAttribute.netstandard.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}

--- a/src/main/Yardarm.Client/Internal/ThrowHelper.cs
+++ b/src/main/Yardarm.Client/Internal/ThrowHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -17,11 +18,7 @@ namespace Yardarm.Client.Internal
         /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
         /// <param name="argument">The reference type argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-        public static void ThrowIfNull([NotNull] object? argument,
-#if NET6_0_OR_GREATER
-            [CallerArgumentExpression(nameof(argument))]
-#endif
-            string? paramName = null)
+        public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))]  string? paramName = null)
         {
 #if NET6_0_OR_GREATER
             // Forward to the common implementation
@@ -42,5 +39,11 @@ namespace Yardarm.Client.Internal
             throw new ArgumentNullException(paramName);
         }
 #endif
+
+        [DoesNotReturn]
+        public static void ThrowKeyNotFoundException(string? message = null)
+        {
+            throw new KeyNotFoundException(message);
+        }
     }
 }

--- a/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
@@ -3,5 +3,6 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Yardarm.Client.UnitTests")]
 [assembly: InternalsVisibleTo("Yardarm.MicrosoftExtensionsHttp.Client")]
+[assembly: InternalsVisibleTo("Yardarm.NewtonsoftJson.Client")]
 [assembly: InternalsVisibleTo("Yardarm.SystemTextJson.Client")]
 #endif

--- a/src/main/Yardarm.Client/Responses/OperationResponse.cs
+++ b/src/main/Yardarm.Client/Responses/OperationResponse.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using RootNamespace.Serialization;
+using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Responses
@@ -37,8 +38,11 @@ namespace RootNamespace.Responses
 
         protected OperationResponse(HttpResponseMessage message, ITypeSerializerRegistry typeSerializerRegistry)
         {
-            Message = message ?? throw new ArgumentNullException(nameof(message));
-            TypeSerializerRegistry = typeSerializerRegistry ?? throw new ArgumentNullException(nameof(typeSerializerRegistry));
+            ThrowHelper.ThrowIfNull(message);
+            ThrowHelper.ThrowIfNull(typeSerializerRegistry);
+
+            Message = message;
+            TypeSerializerRegistry = typeSerializerRegistry;
 
             // ReSharper disable once VirtualMemberCallInConstructor
             ParseHeaders(message.Headers);

--- a/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -13,7 +13,7 @@ namespace RootNamespace.Serialization
 
         public HeaderSerializer(LiteralSerializer literalSerializer)
         {
-            ThrowHelper.ThrowIfNull(literalSerializer, nameof(literalSerializer));
+            ThrowHelper.ThrowIfNull(literalSerializer);
 
             _literalSerializer = literalSerializer;
         }
@@ -65,7 +65,7 @@ namespace RootNamespace.Serialization
 
         public List<T> DeserializeList<T>(IEnumerable<string> values, string? format = null)
         {
-            ThrowHelper.ThrowIfNull(values, nameof(values));
+            ThrowHelper.ThrowIfNull(values);
 
             return _literalSerializer.DeserializeList<T>(values, format);
         }

--- a/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializationData.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializationData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Serialization
 {
@@ -20,14 +21,7 @@ namespace RootNamespace.Serialization
 
         public MultipartFormDataSerializationData(params MultipartPropertyInfo<T>[] properties)
         {
-#if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(properties);
-#else
-            if (properties is null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
-#endif
+            ThrowHelper.ThrowIfNull(properties);
 
             _properties = properties.ToDictionary(static p => p.PropertyName);
         }

--- a/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Serialization
 {
@@ -12,7 +13,9 @@ namespace RootNamespace.Serialization
 
         public MultipartFormDataSerializer(ITypeSerializerRegistry typeSerializerRegistry)
         {
-            _typeSerializerRegistry = typeSerializerRegistry ?? throw new ArgumentNullException(nameof(typeSerializerRegistry));
+            ThrowHelper.ThrowIfNull(typeSerializerRegistry);
+
+            _typeSerializerRegistry = typeSerializerRegistry;
         }
 
         public HttpContent Serialize<T>(T value, string mediaType, MultipartFormDataSerializationData<T> serializationData)

--- a/src/main/Yardarm.Client/Serialization/MultipartPropertyInfo`1.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartPropertyInfo`1.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Serialization
 {
@@ -21,24 +22,9 @@ namespace RootNamespace.Serialization
         protected MultipartPropertyInfo(Func<T, MultipartFieldDetails?> detailsGetter,
             string propertyName, params string[] mediaTypes)
         {
-#if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(detailsGetter);
-            ArgumentNullException.ThrowIfNull(propertyName);
-            ArgumentNullException.ThrowIfNull(mediaTypes);
-#else
-            if (detailsGetter is null)
-            {
-                throw new ArgumentNullException(nameof(detailsGetter));
-            }
-            if (propertyName is null)
-            {
-                throw new ArgumentNullException(nameof(propertyName));
-            }
-            if (mediaTypes is null)
-            {
-                throw new ArgumentNullException(nameof(mediaTypes));
-            }
-#endif
+            ThrowHelper.ThrowIfNull(detailsGetter);
+            ThrowHelper.ThrowIfNull(propertyName);
+            ThrowHelper.ThrowIfNull(mediaTypes);
 
             _detailsGetter = detailsGetter;
             PropertyName = propertyName;

--- a/src/main/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartPropertyInfo`2.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using Yardarm.Client.Internal;
 
 namespace RootNamespace.Serialization
 {
@@ -18,14 +19,7 @@ namespace RootNamespace.Serialization
             params string[] mediaTypes)
             : base(detailsGetter, propertyName, mediaTypes)
         {
-#if NET6_0_OR_GREATER
-            ArgumentNullException.ThrowIfNull(propertyGetter);
-#else
-            if (propertyGetter is null)
-            {
-                throw new ArgumentNullException(nameof(propertyGetter));
-            }
-#endif
+            ThrowHelper.ThrowIfNull(propertyGetter);
 
             _propertyGetter = propertyGetter;
         }

--- a/src/main/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
@@ -24,7 +25,12 @@ namespace RootNamespace.Serialization
                 Interlocked.CompareExchange(ref s_instance, CreateDefaultRegistry(), null);
                 return s_instance;
             }
-            set => s_instance = value ?? throw new ArgumentNullException(nameof(value));
+            set
+            {
+                ThrowHelper.ThrowIfNull(value);
+
+                s_instance = value;
+            }
         }
 
         private readonly Dictionary<string, ITypeSerializer> _mediaTypeRegistry = new();
@@ -32,17 +38,21 @@ namespace RootNamespace.Serialization
 
         public ITypeSerializer Get(string mediaType)
         {
-            if (mediaType is null)
-            {
-                throw new ArgumentNullException(nameof(mediaType));
-            }
+            ThrowHelper.ThrowIfNull(mediaType);
 
             return _mediaTypeRegistry[mediaType];
         }
 
-        public ITypeSerializer Get(Type schemaType) => TryGet(schemaType, out ITypeSerializer? serializer)
-            ? serializer
-            : throw new KeyNotFoundException();
+        public ITypeSerializer Get(Type schemaType)
+        {
+            if (TryGet(schemaType, out ITypeSerializer? serializer))
+            {
+                return serializer;
+            }
+
+            ThrowHelper.ThrowKeyNotFoundException();
+            return null!;
+        }
 
         public bool TryGet(string mediaType, [MaybeNullWhen(false)] out ITypeSerializer typeSerializer) =>
             _mediaTypeRegistry.TryGetValue(mediaType, out typeSerializer);
@@ -70,14 +80,8 @@ namespace RootNamespace.Serialization
 
         public ITypeSerializerRegistry Add(string mediaType, ITypeSerializer serializer)
         {
-            if (mediaType == null)
-            {
-                throw new ArgumentNullException(nameof(mediaType));
-            }
-            if (serializer == null)
-            {
-                throw new ArgumentNullException(nameof(serializer));
-            }
+            ThrowHelper.ThrowIfNull(mediaType);
+            ThrowHelper.ThrowIfNull(serializer);
 
             _mediaTypeRegistry.Add(mediaType, serializer);
 
@@ -86,14 +90,8 @@ namespace RootNamespace.Serialization
 
         public ITypeSerializerRegistry Add(Type schemaType, ITypeSerializer serializer)
         {
-            if (schemaType == null)
-            {
-                throw new ArgumentNullException(nameof(schemaType));
-            }
-            if (serializer == null)
-            {
-                throw new ArgumentNullException(nameof(serializer));
-            }
+            ThrowHelper.ThrowIfNull(schemaType);
+            ThrowHelper.ThrowIfNull(serializer);
 
             _schemaTypeRegistry.Add(schemaType, serializer);
 

--- a/src/main/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/main/Yardarm.Client/Yardarm.Client.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
-    <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
+    <Compile Remove="**/*.netstandard.cs" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
+    <Compile Remove="**/*.netcoreapp.cs" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
 </Project>

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/ApiBuilderExtensions.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/ApiBuilderExtensions.cs
@@ -77,7 +77,7 @@ namespace RootNamespace
             where TClient : class, IApi
             where TImplementation : class, TClient
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
+            ThrowHelper.ThrowIfNull(builder);
 
             if (!ApiClientMappingRegistry.TryReserve(builder.Services, typeof(TClient)))
             {
@@ -114,8 +114,8 @@ namespace RootNamespace
             Action<IHttpClientBuilder>? configureClient = null)
             where TClient : class
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(name, nameof(name));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(name);
 
             var clientBuilder = builder.Services.AddHttpClient<TClient>(name);
 
@@ -143,7 +143,7 @@ namespace RootNamespace
             where TClient : class, IApi
             where TImplementation : class, TClient
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
+            ThrowHelper.ThrowIfNull(builder);
 
             if (!ApiClientMappingRegistry.TryReserve(builder.Services, typeof(TClient)))
             {
@@ -175,8 +175,8 @@ namespace RootNamespace
         public static IApiBuilder ConfigureAuthenticators(this IApiBuilder builder,
             Action<Authentication.Authenticators> configureAuthenticators)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureAuthenticators, nameof(configureAuthenticators));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureAuthenticators);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
                 options.AuthenticatorActions.Add(configureAuthenticators));
@@ -193,8 +193,8 @@ namespace RootNamespace
         public static IApiBuilder ConfigureAuthenticators(this IApiBuilder builder,
             Action<IServiceProvider, Authentication.Authenticators> configureAuthenticators)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureAuthenticators, nameof(configureAuthenticators));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureAuthenticators);
 
             builder.Services.AddTransient<IConfigureOptions<ApiFactoryOptions>>(services =>
             {
@@ -225,8 +225,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigureHttpClient(this IApiBuilder builder, Action<HttpClient> configureClient)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureClient, nameof(configureClient));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureClient);
 
             builder.Services.Configure<ApiFactoryOptions>(options => options.HttpClientActions.Add(configureClient));
 
@@ -247,8 +247,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigureHttpClient(this IApiBuilder builder, Action<IServiceProvider, HttpClient> configureClient)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureClient, nameof(configureClient));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureClient);
 
             builder.Services.AddTransient<IConfigureOptions<ApiFactoryOptions>>(services =>
             {
@@ -279,8 +279,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigurePrimaryHttpMessageHandler(this IApiBuilder builder, Func<HttpMessageHandler> configureHandler)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureHandler, nameof(configureHandler));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureHandler);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -304,8 +304,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigurePrimaryHttpMessageHandler(this IApiBuilder builder, Func<IServiceProvider, HttpMessageHandler> configureHandler)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureHandler, nameof(configureHandler));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureHandler);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -330,7 +330,7 @@ namespace RootNamespace
         public static IApiBuilder ConfigurePrimaryHttpMessageHandler<THandler>(this IApiBuilder builder)
             where THandler : HttpMessageHandler
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
+            ThrowHelper.ThrowIfNull(builder);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -358,8 +358,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder AddHttpMessageHandler(this IApiBuilder builder, Func<DelegatingHandler> configureHandler)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureHandler, nameof(configureHandler));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureHandler);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -383,8 +383,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder AddHttpMessageHandler(this IApiBuilder builder, Func<IServiceProvider, DelegatingHandler> configureHandler)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureHandler, nameof(configureHandler));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureHandler);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -409,7 +409,7 @@ namespace RootNamespace
         public static IApiBuilder AddHttpMessageHandler<THandler>(this IApiBuilder builder)
             where THandler : DelegatingHandler
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
+            ThrowHelper.ThrowIfNull(builder);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -437,8 +437,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigureBaseAddress(this IApiBuilder builder, Uri uri)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(uri, nameof(uri));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(uri);
 
             return builder.ConfigureHttpClient(client => client.BaseAddress = uri);
         }
@@ -457,8 +457,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder ConfigureBaseAddress(this IApiBuilder builder, Func<IServiceProvider, Uri> configureUri)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(configureUri, nameof(configureUri));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(configureUri);
 
             return builder.ConfigureHttpClient((serviceProvider, client) => client.BaseAddress = configureUri(serviceProvider));
         }
@@ -483,8 +483,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder RedactLoggedHeaders(this IApiBuilder builder, Func<string, bool> shouldRedactHeaderValue)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(shouldRedactHeaderValue, nameof(shouldRedactHeaderValue));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(shouldRedactHeaderValue);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -507,8 +507,8 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder RedactLoggedHeaders(this IApiBuilder builder, IEnumerable<string> redactedLoggedHeaderNames)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
-            ThrowHelper.ThrowIfNull(redactedLoggedHeaderNames, nameof(redactedLoggedHeaderNames));
+            ThrowHelper.ThrowIfNull(builder);
+            ThrowHelper.ThrowIfNull(redactedLoggedHeaderNames);
 
             builder.Services.Configure<ApiFactoryOptions>(options =>
             {
@@ -538,7 +538,7 @@ namespace RootNamespace
         /// </remarks>
         public static IApiBuilder SetHandlerLifetime(this IApiBuilder builder, TimeSpan handlerLifetime)
         {
-            ThrowHelper.ThrowIfNull(builder, nameof(builder));
+            ThrowHelper.ThrowIfNull(builder);
 
             if (handlerLifetime != Timeout.InfiniteTimeSpan && handlerLifetime < s_minimumHandlerLifetime)
             {

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/YardarmConfigureHttpClientFactoryOptions.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/YardarmConfigureHttpClientFactoryOptions.cs
@@ -13,7 +13,7 @@ namespace RootNamespace.Internal
         public YardarmConfigureHttpClientFactoryOptions(string name, IOptions<ApiFactoryOptions> apiFactoryOptions)
         {
             ThrowHelper.ThrowIfNull(name, nameof(name));
-            ThrowHelper.ThrowIfNull(apiFactoryOptions, nameof(apiFactoryOptions));
+            ThrowHelper.ThrowIfNull(apiFactoryOptions);
 
             Name = name;
             _apiFactoryOptions = apiFactoryOptions;

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/AdditionalPropertiesDictionary.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/AdditionalPropertiesDictionary.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Newtonsoft.Json.Linq;
+using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization.Json
@@ -14,7 +15,9 @@ namespace RootNamespace.Serialization.Json
 
         public AdditionalPropertiesDictionary(IDictionary<string, JToken> dictionary)
         {
-            _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+            ThrowHelper.ThrowIfNull(dictionary);
+
+            _dictionary = dictionary;
         }
 
 #pragma warning disable 8603
@@ -82,10 +85,7 @@ namespace RootNamespace.Serialization.Json
         /// <inheritdoc />
         public void CopyTo(KeyValuePair<string, TValue>[] array, int arrayIndex)
         {
-            if (array == null)
-            {
-                throw new ArgumentNullException(nameof(array));
-            }
+            ThrowHelper.ThrowIfNull(array);
 
             Array.Copy(this.ToArray(), 0, array, arrayIndex, Count);
         }

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/DiscriminatorConverter.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/DiscriminatorConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization.Json
@@ -23,13 +24,12 @@ namespace RootNamespace.Serialization.Json
 
         public DiscriminatorConverter(string propertyName, Type interfaceType, IEnumerable<KeyValuePair<string, Type>> mappings)
         {
-            _propertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
-            _interfaceType = interfaceType ?? throw new ArgumentNullException(nameof(interfaceType));
+            ThrowHelper.ThrowIfNull(propertyName);
+            ThrowHelper.ThrowIfNull(interfaceType);
+            ThrowHelper.ThrowIfNull(mappings);
 
-            if (mappings == null)
-            {
-                throw new ArgumentNullException(nameof(mappings));
-            }
+            _propertyName = propertyName;
+            _interfaceType = interfaceType;
 
             _mappings = new Dictionary<string, Type>();
             foreach (var mapping in mappings)

--- a/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -19,13 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-    We need access to these attributes to compile for testing, but we don't want them included
-    in the SDK because they would be included multiple times. Yardarm.Client should have the only
-    copy that's embedded.
-    -->
-    <Compile Include="../Yardarm.Client/Internal/NullableAttributes.cs" />
-
     <Compile Remove="**/*.netstandard.cs" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <Compile Remove="**/*.netcoreapp.cs" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
   </ItemGroup>

--- a/src/main/Yardarm/Generation/Authentication/BasicSecuritySchemeTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Authentication/BasicSecuritySchemeTypeGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -42,33 +43,57 @@ namespace Yardarm.Generation.Authentication
                         VariableDeclarator(Identifier(CacheFieldName))))
                 .AddModifiers(Token(SyntaxKind.PublicKeyword));
 
-            yield return PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)),
-                    UsernamePropertyName)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(UsernameFieldName)))
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, Block(
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(UsernameFieldName),
-                            MethodHelpers.ArgumentOrThrowIfNull("value"))),
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(CacheFieldName), LiteralExpression(SyntaxKind.NullLiteralExpression))))));
+            yield return PropertyDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword)),
+                PredefinedType(Token(SyntaxKind.StringKeyword)),
+                null,
+                Identifier(UsernamePropertyName),
+                AccessorList(List(new[]
+                {
+                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration,
+                        default,
+                        default,
+                        Token(SyntaxKind.GetKeyword),
+                        ArrowExpressionClause(IdentifierName(UsernameFieldName)),
+                        Token(SyntaxKind.SemicolonToken)),
+                    AccessorDeclaration(SyntaxKind.SetAccessorDeclaration,
+                        default,
+                        default,
+                        Block(
+                            MethodHelpers.ThrowIfArgumentNull("value"),
+                            ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                                IdentifierName(UsernameFieldName),
+                                IdentifierName("value"))),
+                            ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                                IdentifierName(CacheFieldName), LiteralExpression(SyntaxKind.NullLiteralExpression)))))
+                })));
 
-            yield return PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)),
-                    PasswordPropertyName)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                        .WithExpressionBody(ArrowExpressionClause(IdentifierName(PasswordFieldName)))
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken)),
-                    AccessorDeclaration(SyntaxKind.SetAccessorDeclaration, Block(
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(PasswordFieldName),
-                            MethodHelpers.ArgumentOrThrowIfNull("value"))),
-                        ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
-                            IdentifierName(CacheFieldName), LiteralExpression(SyntaxKind.NullLiteralExpression))))));
+            yield return PropertyDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword)),
+                PredefinedType(Token(SyntaxKind.StringKeyword)),
+                null,
+                Identifier(PasswordPropertyName),
+                AccessorList(List(new[]
+                {
+                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration,
+                        default,
+                        default,
+                        Token(SyntaxKind.GetKeyword),
+                        ArrowExpressionClause(IdentifierName(PasswordFieldName)),
+                        Token(SyntaxKind.SemicolonToken)),
+                    AccessorDeclaration(SyntaxKind.SetAccessorDeclaration,
+                        default,
+                        default,
+                        Block(
+                            MethodHelpers.ThrowIfArgumentNull("value"),
+                            ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                                IdentifierName(PasswordFieldName),
+                                IdentifierName("value"))),
+                            ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
+                                IdentifierName(CacheFieldName), LiteralExpression(SyntaxKind.NullLiteralExpression)))))
+                })));
         }
 
         protected override BlockSyntax GenerateApplyAsyncBody() => Block(

--- a/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -93,25 +94,29 @@ namespace Yardarm.Generation.Tag
 
         protected virtual IEnumerable<ConstructorDeclarationSyntax> GenerateConstructors(string className)
         {
-            yield return ConstructorDeclaration(className)
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddParameterListParameters(
-                    Parameter(Identifier("httpClient"))
-                        .WithType(WellKnownTypes.System.Net.Http.HttpClient.Name),
-                    Parameter(Identifier("typeSerializerRegistry"))
-                        .WithType(_serializationNamespace.ITypeSerializerRegistry),
-                    Parameter(Identifier("authenticators"))
-                        .WithType(_authenticationNamespace.Authenticators))
-                .WithBody(Block(
+            yield return ConstructorDeclaration(
+                default,
+                TokenList(Token(SyntaxKind.PublicKeyword)),
+                Identifier(className),
+                ParameterList(SeparatedList(new[] {
+                    Parameter(default, default, WellKnownTypes.System.Net.Http.HttpClient.Name, Identifier("httpClient"), null),
+                    Parameter(default, default, _serializationNamespace.ITypeSerializerRegistry, Identifier("typeSerializerRegistry"), null),
+                    Parameter(default ,default, _authenticationNamespace.Authenticators, Identifier("authenticators"), null)
+                })),
+                default,
+                Block(
+                    MethodHelpers.ThrowIfArgumentNull("httpClient"),
+                    MethodHelpers.ThrowIfArgumentNull("typeSerializerRegistry"),
+                    MethodHelpers.ThrowIfArgumentNull("authenticators"),
                     ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                         IdentifierName(HttpClientFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("httpClient"))),
+                        IdentifierName("httpClient"))),
                     ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                         IdentifierName(TypeSerializerRegistryFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("typeSerializerRegistry"))),
+                        IdentifierName("typeSerializerRegistry"))),
                     ExpressionStatement(AssignmentExpression(SyntaxKind.SimpleAssignmentExpression,
                         IdentifierName(AuthenticatorsFieldName),
-                        MethodHelpers.ArgumentOrThrowIfNull("authenticators")))));
+                        IdentifierName("authenticators")))));
         }
 
         private string GetClassName() => Context.NameFormatterSelector.GetFormatter(NameKind.Class).Format(Tag.Name);

--- a/src/main/Yardarm/Helpers/SyntaxHelpers.cs
+++ b/src/main/Yardarm/Helpers/SyntaxHelpers.cs
@@ -79,14 +79,5 @@ namespace Yardarm.Helpers
             value is not null
                 ? LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value))
                 : LiteralExpression(SyntaxKind.NullLiteralExpression);
-
-        public static ExpressionSyntax ParameterWithNullCheck(string parameterName) =>
-            BinaryExpression(SyntaxKind.CoalesceExpression,
-                IdentifierName(parameterName),
-                ThrowExpression(ObjectCreationExpression(
-                    QualifiedName(IdentifierName("System"), IdentifierName("ArgumentNullException")),
-                    ArgumentList(SingletonSeparatedList(Argument(
-                        StringLiteral(parameterName)))),
-                    null)));
     }
 }

--- a/src/main/Yardarm/Helpers/WellKnownTypes.Yardarm.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.Yardarm.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Helpers
+{
+    // ReSharper disable InconsistentNaming
+    // ReSharper disable MemberHidesStaticFromOuterClass
+    public static partial class WellKnownTypes
+    {
+        public static partial class Yardarm
+        {
+            public static NameSyntax Name { get; } = AliasQualifiedName(
+                IdentifierName(Token(SyntaxKind.GlobalKeyword)),
+                IdentifierName("Yardarm"));
+
+            public static class Client
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    Yardarm.Name,
+                    IdentifierName("Client"));
+
+                public static class Internal
+                {
+                    public static NameSyntax Name { get; } = QualifiedName(
+                        Client.Name,
+                        IdentifierName("Internal"));
+
+                    public static class ThrowHelper
+                    {
+                        public static NameSyntax Name { get; } = QualifiedName(
+                            Internal.Name,
+                            IdentifierName("ThrowHelper"));
+
+                        public static MemberAccessExpressionSyntax ThrowIfNull { get; } = MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            Name,
+                            IdentifierName("ThrowIfNull"));
+                    }
+
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Using a throw helper reduces JIT code size and improves inlining for a possible performance gain.

Modifications
-------------
For all generated client code where arguments are being validated as non-null, use `ThrowHelper.ThrowIfNull` rather than throwing `ArgumentNullException` directly. This includes prewritten client code as well as generated client code. `MethodHelpers` are updated to use this pattern.

Include the `CallerArgumentExpressionAttribute` in downlevel frameworks so we may consistently avoid passing the parameter name to `ThrowIfNull` manually. Simplify all call sites that are currently passing the name manually.

Add a `ThrowKeyNotFoundException` throw helper for use in the `TypeSerializerRegistry`.

Use `is not null` instead of `!= null` in `MethodHelpers.IfNotNull` to ensure that equality operator overloads are never used.