### PR TITLE
Treat simple additional properties objects as dictionaries

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -14,6 +14,10 @@ namespace Yardarm.SystemTextJson.Helpers
                 IdentifierName("Text")),
             IdentifierName("Json"));
 
+        public static NameSyntax JsonElement { get; } = QualifiedName(
+            SystemTextJson,
+            IdentifierName("JsonElement"));
+
         public static NameSyntax JsonSerializer { get; } = QualifiedName(
             SystemTextJson,
             IdentifierName("JsonSerializer"));
@@ -58,6 +62,10 @@ namespace Yardarm.SystemTextJson.Helpers
             public static NameSyntax JsonNodeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonNode"));
+
+            public static NameSyntax JsonObjectName { get; } = QualifiedName(
+                Name,
+                IdentifierName("JsonObject"));
         }
 
         public static class Serialization
@@ -147,7 +155,7 @@ namespace Yardarm.SystemTextJson.Helpers
             public static NameSyntax JsonSourceGenerationOptionsAttributeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonSourceGenerationOptionsAttribute"));
-                
+
             public static TypeSyntax JsonStringEnumConverterName(TypeSyntax enumType) =>
                 QualifiedName(Name, GenericName(Identifier("JsonStringEnumConverter"),
                     TypeArgumentList(SingletonSeparatedList(enumType))));

--- a/src/main/Yardarm/Generation/Schema/DefaultSchemaGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Schema/DefaultSchemaGeneratorFactory.cs
@@ -10,6 +10,12 @@ namespace Yardarm.Generation.Schema
             {
                 { AllOf.Count: > 0 } => new AllOfSchemaGenerator(element, context, parent),
                 { OneOf.Count: > 0 } => new OneOfSchemaGenerator(element, context, parent),
+                {
+                    Type: "object",
+                    AdditionalPropertiesAllowed: true,
+                    Properties: null or { Count: 0 },
+                    AnyOf: null or { Count: 0 } // AllOf and OneOf are handled above, they don't need to be tested here
+                } => GetDictionaryGenerator(element, parent),
                 { Type: "object" } => GetObjectGenerator(element, parent),
                 { Type: "string" } => GetStringGenerator(element, parent),
                 { Type: "number" or "integer" } => GetNumberGenerator(element, parent),
@@ -34,9 +40,8 @@ namespace Yardarm.Generation.Schema
             element.Element.Enum is { Count: > 0 }
                 ? new EnumSchemaGenerator(element, context, parent)
                 : new StringSchemaGenerator(element, context, parent);
-    }
 
-    // For the most common case, this allows inlining of calls to the various Get methods without guarded devirtualization by PGO.
-    internal sealed class DefaultSchemaGeneratorFactorySealed(GenerationContext context)
-        : DefaultSchemaGeneratorFactory(context);
+        protected virtual ITypeGenerator GetDictionaryGenerator(ILocatedOpenApiElement<OpenApiSchema> element, ITypeGenerator? parent) =>
+            new DictionarySchemaGenerator(element, context, parent);
+    }
 }

--- a/src/main/Yardarm/Generation/Schema/DictionarySchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/DictionarySchemaGenerator.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Helpers;
+using Yardarm.Names;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Schema
+{
+    public class DictionarySchemaGenerator(
+        ILocatedOpenApiElement<OpenApiSchema> schemaElement,
+        GenerationContext context,
+        ITypeGenerator? parent)
+        : TypeGeneratorBase<OpenApiSchema>(schemaElement, context, parent)
+    {
+        protected override YardarmTypeInfo GetTypeInfo() =>
+            new(WellKnownTypes.System.Collections.Generic.DictionaryT.Name(
+                    PredefinedType(Token(SyntaxKind.StringKeyword)),
+                    Context.TypeGeneratorRegistry.Get(Element.GetAdditionalPropertiesOrDefault()).TypeInfo.Name),
+                isGenerated: false);
+
+        public override SyntaxTree? GenerateSyntaxTree() => null;
+
+        public override IEnumerable<MemberDeclarationSyntax> Generate() => [];
+    }
+}

--- a/src/main/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.cs
@@ -42,6 +42,27 @@ namespace Yardarm.Helpers
                                 GenericName(
                                     Identifier("Dictionary"),
                                     TypeArgumentList(SeparatedList(new [] {keyType, valueType}))));
+
+                        public static bool IsOfType(TypeSyntax nameSyntax,
+                            [NotNullWhen(true)] out TypeSyntax? keyArgument,
+                            [NotNullWhen(true)] out TypeSyntax? valueArgument)
+                        {
+                            if (nameSyntax is QualifiedNameSyntax qualifiedName && qualifiedName.Left.IsEquivalentTo(Generic.Name))
+                            {
+                                if (qualifiedName.Right is GenericNameSyntax genericName
+                                    && genericName.Identifier.ValueText == "Dictionary"
+                                    && genericName.TypeArgumentList.Arguments.Count == 2)
+                                {
+                                    keyArgument = genericName.TypeArgumentList.Arguments[0];
+                                    valueArgument = genericName.TypeArgumentList.Arguments[1];
+                                    return true;
+                                }
+                            }
+
+                            keyArgument = null;
+                            valueArgument = null;
+                            return false;
+                        }
                     }
 
                     public static class IDictionaryT


### PR DESCRIPTION
Motivation
----------
The current structure for additional properties on objects is difficult for consumers to use. They must deal with type casting and the specific dynamic implementations of each serialization library (JElement or JsonElement, etc). For cases where the object is ONLY made up of additional properties, without any explicitly defined properties, this can be made much simpler by representing it is as dictionary with string keys. In particular, if a schema is defined for the values of the additional properties this can be directly represented as a strong type on the dictionary value.

Modifications
-------------
- Use a Dictionary<string, T> whenever an object with no properties or inheritence allows additional properties
- Improve the JsonSerializerContext property naming hints to handle generics and nullables cleanly
- Ensure that we add JsonElement and JsonObject to the JsonSerializerContext if required

Results
-------
- Simple dictionaries are much easier to consume and fewer nested model types are produced unnecessarily
- This does create a breaking change for generated SDKs moving from 0.4 to 0.5 of Yardarm
- If an OpenAPI schema includes an object with only additional properties and later an explicit property is added it will produce a breaking change in generated SDKs. However, this seems like a rare corner case and the value of supporting simple dictionaries seems to outweigh this concern.

Resolves #203