### PR TITLE
Avoid NRT warnings if consumer upgrades to Microsoft.Extensions.Http 7.x

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/YardarmConfigureHttpClientFactoryOptions.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Internal/YardarmConfigureHttpClientFactoryOptions.cs
@@ -21,7 +21,7 @@ namespace RootNamespace.Internal
 
         public void Configure(HttpClientFactoryOptions options) => Configure(Options.DefaultName, options);
 
-        public void Configure(string name, HttpClientFactoryOptions options)
+        public void Configure(string? name, HttpClientFactoryOptions options)
         {
             ThrowHelper.ThrowIfNull(options, nameof(options));
 


### PR DESCRIPTION
Motivation
----------
The name parameter should be annotated as nullable to match the nullability annotations in Microsoft.Extensiosn.Http 7.x and greater to avoid warnings.

Modifications
-------------
Fix the annotation.

Results
-------
No warnings with the default 6.x version or newer versions.