### PR TITLE
Generate properties for parameters included on path items

### DIFF
--- a/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -77,7 +77,9 @@ namespace Yardarm.Generation.Request
             }
 
             var propertyNameFormatter = NameFormatterSelector.GetFormatter(NameKind.Property);
-            foreach (var headerParameter in operation.Element.Parameters.Where(p => p.In == ParameterLocation.Header))
+            foreach (var headerParameter in operation.GetAllParameters()
+                .Where(p => p.Element.In == ParameterLocation.Header)
+                .Select(p => p.Element))
             {
                 string propertyName = propertyNameFormatter.Format(headerParameter.Name);
 

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -54,11 +54,14 @@ namespace Yardarm.Generation.Request
 
             var path = (LocatedOpenApiElement<OpenApiPathItem>)operation.Parent!;
 
+            var allParameters = operation.GetAllParameters()
+                .Select(p => p.Element)
+                .ToDictionary(p => p.Name, p => p);
+
             ExpressionSyntax pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
                 pathSegment =>
                 {
-                    OpenApiParameter? parameter = operation.Element.Parameters.FirstOrDefault(
-                        p => p.Name == pathSegment.Value);
+                    allParameters.TryGetValue(pathSegment.Value, out var parameter);
 
                     if (parameter?.Schema?.Type == "array")
                     {
@@ -89,7 +92,7 @@ namespace Yardarm.Generation.Request
                     }
                 });
 
-            OpenApiParameter[] queryParameters = operation.Element.Parameters
+            OpenApiParameter[] queryParameters = allParameters.Values
                 .Where(p => (p.In ?? ParameterLocation.Query) == ParameterLocation.Query)
                 .ToArray();
 

--- a/src/main/Yardarm/Generation/Request/RequestTypeGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/RequestTypeGenerator.cs
@@ -90,7 +90,7 @@ namespace Yardarm.Generation.Request
         {
             var foundParameters = new HashSet<string>(StringComparer.Ordinal);
 
-            foreach (var parameter in Element.GetParameters())
+            foreach (var parameter in Element.GetAllParameters())
             {
                 foundParameters.Add(parameter.Key);
 


### PR DESCRIPTION
Currently, properties are only generated for parameters listed explicitly on each operation (except for simple `string` properties for route parameters). The OpenAPI spec allows for parameters to be defined at the path level and then overridden for each operation.

This implements that behavior, handling query and header parameters defined at the path level and using the correct schema for route parameters defined at the path level.

Relates to #239 