### PR TITLE
Skip operations without ids

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
@@ -17,7 +17,7 @@ namespace Yardarm.SystemTextJson.Internal
         public IEnumerable<SyntaxTree> Generate()
         {
             var schemas = document
-                .GetAllSchemas(operationNameProvider)
+                .GetAllSchemasExcludingOperationsWithoutNames(operationNameProvider)
                 .Where(schema => SchemaHelper.IsPolymorphic(schema.Element));
 
             foreach (var schema in schemas)

--- a/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/DiscriminatorConverterGenerator.cs
@@ -4,34 +4,25 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.OpenApi.Models;
 using Yardarm.Generation;
+using Yardarm.Generation.Operation;
 using Yardarm.Spec;
 
 namespace Yardarm.SystemTextJson.Internal
 {
-    internal class DiscriminatorConverterGenerator : ISyntaxTreeGenerator
+    internal class DiscriminatorConverterGenerator(
+        OpenApiDocument document,
+        ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> converterTypeGeneratorRegistry,
+        IOperationNameProvider operationNameProvider) : ISyntaxTreeGenerator
     {
-        private readonly OpenApiDocument _document;
-        private readonly ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> _converterTypeGeneratorRegistry;
-
-        public DiscriminatorConverterGenerator(OpenApiDocument document,
-            ITypeGeneratorRegistry<OpenApiSchema, SystemTextJsonGeneratorCategory> converterTypeGeneratorRegistry)
-        {
-            ArgumentNullException.ThrowIfNull(document);
-            ArgumentNullException.ThrowIfNull(converterTypeGeneratorRegistry);
-
-            _document = document;
-            _converterTypeGeneratorRegistry = converterTypeGeneratorRegistry;
-        }
-
         public IEnumerable<SyntaxTree> Generate()
         {
-            var schemas = _document
-                .GetAllSchemas()
+            var schemas = document
+                .GetAllSchemas(operationNameProvider)
                 .Where(schema => SchemaHelper.IsPolymorphic(schema.Element));
 
             foreach (var schema in schemas)
             {
-                var converterGenerator = _converterTypeGeneratorRegistry.Get(schema);
+                var converterGenerator = converterTypeGeneratorRegistry.Get(schema);
 
                 var syntaxTree = converterGenerator.GenerateSyntaxTree();
                 if (syntaxTree != null)

--- a/src/main/Yardarm/Enrichment/Tags/DeprecatedOperationEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Tags/DeprecatedOperationEnricher.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
 using Yardarm.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -9,19 +10,21 @@ namespace Yardarm.Enrichment.Tags
     /// <summary>
     /// Marks deprecated operations with <see cref="System.ObsoleteAttribute"/>.
     /// </summary>
-    public class DeprecatedOperationEnricher : IOpenApiSyntaxNodeEnricher<MethodDeclarationSyntax, OpenApiOperation>
+    public class DeprecatedOperationEnricher(
+        IOperationNameProvider operationNameProvider)
+        : IOpenApiSyntaxNodeEnricher<MethodDeclarationSyntax, OpenApiOperation>
     {
         public MethodDeclarationSyntax Enrich(MethodDeclarationSyntax target,
             OpenApiEnrichmentContext<OpenApiOperation> context) =>
             context.Element.Deprecated
-                ? MarkObsolete(target, context.Element.OperationId)
+                ? MarkObsolete(target, operationNameProvider.GetOperationName(context.LocatedElement))
                 : target;
 
-        private static MethodDeclarationSyntax MarkObsolete(MethodDeclarationSyntax target, string operationId) =>
+        private static MethodDeclarationSyntax MarkObsolete(MethodDeclarationSyntax target, string? operationName) =>
             target.AddAttributeLists(AttributeList(SingletonSeparatedList(
                 Attribute(WellKnownTypes.System.ObsoleteAttribute.Name,
                     AttributeArgumentList(SingletonSeparatedList(AttributeArgument(
-                        SyntaxHelpers.StringLiteral($"Operation {operationId} has been marked deprecated.")))))))
+                        SyntaxHelpers.StringLiteral($"Operation {operationName} has been marked deprecated.")))))))
                 .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
 
     }

--- a/src/main/Yardarm/Generation/Operation/DefaultOperationNameProvider.cs
+++ b/src/main/Yardarm/Generation/Operation/DefaultOperationNameProvider.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.OpenApi.Models;
+using Yardarm.Spec;
+
+namespace Yardarm.Generation.Operation
+{
+    internal class DefaultOperationNameProvider : IOperationNameProvider
+    {
+        public string? GetOperationName(ILocatedOpenApiElement<OpenApiOperation> operation) =>
+            operation.Element.OperationId;
+    }
+}

