### PR TITLE
Use JsonSerializerContext to support STJ trimming

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/ModelSerializerContext.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/ModelSerializerContext.cs
@@ -1,0 +1,21 @@
+﻿#if FORTESTS
+
+// This file is included only for local compilation of Yardarm.SystemTextJson.Client to support testing.
+// It is not included in an output SDK from Yardarm, instead Yardarm.SystemTextJson adds its own version
+// of a class with the same name to the compilation.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace RootNamespace.Serialization.Json
+{
+    [JsonSerializable(typeof(FakeModel))]
+    [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization)]
+    public partial class ModelSerializerContext : JsonSerializerContext
+    {
+
+    }
+
+    public class FakeModel { }
+}
+#endif

--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <RootNamespace>RootNamespace</RootNamespace>
     <OutputType>Library</OutputType>
 

--- a/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -122,6 +122,32 @@ namespace Yardarm.SystemTextJson.Helpers
                 QualifiedName(Name, GenericName(Identifier("JsonConverter"),
                     TypeArgumentList(SingletonSeparatedList(t))));
 
+            public static NameSyntax JsonSerializableAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonSerializableAttribute"));
+
+            public static NameSyntax JsonSerializerContextName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonSerializerContext"));
+
+            public static class JsonSourceGenerationMode
+            {
+                // ReSharper disable once MemberHidesStaticFromOuterClass
+                public static NameSyntax Name { get; } = QualifiedName(
+                    SystemTextJsonTypes.Serialization.Name,
+                    IdentifierName("JsonSourceGenerationMode"));
+
+                // ReSharper disable once MemberHidesStaticFromOuterClass
+                public static MemberAccessExpressionSyntax Metadata { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("Metadata"));
+            }
+
+            public static NameSyntax JsonSourceGenerationOptionsAttributeName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonSourceGenerationOptionsAttribute"));
+                
             public static TypeSyntax JsonStringEnumConverterName(TypeSyntax enumType) =>
                 QualifiedName(Name, GenericName(Identifier("JsonStringEnumConverter"),
                     TypeArgumentList(SingletonSeparatedList(enumType))));

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Yardarm.Generation;
+using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson.Internal
+{
+    /// <summary>
+    /// Creates an empty <see cref="JsonSerializerContext"/> which will later be enriched with
+    /// <see cref="JsonSerializableAttribute"/> attributes.
+    /// </summary>
+    internal class JsonSerializerContextGenerator : ISyntaxTreeGenerator
+    {
+        public static SyntaxAnnotation GeneratorAnnotation { get; } = new(
+            GeneratorSyntaxNodeExtensions.GeneratorAnnotationName,
+            typeof(JsonSerializerContextGenerator).FullName);
+
+        public static SyntaxToken TypeName { get; } = Identifier("ModelSerializerContext");
+
+        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
+
+        public JsonSerializerContextGenerator(IJsonSerializationNamespace jsonSerializationNamespace)
+        {
+            ArgumentNullException.ThrowIfNull(jsonSerializationNamespace);
+
+            _jsonSerializationNamespace = jsonSerializationNamespace;
+        }
+
+        public IEnumerable<SyntaxTree> Generate()
+        {
+            // Create a partial class inherited from JsonSerializerContext with the attributes applied
+            var classDeclaration =
+                ClassDeclaration(
+                    SingletonList(AttributeList(SingletonSeparatedList(Attribute(
+                        SystemTextJsonTypes.Serialization.JsonSourceGenerationOptionsAttributeName)))),
+                    TokenList(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.PartialKeyword)),
+                    TypeName,
+                    null,
+                    BaseList(SingletonSeparatedList<BaseTypeSyntax>(
+                        SimpleBaseType(SystemTextJsonTypes.Serialization.JsonSerializerContextName))),
+                    default,
+                    default)
+                .WithAdditionalAnnotations(GeneratorAnnotation);
+
+            yield return CSharpSyntaxTree.Create(CompilationUnit(
+                default,
+                default,
+                default,
+                SingletonList<MemberDeclarationSyntax>(NamespaceDeclaration(
+                    _jsonSerializationNamespace.Name,
+                    default,
+                    default,
+                    SingletonList<MemberDeclarationSyntax>(classDeclaration)))));
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Enrichment;
+using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson
@@ -18,14 +19,24 @@ namespace Yardarm.SystemTextJson
         }
 
         public ExpressionSyntax Enrich(ExpressionSyntax target) =>
-            InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            // Don't use the Add<T> overload here because it will cause trimming to retain
+            // all constructors. This will then cause IL2026 warnings if trimming is enabled.
+            // Instead create a new instance directly using the default constructor and add it.
+            InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                     target,
-                    GenericName(
-                        Identifier("Add"),
-                        TypeArgumentList(SingletonSeparatedList<TypeSyntax>(_jsonSerializationNamespace.JsonTypeSerializer)))))
-                .AddArgumentListArguments(
+                    IdentifierName("Add")),
+                ArgumentList(SeparatedList(new[]
+                {
                     Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         _jsonSerializationNamespace.JsonTypeSerializer,
-                        IdentifierName("SupportedMediaTypes"))));
+                        IdentifierName("SupportedMediaTypes"))),
+                    Argument(ObjectCreationExpression(_jsonSerializationNamespace.JsonTypeSerializer,
+                        ArgumentList(SingletonSeparatedList(
+                            Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                                QualifiedName(_jsonSerializationNamespace.Name, IdentifierName(JsonSerializerContextGenerator.TypeName)),
+                                IdentifierName("Default"))))),
+                            null))
+                })));
     }
 }

