### PR TITLE
Allow deserializing numbers from strings in STJ

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
+++ b/src/main/Yardarm.SystemTextJson/Helpers/SystemTextJsonTypes.cs
@@ -86,6 +86,18 @@ namespace Yardarm.SystemTextJson.Helpers
                 Name,
                 IdentifierName("JsonIgnoreAttribute"));
 
+            public static class JsonNumberHandling
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    Serialization.Name,
+                    IdentifierName("JsonNumberHandling"));
+
+                public static MemberAccessExpressionSyntax AllowReadingFromString { get; } = MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    Name,
+                    IdentifierName("AllowReadingFromString"));
+            }
+
             public static NameSyntax JsonPolymorphicAttributeName { get; } = QualifiedName(
                 Name,
                 IdentifierName("JsonPolymorphicAttribute"));

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
@@ -37,7 +37,12 @@ namespace Yardarm.SystemTextJson.Internal
             var classDeclaration =
                 ClassDeclaration(
                     SingletonList(AttributeList(SingletonSeparatedList(Attribute(
-                        SystemTextJsonTypes.Serialization.JsonSourceGenerationOptionsAttributeName)))),
+                        SystemTextJsonTypes.Serialization.JsonSourceGenerationOptionsAttributeName,
+                        AttributeArgumentList(SingletonSeparatedList(
+                            AttributeArgument(
+                                nameEquals: NameEquals("NumberHandling"),
+                                nameColon: null,
+                                expression: SystemTextJsonTypes.Serialization.JsonNumberHandling.AllowReadingFromString))))))),
                     TokenList(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.PartialKeyword)),
                     TypeName,
                     null,


### PR DESCRIPTION
It's relatively common for web JSON implementations to return numeric values as strings. So long as they're valid numbers, the SDK should accept them when deserializing.