### PR TITLE
Fixup package source mapping

### DIFF
--- a/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 

--- a/src/main/Yardarm.NewtonsoftJson/JsonDependencyGenerator.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonDependencyGenerator.cs
@@ -16,7 +16,7 @@ namespace Yardarm.NewtonsoftJson
                 {
                     Name = "Newtonsoft.Json",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("13.0.1")
+                    VersionRange = VersionRange.Parse("13.0.3")
                 }
             };
         }

--- a/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
+++ b/src/main/Yardarm/Packaging/Internal/NuGetRestoreProcessor.cs
@@ -71,7 +71,7 @@ namespace Yardarm.Packaging.Internal
                     SettingsUtility.GetGlobalPackagesFolder(settings),
                     Enumerable.Empty<string>(),
                     SettingsUtility.GetEnabledSources(settings).Select(source =>
-                        Repository.Factory.GetCoreV3(source.Source)),
+                        Repository.Factory.GetCoreV3(source)),
                     cacheContext,
                     new LocalPackageFileCache(),
                     logger);

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NuGet.Commands" Version="6.7.0" />
+    <PackageReference Include="NuGet.Commands" Version="6.8.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>


### PR DESCRIPTION
Motivation
----------
Package source mapping doesn't always match sources by name.

Modifications
-------------
Upgrade the NuGet version and change the overload used to create sources. This also required upgrading Newtonsoft.Json.