### PR TITLE
Provide stream bodies for binary responses

### DIFF
--- a/src/main/Yardarm.Client/Responses/IOperationResponse`1.cs
+++ b/src/main/Yardarm.Client/Responses/IOperationResponse`1.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Responses
@@ -12,7 +13,8 @@ namespace RootNamespace.Responses
         /// <summary>
         /// Get the body of the response.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The deserialized body.</returns>
-        ValueTask<TBody> GetBodyAsync();
+        ValueTask<TBody> GetBodyAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/main/Yardarm/Generation/MediaType/PriorityMediaTypeSelector.cs
+++ b/src/main/Yardarm/Generation/MediaType/PriorityMediaTypeSelector.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.OpenApi.Models;
 using Yardarm.Serialization;
 using Yardarm.Spec;
@@ -17,13 +16,30 @@ namespace Yardarm.Generation.MediaType
             _serializerSelector = serializerSelector;
         }
 
-        public ILocatedOpenApiElement<OpenApiMediaType>? Select(ILocatedOpenApiElement<OpenApiResponse> response) =>
-            response
-                .GetMediaTypes()
-                .Select(mediaType => (mediaType, descriptor: _serializerSelector.Select(mediaType)))
-                .Where(p => p.descriptor != null)
-                .OrderByDescending(p => p.descriptor.GetValueOrDefault().Quality)
-                .Select(p => p.mediaType)
-                .FirstOrDefault();
+        public ILocatedOpenApiElement<OpenApiMediaType>? Select(ILocatedOpenApiElement<OpenApiResponse> response)
+        {
+            ILocatedOpenApiElement<OpenApiMediaType>? highestPriorityMediaType = null;
+            double? highestQuality = null;
+
+            // Select the highest priority media type. In the event of a tie, the first one wins. In the event there
+            // is no matching serializer, select the first binary string.
+            foreach (var mediaType in response.GetMediaTypes())
+            {
+                double quality = _serializerSelector.Select(mediaType)?.Quality ?? 0.0;
+                if (quality == 0 && mediaType.Element.Schema is not { Type: "string", Format: "binary" })
+                {
+                    // Don't allow a media type with no serializer to be selected unless it's a binary string
+                    continue;
+                }
+
+                if (highestQuality is null || quality > highestQuality)
+                {
+                    highestQuality = quality;
+                    highestPriorityMediaType = mediaType;
+                }
+            }
+
+            return highestPriorityMediaType;
+        }
     }
 }

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
+using Yardarm.Helpers;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -30,8 +31,7 @@ namespace Yardarm.Generation.Schema
                     "byte" => ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)),
                         SingletonList(ArrayRankSpecifier(
                             SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression())))),
-                    "binary" => QualifiedName(QualifiedName(IdentifierName("System"), IdentifierName("IO")),
-                        IdentifierName("Stream")),
+                    "binary" => WellKnownTypes.System.IO.Stream.Name,
                     _ => PredefinedType(Token(SyntaxKind.StringKeyword))
                 },
                 isGenerated: false);

--- a/src/main/Yardarm/GenerationContext.cs
+++ b/src/main/Yardarm/GenerationContext.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using NuGet.Frameworks;
@@ -17,6 +19,9 @@ namespace Yardarm
         private readonly Lazy<INameFormatterSelector> _nameFormatterSelector;
         private readonly Lazy<ITypeGeneratorRegistry> _typeGeneratorRegistry;
 
+        private NuGetFramework _currentTargetFramework = NuGetFramework.UnsupportedFramework;
+        private HashSet<string>? _preprocessorSymbols;
+
         public OpenApiDocument Document => _openApiDocument.Value;
         public IOpenApiElementRegistry ElementRegistry => _elementRegistry.Value;
         public INamespaceProvider NamespaceProvider => _namespaceProvider.Value;
@@ -24,7 +29,19 @@ namespace Yardarm
 
         public ITypeGeneratorRegistry TypeGeneratorRegistry => _typeGeneratorRegistry.Value;
 
