### PR TITLE
Add support for cancellation during deserialization

### DIFF
--- a/src/main/Yardarm.Client/Internal/ThrowHelper.cs
+++ b/src/main/Yardarm.Client/Internal/ThrowHelper.cs
@@ -31,6 +31,12 @@ namespace Yardarm.Client.Internal
 #endif
         }
 
+        [DoesNotReturn]
+        public static void ThrowArgumentException(string? message, string? paramName)
+        {
+            throw new ArgumentException(message, paramName);
+        }
+
 #if !NET6_0_OR_GREATER
         // Use a separate method to throw so that ThrowIfNull may be inlined
         [DoesNotReturn]

--- a/src/main/Yardarm.Client/Responses/UnknownResponse.cs
+++ b/src/main/Yardarm.Client/Responses/UnknownResponse.cs
@@ -17,7 +17,7 @@ namespace RootNamespace.Responses
         [return: MaybeNull]
         public ValueTask<T> GetBodyAsync<T>(CancellationToken cancellationToken = default) =>
             Message.Content != null
-                ? TypeSerializerRegistry.DeserializeAsync<T>(Message.Content)
+                ? TypeSerializerRegistry.DeserializeAsync<T>(Message.Content, cancellationToken: cancellationToken)
                 : new ValueTask<T>(default(T)!);
     }
 }

--- a/src/main/Yardarm.Client/Serialization/ITypeSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/ITypeSerializer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
@@ -8,6 +9,24 @@ namespace RootNamespace.Serialization
     {
         HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null);
 
-        ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null);
+        // Retained for backward compatibility of the public API surface in the generated SDK. The overload
+        // with a CancellationToken simply forwards to this implementation by default if not explicitly implemented.
+        // Implementations which support cancellation should implement the overload with a CancellationToken and
+        // forward calls from this method to that overload. Note that .NET Standard 2.0 does not support default
+        // interface implementations, so this is a breaking change for SDKs targeting .NET Standard 2.0 which must
+        // implement both variants.
+        ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData);
+
+        ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            CancellationToken cancellationToken = default)
+#if NETCOREAPP3_1_OR_GREATER
+        {
+            // We can only provide a default implementation for .NET 6 and later
+            return DeserializeAsync<T>(content, serializationData);
+        }
+#else
+        ;
+#endif
     }
 }

--- a/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/MultipartFormDataSerializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Yardarm.Client.Internal;
 
@@ -47,14 +48,21 @@ namespace RootNamespace.Serialization
         {
             if (serializationData is not MultipartFormDataSerializationData<T> multipartData)
             {
-                throw new ArgumentException(
-                    $"{nameof(serializationData)} must be of type {typeof(MultipartFormDataSerializationData<T>).FullName}.");
+                ThrowHelper.ThrowArgumentException(
+                    $"{nameof(serializationData)} must be of type {typeof(MultipartFormDataSerializationData<T>).FullName}.",
+                    nameof(serializationData));
+                return null!; // unreachable
             }
 
             return Serialize(value, mediaType, multipartData);
         }
 
-        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null) =>
+        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData) =>
+            throw new NotImplementedException();
+
+        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            CancellationToken cancellationToken = default) =>
             throw new NotImplementedException();
     }
 }

--- a/src/main/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
+++ b/src/main/Yardarm.Client/Serialization/TypeSerializerRegistryExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
@@ -66,8 +67,15 @@ namespace RootNamespace.Serialization
             return typeSerializerRegistry;
         }
 
+        // Retained for backward compatibility of the public API surface in the generated SDK
         public static ValueTask<T> DeserializeAsync<T>(this ITypeSerializerRegistry typeSerializerRegistry,
-            HttpContent content, ISerializationData? serializationData = null)
+            HttpContent content, ISerializationData? serializationData) =>
+            typeSerializerRegistry.DeserializeAsync<T>(content, serializationData, default);
+
+        public static ValueTask<T> DeserializeAsync<T>(this ITypeSerializerRegistry typeSerializerRegistry,
+            HttpContent content, ISerializationData? serializationData = null,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            CancellationToken cancellationToken = default)
         {
             string? mediaType = content.Headers.ContentType?.MediaType;
 
@@ -80,7 +88,7 @@ namespace RootNamespace.Serialization
                 }
             }
 
-            return typeSerializer.DeserializeAsync<T>(content, serializationData);
+            return typeSerializer.DeserializeAsync<T>(content, serializationData, cancellationToken);
         }
 
         public static HttpContent Serialize<T>(this ITypeSerializerRegistry typeSerializerRegistry,

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading;
 using System.Threading.Tasks;
 using Yardarm.Client.Internal;
 
@@ -54,7 +55,16 @@ namespace RootNamespace.Serialization.Json
         public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
             JsonContent.Create(value, _options.GetTypeInfo(typeof(T)), new MediaTypeHeaderValue(mediaType) {CharSet = Encoding.UTF8.WebName});
 
-        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null) =>
-            new(content.ReadFromJsonAsync((JsonTypeInfo<T>) _options.GetTypeInfo(typeof(T)))!);
+        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData) =>
+            DeserializeAsync<T>(content, serializationData, default);
+
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026",
+            Justification = "Incompatible constructors are marked with RequiresUnreferencedCode")]
+        [UnconditionalSuppressMessage("Aot", "IL3050",
+            Justification = "Incompatible constructors are marked with RequiresDynamicCode")]
+        public ValueTask<T> DeserializeAsync<T>(HttpContent content, ISerializationData? serializationData = null,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            CancellationToken cancellationToken = default) =>
+            new(content.ReadFromJsonAsync<T>(_options, cancellationToken)!);
     }
 }

--- a/src/main/Yardarm/Generation/Response/GetBodyMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Response/GetBodyMethodGenerator.cs
@@ -91,7 +91,8 @@ namespace Yardarm.Generation.Response
                         Argument(IdentifierName("TypeSerializerRegistry")), Argument(MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             IdentifierName("Message"),
-                            IdentifierName("Content")))
+                            IdentifierName("Content"))),
+                        Argument(NameColon("cancellationToken"), default, IdentifierName("cancellationToken"))
                     }))));
             }
             else


### PR DESCRIPTION
Motivation
----------
Now that we support streaming response bodies to the deserializer it's more likely that we could encounter a cancellation while deserializing. We should respect the request for cancellation where possible.

Modifications
-------------
Add an overload of `DeserializeAsync` to `ITypeSerializer` and `TypeSerializerRegistryExtensions` that accepts a cancellation token. For modern runtimes add a default implementation for the new overload in `ITypeSerializer`.

Use the cancellation token parameter wherever possible. For legacy frameworks that don't accept the cancellation token when requesting the response body from `HttpResponseContent` at least verify the token before making the call.

Results
-------
Cancellation is now supported for most cases, including all of the most common cases, when deserializing.

BREAKING CHANGE
----------------------

Custom implementations of `ITypeSerializer` in an extension must implement both overloads if they support generating SDKs targeting .NET Standard 2.0.

This may also affect SDK consumers if they use their own custom `ITypeSerializer` implementations and are using a .NET Standard 2.0 SDK. This could occur if the consumer is targeting .NET Framework, the consumer is an intermediate NuGet package targeting .NET Standard 2.0, or any case where the SDK is only distributed as a .NET Standard 2.0 package without a secondary modern runtime such as .NET 6 included in the NuGet package. It is recommended that any SDK distribution that includes .NET Standard 2.0 also include .NET 6 assembly at a minimum.