### PR TITLE
Treat "date-span" string formats as System.TimeSpan

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -132,26 +132,30 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().Be("2020-01-02T03:04:05.0000000-04:00");
         }
 
-        [Fact]
-        public void Serialize_TimeSpan_ReturnsString()
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void Serialize_TimeSpan_ReturnsString(string format)
         {
             // Act
 
             string result = LiteralSerializer.Instance.Serialize(
-                new TimeSpan(0, 3, 4, 5), "partial-time");
+                new TimeSpan(0, 3, 4, 5), format);
 
             // Assert
 
             result.Should().Be("03:04:05");
         }
 
-        [Fact]
-        public void Serialize_TimeSpanMillis_ReturnsString()
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void Serialize_TimeSpanMillis_ReturnsString(string format)
         {
             // Act
 
             string result = LiteralSerializer.Instance.Serialize(
-                new TimeSpan(0, 3, 4, 5, 123), "partial-time");
+                new TimeSpan(0, 3, 4, 5, 123), format);
 
             // Assert
 
@@ -288,24 +292,28 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().Be(new DateTime(2020, 01, 02));
         }
 
-        [Fact]
-        public void Deserialize_TimeSpan_ReturnsString()
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void Deserialize_TimeSpan_ReturnsString(string format)
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02", "partial-time");
+            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02", format);
 
             // Assert
 
             result.Should().Be(new TimeSpan(0, 13, 1, 2));
         }
 
-        [Fact]
-        public void Deserialize_TimeSpanWithMillis_ReturnsString()
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void Deserialize_TimeSpanWithMillis_ReturnsString(string format)
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02.234000", "partial-time");
+            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02.234000", format);
 
             // Assert
 

--- a/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/LiteralSerializer.cs
@@ -137,7 +137,7 @@ namespace RootNamespace.Serialization
             {
                 return (T)(object)(format switch
                 {
-                    "partial-time" => TimeSpan.ParseExact(value, "c", CultureInfo.InvariantCulture),
+                    "partial-time" or "date-span" => TimeSpan.ParseExact(value, "c", CultureInfo.InvariantCulture),
                     _ => TimeSpan.Parse(value, CultureInfo.InvariantCulture)
                 });
             }

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -24,7 +24,7 @@ namespace Yardarm.Generation.Schema
                 Element.Element.Format switch
                 {
                     "date" or "full-date" => QualifiedName(IdentifierName("System"), IdentifierName("DateTime")),
-                    "partial-time" => QualifiedName(IdentifierName("System"), IdentifierName("TimeSpan")),
+                    "partial-time" or "date-span" => QualifiedName(IdentifierName("System"), IdentifierName("TimeSpan")),
                     "date-time" => QualifiedName(IdentifierName("System"), IdentifierName("DateTimeOffset")),
                     "uuid" => QualifiedName(IdentifierName("System"), IdentifierName("Guid")),
                     "uri" => QualifiedName(IdentifierName("System"), IdentifierName("Uri")),


### PR DESCRIPTION
Motivation
----------
Swashbuckle commonly outputs TimeSpan types as `date-span` string formats in the output Swagger specifications.

Modifications
-------------
Treat `date-span` the same as `partial-time`.

Fixes #214