-        public NuGetFramework CurrentTargetFramework { get; set; } = NuGetFramework.UnsupportedFramework;
+        public NuGetFramework CurrentTargetFramework
+        {
+            get => _currentTargetFramework;
+            set
+            {
+                ArgumentNullException.ThrowIfNull(value);
+                _currentTargetFramework = value;
+                _preprocessorSymbols = null;
+            }
+        }
+
+        public IReadOnlySet<string> PreprocessorSymbols =>
+            _preprocessorSymbols ??= GetPreprocessorSymbols(CurrentTargetFramework);
 
         public GenerationContext(IServiceProvider serviceProvider) : base(serviceProvider)
         {
@@ -35,6 +52,63 @@ namespace Yardarm
                 new Lazy<INameFormatterSelector>(serviceProvider.GetRequiredService<INameFormatterSelector>);
             _typeGeneratorRegistry =
                 new Lazy<ITypeGeneratorRegistry>(serviceProvider.GetRequiredService<ITypeGeneratorRegistry>);
+        }
+
+        private static HashSet<string> GetPreprocessorSymbols(NuGetFramework targetFramework) =>
+            new(targetFramework switch
+            {
+                { Framework: NuGetFrameworkConstants.NetStandardFramework } =>
+                    GetNetStandardPreprocessorSymbols(targetFramework.Version),
+                { Framework: NuGetFrameworkConstants.NetCoreApp, Version.Major: < 5 } =>
+                    GetNetCoreAppPreprocessorSymbols(targetFramework.Version),
+                { Framework: NuGetFrameworkConstants.NetCoreApp, Version.Major: >= 5 } =>
+                    GetNetPreprocessorSymbols(targetFramework.Version),
+                _ => Enumerable.Empty<string>()
+            });
+
+        private static IEnumerable<string> GetNetStandardPreprocessorSymbols(Version frameworkVersion)
+        {
+            var result = new List<string> { "NETSTANDARD", $"NETSTANDARD{frameworkVersion.Major}_{frameworkVersion.Minor}" };
+
+            foreach (var version in new Version[] { new(2, 0), new(2, 1) }
+                         .Where(p => p <= frameworkVersion))
+            {
+                result.Add($"NETSTANDARD{version.Major}_{version.Minor}_OR_GREATER");
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<string> GetNetCoreAppPreprocessorSymbols(Version frameworkVersion)
+        {
+            var result = new List<string>
+            {
+                "NETCOREAPP", $"NETCOREAPP{frameworkVersion.Major}_{frameworkVersion.Minor}"
+            };
+
+            foreach (var version in new Version[] { new(2, 0), new(2, 1), new(3, 0), new(3, 1) }
+                         .Where(p => p <= frameworkVersion))
+            {
+                result.Add($"NETCOREAPP{version.Major}_{version.Minor}_OR_GREATER");
+            }
+
+            return result;
+        }
+
+        private static IEnumerable<string> GetNetPreprocessorSymbols(Version frameworkVersion)
+        {
+            var result = new List<string> { $"NET{frameworkVersion.Major}_{frameworkVersion.Minor}" };
+
+            foreach (var version in new Version[] { new(5, 0), new(6, 0), new(7, 0), new(8, 0) }
+                         .Where(p => p <= frameworkVersion))
+            {
+                result.Add($"NET{version.Major}_{version.Minor}_OR_GREATER");
+            }
+
+            // Also include all .NET Core 3.1 symbols except NETCOREAPP3_1
+            result.AddRange(GetNetCoreAppPreprocessorSymbols(new Version(3, 1)).Except(new[] { "NETCOREAPP3_1" }));
+
+            return result;
         }
     }
 }

--- a/src/main/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.cs
@@ -174,6 +174,20 @@ namespace Yardarm.Helpers
                     IdentifierName("IDisposable"));
             }
 
+            public static class IO
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    System.Name,
+                    IdentifierName("IO"));
+
+                public static class Stream
+                {
+                    public static NameSyntax Name { get; } = QualifiedName(
+                        IO.Name,
+                        IdentifierName("Stream"));
+                }
+            }
+
             public static partial class Net
             {
                 public static NameSyntax Name { get; } = QualifiedName(


### PR DESCRIPTION
Motivation
----------
Binary responses are currently difficult to receive because you must extract the stream from a nested `HttpResponseMessage` object.

Modifications
-------------
Expose the stream as the body whenever there is no response content type that matches a known serializer and the body type is marked as binary in the spec.

Resolves #213