--- a/src/main/Yardarm/Generation/Operation/IOperationNameProvider.cs
+++ b/src/main/Yardarm/Generation/Operation/IOperationNameProvider.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.OpenApi.Models;
+using Yardarm.Spec;
+
+namespace Yardarm.Generation.Operation
+{
+    /// <summary>
+    /// Provides the name for an operation, used to control the generation of methods and classes
+    /// related to the operation.
+    /// </summary>
+    public interface IOperationNameProvider
+    {
+        /// <summary>
+        /// Provides the name for an operation, used to control the generation of methods and classes
+        /// related to the operation.
+        /// </summary>
+        /// <param name="operation">The operation.</param>
+        /// <returns>The name of the operation, or null if the operation has no name and should be excluded.</returns>
+        string? GetOperationName(ILocatedOpenApiElement<OpenApiOperation> operation);
+    }
+}

--- a/src/main/Yardarm/Generation/Request/RequestTypeGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Request/RequestTypeGeneratorFactory.cs
@@ -1,41 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Yardarm.Generation.MediaType;
-using Yardarm.Names;
-using Yardarm.Serialization;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Request
 {
-    public class RequestTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiOperation>
+    public class RequestTypeGeneratorFactory(IServiceProvider serviceProvider) : ITypeGeneratorFactory<OpenApiOperation>
     {
-        private readonly GenerationContext _context;
-        private readonly IMediaTypeSelector _mediaTypeSelector;
-        private readonly IList<IRequestMemberGenerator> _memberGenerators;
-        private readonly IRequestsNamespace _requestsNamespace;
-        private readonly ISerializerSelector _serializerSelector;
-
-        public RequestTypeGeneratorFactory(GenerationContext context, IMediaTypeSelector mediaTypeSelector,
-            IEnumerable<IRequestMemberGenerator> memberGenerators,
-            IRequestsNamespace requestsNamespace, ISerializerSelector serializerSelector)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(mediaTypeSelector);
-            ArgumentNullException.ThrowIfNull(memberGenerators);
-            ArgumentNullException.ThrowIfNull(requestsNamespace);
-            ArgumentNullException.ThrowIfNull(serializerSelector);
-
-            _context = context;
-            _mediaTypeSelector = mediaTypeSelector;
-            _memberGenerators = memberGenerators.ToArray();
-            _requestsNamespace = requestsNamespace;
-            _serializerSelector = serializerSelector;
-        }
+        private static readonly ObjectFactory<RequestTypeGenerator> Factory =
+            ActivatorUtilities.CreateFactory<RequestTypeGenerator>(
+            [
+                typeof(ILocatedOpenApiElement<OpenApiOperation>)
+            ]);
 
         public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiOperation> element, ITypeGenerator? parent) =>
-            new RequestTypeGenerator(element, _context, _mediaTypeSelector, _memberGenerators,
-                _requestsNamespace, _serializerSelector);
+            Factory(serviceProvider, [element]);
     }
 }

--- a/src/main/Yardarm/Generation/Response/ResponseSetGenerator.cs
+++ b/src/main/Yardarm/Generation/Response/ResponseSetGenerator.cs
@@ -3,29 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Response
 {
-    public class ResponseSetGenerator : ISyntaxTreeGenerator
+    public class ResponseSetGenerator(
+        OpenApiDocument document,
+        ITypeGeneratorRegistry<OpenApiResponses> responsesGeneratorRegistry,
+        ITypeGeneratorRegistry<OpenApiUnknownResponse> unknownResponseGeneratorRegistry,
+        IOperationNameProvider operationNameProvider)
+        : ISyntaxTreeGenerator
     {
-        private readonly OpenApiDocument _document;
-        private readonly ITypeGeneratorRegistry<OpenApiResponses> _responsesGeneratorRegistry;
-        private readonly ITypeGeneratorRegistry<OpenApiUnknownResponse> _unknownResponseGeneratorRegistry;
-
-        public ResponseSetGenerator(OpenApiDocument document,
-            ITypeGeneratorRegistry<OpenApiResponses> responsesGeneratorRegistry,
-            ITypeGeneratorRegistry<OpenApiUnknownResponse> unknownResponseGeneratorRegistry)
-        {
-            ArgumentNullException.ThrowIfNull(document);
-            ArgumentNullException.ThrowIfNull(responsesGeneratorRegistry);
-            ArgumentNullException.ThrowIfNull(unknownResponseGeneratorRegistry);
-
-            _document = document;
-            _responsesGeneratorRegistry = responsesGeneratorRegistry;
-            _unknownResponseGeneratorRegistry = unknownResponseGeneratorRegistry;
-        }
-
         public IEnumerable<SyntaxTree> Generate() =>
             GetResponseSets()
                 .Select(Generate)
@@ -36,14 +25,15 @@ namespace Yardarm.Generation.Response
                 .Where(p => p != null)!;
 
         private IEnumerable<ILocatedOpenApiElement<OpenApiResponses>> GetResponseSets() =>
-            _document.Paths.ToLocatedElements()
+            document.Paths.ToLocatedElements()
                 .GetOperations()
+                .WhereOperationHasName(operationNameProvider)
                 .GetResponseSets();
 
         protected virtual SyntaxTree? Generate(ILocatedOpenApiElement<OpenApiResponses> responseSet) =>
-            _responsesGeneratorRegistry.Get(responseSet).GenerateSyntaxTree();
+            responsesGeneratorRegistry.Get(responseSet).GenerateSyntaxTree();
 
         protected virtual SyntaxTree? Generate(ILocatedOpenApiElement<OpenApiUnknownResponse> unknownResponse) =>
-            _unknownResponseGeneratorRegistry.Get(unknownResponse).GenerateSyntaxTree();
+            unknownResponseGeneratorRegistry.Get(unknownResponse).GenerateSyntaxTree();
     }
 }

