### PR TITLE
Optimize schema type info for some common types

### DIFF
--- a/src/main/Yardarm/Generation/Schema/BooleanSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/BooleanSchemaGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,19 +10,20 @@ namespace Yardarm.Generation.Schema
 {
     public class BooleanSchemaGenerator : ITypeGenerator
     {
-        public static BooleanSchemaGenerator Instance { get; } = new BooleanSchemaGenerator();
-
-        public ITypeGenerator? Parent => null;
-
-        public YardarmTypeInfo TypeInfo { get; } = new YardarmTypeInfo(
+        private static readonly YardarmTypeInfo s_typeInfo = new(
             SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword)),
             NameKind.Struct,
             isGenerated: false);
 
+        public static BooleanSchemaGenerator Instance { get; } = new();
+
+        public ITypeGenerator? Parent => null;
+
+        public YardarmTypeInfo TypeInfo => s_typeInfo;
+
         public SyntaxTree? GenerateSyntaxTree() => null;
 
-        public IEnumerable<MemberDeclarationSyntax> Generate() =>
-            Enumerable.Empty<MemberDeclarationSyntax>();
+        public IEnumerable<MemberDeclarationSyntax> Generate() => [];
 
         public QualifiedNameSyntax? GetChildName<TChild>(ILocatedOpenApiElement<TChild> child, NameKind nameKind)
             where TChild : IOpenApiElement =>

--- a/src/main/Yardarm/Generation/Schema/DynamicSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/DynamicSchemaGenerator.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Schema
+{
+    public sealed class DynamicSchemaGenerator(
+        ILocatedOpenApiElement<OpenApiSchema> element,
+        GenerationContext context,
+        ITypeGenerator? parent)
+        : TypeGeneratorBase<OpenApiSchema>(element, context, parent)
+    {
+        internal static YardarmTypeInfo DynamicObjectTypeInfo { get; }  = new(
+            NullableType(PredefinedType(Token(SyntaxKind.ObjectKeyword))),
+            isGenerated: false,
+            requiresDynamicSerialization: true);
+
+        protected override YardarmTypeInfo GetTypeInfo() => DynamicObjectTypeInfo;
+
+        public override IEnumerable<MemberDeclarationSyntax> Generate() => [];
+    }
+}

--- a/src/main/Yardarm/Generation/Schema/NullSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/NullSchemaGenerator.cs
@@ -1,18 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Interfaces;
 using Yardarm.Names;
 using Yardarm.Spec;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.Generation.Schema
 {
+    [Obsolete("Use DynamicSchemaGenerator instead.")]
     public class NullSchemaGenerator : ITypeGenerator
     {
-        public static NullSchemaGenerator Instance { get; } = new NullSchemaGenerator();
+        public static NullSchemaGenerator Instance { get; } = new();
 
         public ITypeGenerator? Parent => null;
 
@@ -20,14 +20,11 @@ namespace Yardarm.Generation.Schema
         {
         }
 
-        public YardarmTypeInfo TypeInfo { get; } = new(
-            NullableType(PredefinedType(Token(SyntaxKind.ObjectKeyword))),
-            isGenerated: false);
+        public YardarmTypeInfo TypeInfo => DynamicSchemaGenerator.DynamicObjectTypeInfo;
 
         public SyntaxTree? GenerateSyntaxTree() => null;
 
-        public IEnumerable<MemberDeclarationSyntax> Generate() =>
-            Enumerable.Empty<MemberDeclarationSyntax>();
+        public IEnumerable<MemberDeclarationSyntax> Generate() => [];
 
         public QualifiedNameSyntax? GetChildName<TChild>(ILocatedOpenApiElement<TChild> child, NameKind nameKind)
             where TChild : IOpenApiElement =>

--- a/src/main/Yardarm/Generation/Schema/NumberSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/NumberSchemaGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -10,35 +9,53 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.Generation.Schema
 {
-    public class NumberSchemaGenerator : TypeGeneratorBase<OpenApiSchema>
+    public class NumberSchemaGenerator(
+        ILocatedOpenApiElement<OpenApiSchema> schemaElement,
+        GenerationContext context,
+        ITypeGenerator? parent)
+        : TypeGeneratorBase<OpenApiSchema>(schemaElement, context, parent)
     {
-        public NumberSchemaGenerator(ILocatedOpenApiElement<OpenApiSchema> schemaElement, GenerationContext context,
-            ITypeGenerator? parent)
-            : base(schemaElement, context, parent)
-        {
-        }
+        private static YardarmTypeInfo? s_integer;
+        private static YardarmTypeInfo Integer => s_integer ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.IntKeyword)), NameKind.Struct, isGenerated: false);
+
+        private static YardarmTypeInfo? s_long;
+        private static YardarmTypeInfo Long => s_long ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.LongKeyword)), NameKind.Struct, isGenerated: false);
+
+        private static YardarmTypeInfo? s_byte;
+        private static YardarmTypeInfo Byte => s_byte ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.ByteKeyword)), NameKind.Struct, isGenerated: false);
+
+        private static YardarmTypeInfo? s_decimal;
+        private static YardarmTypeInfo Decimal => s_decimal ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.DecimalKeyword)), NameKind.Struct, isGenerated: false);
+
+        private static YardarmTypeInfo? s_float;
+        private static YardarmTypeInfo Float => s_float ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.FloatKeyword)), NameKind.Struct, isGenerated: false);
+
+        private static YardarmTypeInfo? s_double;
+        private static YardarmTypeInfo Double => s_double ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.DoubleKeyword)), NameKind.Struct, isGenerated: false);
 
         protected override YardarmTypeInfo GetTypeInfo() =>
