### PR TITLE
Generate correct code for parameter components

### DIFF
--- a/src/main/Yardarm/Generation/Request/ParameterGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/ParameterGenerator.cs
@@ -7,23 +7,14 @@ using Yardarm.Spec;
 
 namespace Yardarm.Generation.Request
 {
-    public class ParameterGenerator : ISyntaxTreeGenerator
+    public class ParameterGenerator(
+        OpenApiDocument document,
+        ITypeGeneratorRegistry<OpenApiParameter> parameterGeneratorRegistry)
+        : ISyntaxTreeGenerator
     {
-        private readonly OpenApiDocument _document;
-        private readonly ITypeGeneratorRegistry<OpenApiParameter> _parameterGeneratorRegistry;
-
-        public ParameterGenerator(OpenApiDocument document, ITypeGeneratorRegistry<OpenApiParameter> parameterGeneratorRegistry)
-        {
-            ArgumentNullException.ThrowIfNull(document);
-            ArgumentNullException.ThrowIfNull(parameterGeneratorRegistry);
-
-            _document = document;
-            _parameterGeneratorRegistry = parameterGeneratorRegistry;
-        }
-
         public IEnumerable<SyntaxTree> Generate()
         {
-            foreach (var syntaxTree in _document.Components.Parameters
+            foreach (var syntaxTree in document.Components.Parameters
                 .Select(p => p.Value.CreateRoot(p.Key))
                 .Select(Generate)
                 .Where(p => p != null))
@@ -33,6 +24,6 @@ namespace Yardarm.Generation.Request
         }
 
         protected virtual SyntaxTree? Generate(ILocatedOpenApiElement<OpenApiParameter> parameter) =>
-            _parameterGeneratorRegistry.Get(parameter).GenerateSyntaxTree();
+            parameterGeneratorRegistry.Get(parameter).GenerateSyntaxTree();
     }
 }


### PR DESCRIPTION
The current code for parameter components fails because it can't generate a source file path for embedding. Also, it results in duplicate schema generation if there are references to schemas from the parameters and can have name conflicts between these schemas.

Instead, generate parameter classes only in cases where a nested schema needs to be generated and nest the schema inside that class. This also addresses the source file name problem since there is a type name to use as the basis for the file name.

Relates to #239 