--- a/src/main/Yardarm/Generation/Response/ResponseSetTypeGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Response/ResponseSetTypeGeneratorFactory.cs
@@ -1,26 +1,19 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
-using Yardarm.Names;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Response
 {
-    public class ResponseSetTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiResponses>
+    public class ResponseSetTypeGeneratorFactory(IServiceProvider serviceProvider) : ITypeGeneratorFactory<OpenApiResponses>
     {
-        private readonly GenerationContext _context;
-        private readonly IResponsesNamespace _responsesNamespace;
-
-        public ResponseSetTypeGeneratorFactory(GenerationContext context,
-            IResponsesNamespace responsesNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(responsesNamespace);
-
-            _context = context;
-            _responsesNamespace = responsesNamespace;
-        }
+        private static readonly ObjectFactory<ResponseSetTypeGenerator> Factory =
+            ActivatorUtilities.CreateFactory<ResponseSetTypeGenerator>(
+            [
+                typeof(ILocatedOpenApiElement<OpenApiResponses>)
+            ]);
 
         public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiResponses> element, ITypeGenerator? parent) =>
-            new ResponseSetTypeGenerator(element, _context, _responsesNamespace);
+            Factory(serviceProvider, [element]);
     }
 }

--- a/src/main/Yardarm/Generation/Response/UnknownResponseTypeGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Response/UnknownResponseTypeGeneratorFactory.cs
@@ -1,29 +1,18 @@
 ﻿using System;
-using Yardarm.Names;
+using Microsoft.Extensions.DependencyInjection;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Response
 {
-    public class UnknownResponseTypeGeneratorFactory : ITypeGeneratorFactory<OpenApiUnknownResponse>
+    public class UnknownResponseTypeGeneratorFactory(IServiceProvider serviceProvider) : ITypeGeneratorFactory<OpenApiUnknownResponse>
     {
-        private readonly GenerationContext _context;
-        private readonly IResponsesNamespace _responsesNamespace;
-        private readonly ISerializationNamespace _serializationNamespace;
-
-        public UnknownResponseTypeGeneratorFactory(GenerationContext context,
-            IResponsesNamespace responsesNamespace,
-            ISerializationNamespace serializationNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(responsesNamespace);
-            ArgumentNullException.ThrowIfNull(serializationNamespace);
-
-            _context = context;
-            _responsesNamespace = responsesNamespace;
-            _serializationNamespace = serializationNamespace;
-        }
+        private static readonly ObjectFactory<UnknownResponseTypeGenerator> Factory =
+            ActivatorUtilities.CreateFactory<UnknownResponseTypeGenerator>(
+            [
+                typeof(ILocatedOpenApiElement<OpenApiUnknownResponse>)
+            ]);
 
         public ITypeGenerator Create(ILocatedOpenApiElement<OpenApiUnknownResponse> element, ITypeGenerator? parent) =>
-            new UnknownResponseTypeGenerator(element, _context, _serializationNamespace, _responsesNamespace);
+            Factory(serviceProvider, [element]);
     }
 }

