### PR TITLE
Register JsonNode on JsonSerializerContext, not JsonObject

### DIFF
--- a/src/main/Yardarm.SystemTextJson/JsonSerializableEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonSerializableEnricher.cs
@@ -113,7 +113,7 @@ namespace Yardarm.SystemTextJson
                     hasEmittedDynamicTypes = true;
 
                     yield return (SystemTextJsonTypes.JsonElement, "JsonElement");
-                    yield return (SystemTextJsonTypes.Nodes.JsonObjectName, "JsonObject");
+                    yield return (SystemTextJsonTypes.Nodes.JsonNodeName, "JsonNode");
                 }
 
                 if (alreadyEmitted.Contains(modelNameString))


### PR DESCRIPTION
This ensures that all variants of JsonNode may be serialized, such as JsonArray and JsonValue, not just JsonObject.

Fixes #248