--- a/src/main/Yardarm.SystemTextJson/JsonSerializableEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonSerializableEnricher.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment.Compilation;
+using Yardarm.Generation;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.SystemTextJson.Helpers;
+using Yardarm.SystemTextJson.Internal;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson
+{
+    /// <summary>
+    /// Adds <see cref="JsonSerializableAttribute"/> for each schema to the ModelSerializerContext.
+    /// </summary>
+    internal class JsonSerializableEnricher : ICompilationEnricher
+    {
+        private readonly ITypeGeneratorRegistry<OpenApiSchema> _schemaGeneratorRegistry;
+        private readonly string _rootNamespacePrefix;
+
+        public Type[] ExecuteAfter { get; } =
+        {
+            typeof(ResourceFileCompilationEnricher),
+            typeof(SyntaxTreeCompilationEnricher)
+        };
+
+        public JsonSerializableEnricher(ITypeGeneratorRegistry<OpenApiSchema> schemaGeneratorRegistry, IRootNamespace rootNamespace)
+        {
+            ArgumentNullException.ThrowIfNull(schemaGeneratorRegistry);
+
+            _schemaGeneratorRegistry = schemaGeneratorRegistry;
+            _rootNamespacePrefix = rootNamespace.Name + ".";
+        }
+
+        public ValueTask<CSharpCompilation> EnrichAsync(CSharpCompilation target, CancellationToken cancellationToken = default)
+        {
+            foreach (var syntaxTree in target.SyntaxTrees)
+            {
+                var compilationUnit = syntaxTree.GetRoot(cancellationToken);
+                var declarations = compilationUnit
+                    .GetAnnotatedNodes(JsonSerializerContextGenerator.GeneratorAnnotation)
+                    .OfType<ClassDeclarationSyntax>()
+                    .ToArray();
+
+                if (declarations.Length > 0)
+                {
+                    var newCompilationUnit = compilationUnit.ReplaceNodes(
+                        declarations,
+                        AddAttributes);
+
+                    target = target.ReplaceSyntaxTree(syntaxTree,
+                        syntaxTree.WithRootAndOptions(newCompilationUnit, syntaxTree.Options));
+                }
+            }
+
+            return new(target);
+        }
+
+        public ClassDeclarationSyntax AddAttributes(ClassDeclarationSyntax _, ClassDeclarationSyntax currentDeclaration)
+        {
+            // Collect a list of schemas which have types generated
+            var types = _schemaGeneratorRegistry.GetAll()
+                .OfType<TypeGeneratorBase<OpenApiSchema>>()
+                .Where(p => p.Element.IsJsonSchema())
+                .Select(p =>
+                {
+                    YardarmTypeInfo typeInfo = p.TypeInfo;
+
+                    TypeSyntax modelName = typeInfo.Name;
+                    bool isList = false;
+                    if (!typeInfo.IsGenerated
+                        && WellKnownTypes.System.Collections.Generic.ListT.IsOfType(modelName, out var genericArgument))
+                    {
+                        isList = true;
+                        modelName = genericArgument;
+                    }
+
+                    return (typeInfo, modelName, isList);
+                })
+                .Where(p => p.isList || p.typeInfo.IsGenerated);
+
+            // Generate JsonSerializable attributes for each type
+            var typeInfoPropertyName = NameEquals(IdentifierName("TypeInfoPropertyName"));
+            var attributeLists = types.Select(type =>
+                AttributeList(SingletonSeparatedList(Attribute(
+                    SystemTextJsonTypes.Serialization.JsonSerializableAttributeName,
+                    AttributeArgumentList(SeparatedList(new[]
+                    {
+                        AttributeArgument(TypeOfExpression(type.typeInfo.Name)),
+                        AttributeArgument(
+                            typeInfoPropertyName,
+                            default,
+                            SyntaxHelpers.StringLiteral(GetPropertyName(type.modelName, type.isList)))
+                    }))))));
+
+            return currentDeclaration.WithAttributeLists(currentDeclaration.AttributeLists.AddRange(attributeLists));
+        }
+
+        // Since we may have multiple models with the same name but nested within different classes, we need
+        // to avoid collisions by giving them a unique name.
+        private string GetPropertyName(TypeSyntax typeName, bool isList)
+        {
+            const string listNamePrefix = "__List_";
+
+            ReadOnlySpan<char> typeNameString = typeName.ToString().AsSpan();
+
+            if (typeNameString.StartsWith("global::"))
+            {
+                typeNameString = typeNameString.Slice("global::".Length);
+            }
+            if (typeNameString.StartsWith(_rootNamespacePrefix))
+            {
+                typeNameString = typeNameString.Slice(_rootNamespacePrefix.Length);
+            }
+
+            Span<char> dest = stackalloc char[typeNameString.Length + listNamePrefix.Length];
+
+            int length = 0;
+            if (isList)
+            {
+                listNamePrefix.CopyTo(dest);
+                length += listNamePrefix.Length;
+            }
+
+            // Skip separators
+            foreach (char ch in typeNameString)
+            {
+                dest[length++] = ch switch
+                {
+                    '.' => '_',
+                    '<' or '>' => 'ſ',
+                    _ => ch
+                };
+            }
+
+            return new string(dest.Slice(0, length));
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.OpenApi.Models;
 using Yardarm.Enrichment;
+using Yardarm.Enrichment.Compilation;
 using Yardarm.Generation;
 using Yardarm.Packaging;
 using Yardarm.Serialization;
@@ -12,6 +13,8 @@ namespace Yardarm.SystemTextJson
 {
     public class SystemTextJsonExtension : YardarmExtension
     {
+        public override bool IsOutputTrimmable(GenerationContext context) => true;
+
         public override IServiceCollection ConfigureServices(IServiceCollection services)
         {
             services
@@ -26,6 +29,8 @@ namespace Yardarm.SystemTextJson
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, DiscriminatorConverterGenerator>()
+                .AddSingleton<ISyntaxTreeGenerator, JsonSerializerContextGenerator>()
+                .AddSingleton<ICompilationEnricher, JsonSerializableEnricher>()
                 .TryAddTypeGeneratorFactory<OpenApiSchema, SystemTextJsonGeneratorCategory, DiscriminatorConverterTypeGeneratorFactory>();
 
             services


### PR DESCRIPTION
Motivation
----------
When using System.Text.Json serialization support for NativeAOT would be beneficial, especially for Blazor WASM consumers of the generated SDKs. Compatibility with trimming is also beneficial for other apps.

Modifications
-------------
Generate and use a JsonSerializerContext for all model serialization and deserialization by default.

Relates to #158