--- a/src/main/Yardarm/Generation/Tag/TagGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagGenerator.cs
@@ -3,39 +3,30 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Tag
 {
-    public class TagGenerator : ISyntaxTreeGenerator
+    public class TagGenerator(
+        OpenApiDocument document,
+        ITypeGeneratorRegistry<OpenApiTag> tagGeneratorRegistry,
+        ITypeGeneratorRegistry<OpenApiTag,
+        TagImplementationCategory> tagImplementationGeneratorRegistry,
+        IOperationNameProvider operationNameProvider)
+        : ISyntaxTreeGenerator
     {
-        private readonly OpenApiDocument _document;
-        private readonly ITypeGeneratorRegistry<OpenApiTag> _tagGeneratorRegistry;
-        private readonly ITypeGeneratorRegistry<OpenApiTag, TagImplementationCategory> _tagImplementationGeneratorRegistry;
-
-        public TagGenerator(OpenApiDocument document, ITypeGeneratorRegistry<OpenApiTag> tagGeneratorRegistry,
-            ITypeGeneratorRegistry<OpenApiTag, TagImplementationCategory> tagImplementationGeneratorRegistry)
-        {
-            ArgumentNullException.ThrowIfNull(document);
-            ArgumentNullException.ThrowIfNull(tagGeneratorRegistry);
-            ArgumentNullException.ThrowIfNull(tagImplementationGeneratorRegistry);
-
-            _document = document;
-            _tagGeneratorRegistry = tagGeneratorRegistry;
-            _tagImplementationGeneratorRegistry = tagImplementationGeneratorRegistry;
-        }
-
         public IEnumerable<SyntaxTree> Generate()
         {
             foreach (ILocatedOpenApiElement<OpenApiTag> tag in GetTags())
             {
-                SyntaxTree? tree = _tagGeneratorRegistry.Get(tag).GenerateSyntaxTree();
+                SyntaxTree? tree = tagGeneratorRegistry.Get(tag).GenerateSyntaxTree();
                 if (tree is not null)
                 {
                     yield return tree;
                 }
 
-                tree = _tagImplementationGeneratorRegistry.Get(tag).GenerateSyntaxTree();
+                tree = tagImplementationGeneratorRegistry.Get(tag).GenerateSyntaxTree();
                 if (tree is not null)
                 {
                     yield return tree;
@@ -43,8 +34,9 @@ namespace Yardarm.Generation.Tag
             }
         }
 
-        private IEnumerable<ILocatedOpenApiElement<OpenApiTag>> GetTags() => _document.Paths.ToLocatedElements()
+        private IEnumerable<ILocatedOpenApiElement<OpenApiTag>> GetTags() => document.Paths.ToLocatedElements()
             .GetOperations()
+            .WhereOperationHasName(operationNameProvider)
             .GetTags()
             .Distinct(TagComparer.Instance);
 

--- a/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagImplementationTypeGenerator.cs
@@ -25,8 +25,8 @@ namespace Yardarm.Generation.Tag
 
         public TagImplementationTypeGenerator(ILocatedOpenApiElement<OpenApiTag> tagElement, GenerationContext context,
             ISerializationNamespace serializationNamespace, IAuthenticationNamespace authenticationNamespace,
-            IOperationMethodGenerator operationMethodGenerator)
-            : base(tagElement, context)
+            IOperationMethodGenerator operationMethodGenerator, IOperationNameProvider operationNameProvider)
+            : base(tagElement, context, operationNameProvider)
         {
             ArgumentNullException.ThrowIfNull(serializationNamespace);
             ArgumentNullException.ThrowIfNull(authenticationNamespace);

--- a/src/main/Yardarm/Generation/Tag/TagTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Tag/TagTypeGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
+using Yardarm.Generation.Operation;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -15,8 +16,8 @@ namespace Yardarm.Generation.Tag
         private readonly IApiNamespace _apiNamespace;
 
         public TagTypeGenerator(ILocatedOpenApiElement<OpenApiTag> tagElement, GenerationContext context,
-            IApiNamespace apiNamespace)
-            : base(tagElement, context)
+            IApiNamespace apiNamespace, IOperationNameProvider operationNameProvider)
+            : base(tagElement, context, operationNameProvider)
         {
             ArgumentNullException.ThrowIfNull(apiNamespace);
 

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="NuGet.Commands" Version="6.8.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />

--- a/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ namespace Yardarm
             services.AddSingleton<IResponseMethodGenerator, BodyConstructorMethodGenerator>();
             services.AddSingleton<IResponseMethodGenerator, NoBodyConstructorMethodGenerator>();
             services.TryAddSingleton<IOperationMethodGenerator, OperationMethodGenerator>();
+            services.TryAddSingleton<IOperationNameProvider, DefaultOperationNameProvider>();
             services.TryAddSingleton<IMediaTypeSelector, PriorityMediaTypeSelector>();
 
             // Need to be able to specifically inject this one as well


### PR DESCRIPTION
Motivation
----------
We can't generate methods or classes for operations without ids because we don't have a way to name them. We would, however, like to provide room for extensibility so consumers may provide their own operation naming scheme.

Modifications
-------------
- Add IOperationNameProvider with a default implementation that uses the operation ID
- Skip generation for any operations where the returned name is null or empty
- Update to Microsoft.Extensions 8.0 libraries
- Use ActivatorUtilities object factories for easier DI in several places
- Convert to primary constructors in several places

Relates to #239 