### PR TITLE
Generate classes for common request bodies

### DIFF
--- a/src/main/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
+++ b/src/main/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
@@ -40,7 +40,7 @@ namespace Yardarm.Generation.Internal
 
         private ITypeGenerator CreateTypeGenerator(ILocatedOpenApiElement<TElement> element)
         {
-            if (LocatedElementEqualityComparer<TElement>.GetIsReferenceEqualDefault() &&
+            if (LocatedElementEqualityComparer<TElement>.IsReferenceEqualDefault &&
                 element.Element is IOpenApiReferenceable referenceable && referenceable.Reference != null)
             {
                 // When making the new type generator with the factory for a reference, we must ensure

--- a/src/main/Yardarm/Spec/LocatedElementEqualityComparer.cs
+++ b/src/main/Yardarm/Spec/LocatedElementEqualityComparer.cs
@@ -13,7 +13,7 @@ namespace Yardarm.Spec
         /// </summary>
         public bool IsReferenceEqual { get; }
 
-        public LocatedElementEqualityComparer() : this(GetIsReferenceEqualDefault())
+        public LocatedElementEqualityComparer() : this(IsReferenceEqualDefault)
         {
         }
 
@@ -78,9 +78,10 @@ namespace Yardarm.Spec
             }
         }
 
-        // For OpenApiResponse, treat the element in the components section as unequal to an element
-        // referencing it in an operation, allowing us to define a separate class for each case.
-        public static bool GetIsReferenceEqualDefault() =>
-            typeof(T) != typeof(OpenApiResponse);
+        // For OpenApiResponse and OpenApiRequestBody, treat the element in the components section
+        // as unequal to an element referencing it in an operation, allowing us to define a separate
+        // class for each case.
+        public static bool IsReferenceEqualDefault { get; } =
+            typeof(T) != typeof(OpenApiResponse) && typeof(T) != typeof(OpenApiRequestBody);
     }
 }


### PR DESCRIPTION
If request bodies are references to shared components we still need to treat them separately, rather than sharing a single instance across all operations that reference the request body. This allows the child media types to track up to their operation parent and generate a separate class for each operation/mediatype combination.

Relates to #239 