-            new YardarmTypeInfo(
-                (Element.Element.Type, Element.Element.Format) switch
-                {
-                    (_, "int32") => PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    (_, "integer") => PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    (_, "int") => PredefinedType(Token(SyntaxKind.IntKeyword)),
-                    (_, "int64") => PredefinedType(Token(SyntaxKind.LongKeyword)),
-                    (_, "byte") => PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                    ("integer", _) => PredefinedType(Token(SyntaxKind.LongKeyword)),
-                    ("number", "decimal") => PredefinedType(Token(SyntaxKind.DecimalKeyword)),
-                    ("number", "float") => PredefinedType(Token(SyntaxKind.FloatKeyword)),
-                    ("number", _) => PredefinedType(Token(SyntaxKind.DoubleKeyword)),
-                    _ => PredefinedType(Token(SyntaxKind.ObjectKeyword))
-                },
-                NameKind.Struct,
-                isGenerated: false);
+            (Element.Element.Type, Element.Element.Format) switch
+            {
+                (_, "int32") => Integer,
+                (_, "integer") => Integer,
+                (_, "int") => Integer,
+                (_, "int64") => Long,
+                (_, "byte") => Byte,
+                ("integer", _) => Long,
+                ("number", "decimal") => Decimal,
+                ("number", "float") => Float,
+                ("number", _) => Double,
+                _ => DynamicSchemaGenerator.DynamicObjectTypeInfo
+            };
 
         public override SyntaxTree? GenerateSyntaxTree() => null;
 
-        public override IEnumerable<MemberDeclarationSyntax> Generate() =>
-            Enumerable.Empty<MemberDeclarationSyntax>();
+        public override IEnumerable<MemberDeclarationSyntax> Generate() => [];
     }
 }

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,34 +10,62 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.Generation.Schema
 {
-    public class StringSchemaGenerator : TypeGeneratorBase<OpenApiSchema>
+    public class StringSchemaGenerator(
+        ILocatedOpenApiElement<OpenApiSchema> schemaElement,
+        GenerationContext context,
+        ITypeGenerator? parent)
+        : TypeGeneratorBase<OpenApiSchema>(schemaElement, context, parent)
     {
-        public StringSchemaGenerator(ILocatedOpenApiElement<OpenApiSchema> schemaElement, GenerationContext context,
-            ITypeGenerator? parent)
-            : base(schemaElement, context, parent)
-        {
-        }
+        private static YardarmTypeInfo? s_string;
+        private static YardarmTypeInfo String => s_string ??= new YardarmTypeInfo(
+            PredefinedType(Token(SyntaxKind.StringKeyword)), isGenerated: false);
+
+        private static YardarmTypeInfo? s_dateTime;
+        private static YardarmTypeInfo DateTime => s_dateTime ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("DateTime")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_dateTimeOffset;
+        private static YardarmTypeInfo DateTimeOffset => s_dateTimeOffset ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("DateTimeOffset")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_timeSpan;
+        private static YardarmTypeInfo TimeSpan => s_timeSpan ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("TimeSpan")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_guid;
+        private static YardarmTypeInfo Guid => s_guid ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("Guid")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_uri;
+        private static YardarmTypeInfo Uri => s_uri ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("Uri")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_byteArray;
+        private static YardarmTypeInfo ByteArray => s_byteArray ??= new YardarmTypeInfo(
+            ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)),
+                SingletonList(ArrayRankSpecifier(
+                    SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression())))),
+            isGenerated: false);
+
+        private static YardarmTypeInfo? s_binary;
+        private static YardarmTypeInfo Binary => s_binary ??= new YardarmTypeInfo(
+            WellKnownTypes.System.IO.Stream.Name, isGenerated: false);
 
         protected override YardarmTypeInfo GetTypeInfo() =>
