### PR TITLE
Enable Server GC

### DIFF
--- a/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
 
+    <!--
+      Since we are highly parallelized and doing a lot of SyntaxNode heap allocations, for multicore
+      machines we can get fewer GC pauses by using server GC. This is a good default for this project.
+    -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
Motivation
----------
Since we are highly parallelized and doing a lot of SyntaxNode heap allocations, for multicore machines we can get fewer GC pauses by using server GC. This is a good default for this project.

Modifications
-------------
Enable Server GC for the Yardarm command line. Note that a single core machine will ignore this setting and use Workstation GC.