-            new YardarmTypeInfo(
-                Element.Element.Format switch
-                {
-                    "date" or "full-date" => QualifiedName(IdentifierName("System"), IdentifierName("DateTime")),
-                    "partial-time" or "date-span" => QualifiedName(IdentifierName("System"), IdentifierName("TimeSpan")),
-                    "date-time" => QualifiedName(IdentifierName("System"), IdentifierName("DateTimeOffset")),
-                    "uuid" => QualifiedName(IdentifierName("System"), IdentifierName("Guid")),
-                    "uri" => QualifiedName(IdentifierName("System"), IdentifierName("Uri")),
-                    "byte" => ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)),
-                        SingletonList(ArrayRankSpecifier(
-                            SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression())))),
-                    "binary" => WellKnownTypes.System.IO.Stream.Name,
-                    _ => PredefinedType(Token(SyntaxKind.StringKeyword))
-                },
-                isGenerated: false);
+            Element.Element.Format switch
+            {
+                "date" or "full-date" => DateTime,
+                "partial-time" or "date-span" => TimeSpan,
+                "date-time" => DateTimeOffset,
+                "uuid" => Guid,
+                "uri" => Uri,
+                "byte" => ByteArray,
+                "binary" => Binary,
+                _ => String
+            };
 
         public override SyntaxTree? GenerateSyntaxTree() => null;
 
-        public override IEnumerable<MemberDeclarationSyntax> Generate() =>
-            Enumerable.Empty<MemberDeclarationSyntax>();
+        public override IEnumerable<MemberDeclarationSyntax> Generate() => [];
     }
 }

--- a/src/main/Yardarm/Names/YardarmTypeInfo.cs
+++ b/src/main/Yardarm/Names/YardarmTypeInfo.cs
@@ -9,18 +9,38 @@ namespace Yardarm.Names
 
         public NameKind Kind { get; }
 
-        public bool IsGenerated { get; }
+        [Flags]
+        private enum Flags : byte
+        {
+            None = 0,
+            Generated = 1,
+            RequiresDynamicSerialization = 2
+        }
 
-        public YardarmTypeInfo(TypeSyntax name, NameKind kind = NameKind.Class, bool isGenerated = true)
+        private readonly Flags _flags;
+
+        public bool IsGenerated => _flags.HasFlag(Flags.Generated);
+
+        public bool RequiresDynamicSerialization => _flags.HasFlag(Flags.RequiresDynamicSerialization);
+
+        public YardarmTypeInfo(TypeSyntax name, NameKind kind, bool isGenerated)
+            : this(name, kind, isGenerated, false)
+        {
+        }
+
+        public YardarmTypeInfo(TypeSyntax name, NameKind kind = NameKind.Class, bool isGenerated = true,
+            bool requiresDynamicSerialization = false)
         {
             ArgumentNullException.ThrowIfNull(name);
 
             Name = name;
             Kind = kind;
-            IsGenerated = isGenerated;
+
+            _flags = (isGenerated ? Flags.Generated : Flags.None) |
+                     (requiresDynamicSerialization ? Flags.RequiresDynamicSerialization : Flags.None);
         }
 
-        private bool Equals(YardarmTypeInfo other) => Name.Equals(other.Name) && Kind == other.Kind && IsGenerated == other.IsGenerated;
+        private bool Equals(YardarmTypeInfo other) => Name.Equals(other.Name) && Kind == other.Kind && _flags == other._flags;
 
         public override bool Equals(object? obj)
         {
@@ -42,6 +62,6 @@ namespace Yardarm.Names
             return Equals((YardarmTypeInfo) obj);
         }
 
-        public override int GetHashCode() => HashCode.Combine(Name, (int) Kind, IsGenerated);
+        public override int GetHashCode() => HashCode.Combine(Name, (int) Kind, _flags);
     }
 }


### PR DESCRIPTION
Motivation
----------
For common types like numbers and strings we're allocating more YardarmTypeInfo objects on the heap than necessary. We'd also like to get more clarity when a given type requires dynamic serialization as this may require additional support by serialization libraries.

Modifications
-------------
- For string and number types use shared static instances of YardarmTypeInfo
- Obsolete the NullSchemaGenerator and replace with the DynamicSchemaGenerator which tracks it's parent element. This allows serialization extenions to recognize if the schema requires certain types of serialization support based on where it's located.
- Add RequiresDynamicSerialization to YardarmTypeInfo and set to true for the DynamicSchemaGenerator