### PR TITLE
Load and parse embedded resources more efficiently

### DIFF
--- a/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -1,14 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
-using Yardarm.Generation.Internal;
 using Yardarm.Helpers;
+using Yardarm.Internal;
 using Yardarm.Names;
 using Yardarm.Packaging;
 
@@ -16,6 +14,9 @@ namespace Yardarm.Generation
 {
     public abstract class ResourceSyntaxTreeGenerator : ISyntaxTreeGenerator
     {
+        private static readonly UTF8Encoding s_utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+        private static ReadOnlySpan<byte> RootNamespaceBytes => "RootNamespace"u8;
+
         public GenerationContext GenerationContext { get; }
         public IRootNamespace RootNamespace { get; }
 
@@ -37,21 +38,40 @@ namespace Yardarm.Generation
                 ? ".netcoreapp.cs"
                 : ".netstandard.cs";
 
-            return GetType().Assembly.GetManifestResourceNames()
-                .Where(p => p.StartsWith(ResourcePrefix) && p.EndsWith(".cs") && !p.EndsWith(excludeSuffix))
-                .Select(ParseResource);
+            byte[] namespaceName = s_utf8NoBom.GetBytes(RootNamespace.Name.ToString());
+
+            var result = new List<SyntaxTree>();
+            foreach (string resourceName in GetType().Assembly.GetManifestResourceNames())
+            {
+                if (resourceName.StartsWith(ResourcePrefix) && resourceName.EndsWith(".cs") && !resourceName.EndsWith(excludeSuffix))
+                {
+                    result.Add(ParseResource(resourceName, namespaceName));
+                }
+            };
+
+            return result;
         }
 
-        private SyntaxTree ParseResource(string resourceName)
+        private unsafe SyntaxTree ParseResource(string resourceName, ReadOnlySpan<byte> namespaceName)
         {
-            using var stream = GetType().Assembly
-                .GetManifestResourceStream(resourceName);
-            using var reader = new StreamReader(stream!, Encoding.UTF8);
+            using var stream = (UnmanagedMemoryStream)GetType().Assembly
+                .GetManifestResourceStream(resourceName)!;
+            if (stream.Length > int.MaxValue)
+            {
+                throw new InvalidOperationException("Resource is too large to parse");
+            }
 
-            string rawText = reader.ReadToEnd();
-            rawText = rawText.Replace("RootNamespace", RootNamespace.Name.ToString());
+            int length = (int)stream.Length;
+            ReadOnlySpan<byte> resourceContents = new(stream.PositionPointer, length);
 
-            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(rawText, Encoding.UTF8),
+            SourceText sourceText = resourceContents.TryCopyWithReplace(RootNamespaceBytes, namespaceName, out ArrayPoolBuffer<byte> buffer)
+                ? SourceText.From(buffer.Buffer!, buffer.Length, s_utf8NoBom, canBeEmbedded: true)
+                : SourceText.From(stream, s_utf8NoBom, canBeEmbedded: true);
+
+            // Return the buffer, if any, to the array pool
+            buffer.Dispose();
+
+            SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sourceText,
                 CSharpParseOptions.Default
                     .WithLanguageVersion(LanguageVersion.CSharp12)
                     .WithPreprocessorSymbols(GenerationContext.PreprocessorSymbols),

--- a/src/main/Yardarm/Internal/ArrayPoolBuffer.cs
+++ b/src/main/Yardarm/Internal/ArrayPoolBuffer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Buffers;
+
+namespace Yardarm.Internal
+{
+    internal readonly ref struct ArrayPoolBuffer<T>
+    {
+        public T[]? Buffer { get; }
+        public int Length { get; }
+
+        public Span<T> Span => Buffer.AsSpan(0, Length);
+
+        public ArrayPoolBuffer(T[] buffer, int length)
+        {
+            ArgumentNullException.ThrowIfNull(buffer);
+            ArgumentOutOfRangeException.ThrowIfLessThan(length, 0);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(length, buffer.Length);
+
+            Buffer = buffer;
+            Length = length;
+        }
+
+        public void Dispose()
+        {
+            if (Buffer is not null) // Maybe null if default struct
+            {
+                ArrayPool<T>.Shared.Return(Buffer);
+            }
+        }
+    }
+}

--- a/src/main/Yardarm/Internal/ValueListBuilder.cs
+++ b/src/main/Yardarm/Internal/ValueListBuilder.cs
@@ -1,0 +1,204 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Yardarm.Internal;
+
+internal ref struct ValueListBuilder<T>
+{
+    private Span<T> _span;
+    private T[]? _arrayFromPool;
+    private int _pos;
+
+    public ValueListBuilder(Span<T> initialSpan)
+    {
+        _span = initialSpan;
+        _arrayFromPool = null;
+        _pos = 0;
+    }
+
+    public int Length
+    {
+        get => _pos;
+        set
+        {
+            Debug.Assert(value >= 0);
+            Debug.Assert(value <= _span.Length);
+            _pos = value;
+        }
+    }
+
+    public ref T this[int index]
+    {
+        get
+        {
+            Debug.Assert(index < _pos);
+            return ref _span[index];
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(T item)
+    {
+        int pos = _pos;
+
+        // Workaround for https://github.com/dotnet/runtime/issues/72004
+        Span<T> span = _span;
+        if ((uint)pos < (uint)span.Length)
+        {
+            span[pos] = item;
+            _pos = pos + 1;
+        }
+        else
+        {
+            AddWithResize(item);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(scoped ReadOnlySpan<T> source)
+    {
+        int pos = _pos;
+        Span<T> span = _span;
+        if (source.Length == 1 && (uint)pos < (uint)span.Length)
+        {
+            span[pos] = source[0];
+            _pos = pos + 1;
+        }
+        else
+        {
+            AppendMultiChar(source);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AppendMultiChar(scoped ReadOnlySpan<T> source)
+    {
+        if ((uint)(_pos + source.Length) > (uint)_span.Length)
+        {
+            Grow(_span.Length - _pos + source.Length);
+        }
+
+        source.CopyTo(_span.Slice(_pos));
+        _pos += source.Length;
+    }
+
+    public void Insert(int index, scoped ReadOnlySpan<T> source)
+    {
+        Debug.Assert(index == 0, "Implementation currently only supports index == 0");
+
+        if ((uint)(_pos + source.Length) > (uint)_span.Length)
+        {
+            Grow(source.Length);
+        }
+
+        _span.Slice(0, _pos).CopyTo(_span.Slice(source.Length));
+        source.CopyTo(_span);
+        _pos += source.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<T> AppendSpan(int length)
+    {
+        Debug.Assert(length >= 0);
+
+        int pos = _pos;
+        Span<T> span = _span;
+        if ((ulong)(uint)pos + (ulong)(uint)length <= (ulong)(uint)span.Length) // same guard condition as in Span<T>.Slice on 64-bit
+        {
+            _pos = pos + length;
+            return span.Slice(pos, length);
+        }
+        else
+        {
+            return AppendSpanWithGrow(length);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Span<T> AppendSpanWithGrow(int length)
+    {
+        int pos = _pos;
+        Grow(_span.Length - pos + length);
+        _pos += length;
+        return _span.Slice(pos, length);
+    }
+
+    // Hide uncommon path
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddWithResize(T item)
+    {
+        Debug.Assert(_pos == _span.Length);
+        int pos = _pos;
+        Grow(1);
+        _span[pos] = item;
+        _pos = pos + 1;
+    }
+
+    public ReadOnlySpan<T> AsSpan()
+    {
+        return _span.Slice(0, _pos);
+    }
+
+    public bool TryCopyTo(Span<T> destination, out int itemsWritten)
+    {
+        if (_span.Slice(0, _pos).TryCopyTo(destination))
+        {
+            itemsWritten = _pos;
+            return true;
+        }
+
+        itemsWritten = 0;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose()
+    {
+        T[]? toReturn = _arrayFromPool;
+        if (toReturn != null)
+        {
+            _arrayFromPool = null;
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+
+    // Note that consuming implementations depend on the list only growing if it's absolutely
+    // required.  If the list is already large enough to hold the additional items be added,
+    // it must not grow. The list is used in a number of places where the reference is checked
+    // and it's expected to match the initial reference provided to the constructor if that
+    // span was sufficiently large.
+    private void Grow(int additionalCapacityRequired = 1)
+    {
+        const int ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+        // Double the size of the span.  If it's currently empty, default to size 4,
+        // although it'll be increased in Rent to the pool's minimum bucket size.
+        int nextCapacity = Math.Max(_span.Length != 0 ? _span.Length * 2 : 4, _span.Length + additionalCapacityRequired);
+
+        // If the computed doubled capacity exceeds the possible length of an array, then we
+        // want to downgrade to either the maximum array length if that's large enough to hold
+        // an additional item, or the current length + 1 if it's larger than the max length, in
+        // which case it'll result in an OOM when calling Rent below.  In the exceedingly rare
+        // case where _span.Length is already int.MaxValue (in which case it couldn't be a managed
+        // array), just use that same value again and let it OOM in Rent as well.
+        if ((uint)nextCapacity > ArrayMaxLength)
+        {
+            nextCapacity = Math.Max(Math.Max(_span.Length + 1, ArrayMaxLength), _span.Length);
+        }
+
+        T[] array = ArrayPool<T>.Shared.Rent(nextCapacity);
+        _span.CopyTo(array);
+
+        T[]? toReturn = _arrayFromPool;
+        _span = _arrayFromPool = array;
+        if (toReturn != null)
+        {
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+}

--- a/src/main/Yardarm/Internal/YardarmMemoryExtensions.cs
+++ b/src/main/Yardarm/Internal/YardarmMemoryExtensions.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// TryCopyAndReplace is a variant based on String.Replace in .NET.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+
+namespace Yardarm.Internal
+{
+    internal static class YardarmMemoryExtensions
+    {
+        /// <summary>
+        /// Copies the contents of the source to a new buffer, replacing all occurrences of oldValue with newValue,
+        /// if there is at least one instance of oldValue found.
+        /// </summary>
+        /// <typeparam name="T">Type of element.</typeparam>
+        /// <param name="source">Source buffer to search and copy.</param>
+        /// <param name="oldValue">Value to replace in the source buffer.</param>
+        /// <param name="newValue">Value to place in locations where <paramref name="oldValue"/> is found.</param>
+        /// <param name="result">Buffer backed by the <see cref="ArrayPool{T}"/> if replacements were made.</param>
+        /// <returns>True if a copy with replacements was placed in <paramref name="result"/>.</returns>
+        public static bool TryCopyWithReplace<T>(this ReadOnlySpan<T> source, ReadOnlySpan<T> oldValue,
+            ReadOnlySpan<T> newValue, out ArrayPoolBuffer<T> result)
+            where T : IEquatable<T>?
+        {
+            var replacementIndices = new ValueListBuilder<int>(stackalloc int[32]);
+
+            // Find all occurrences of the oldValue
+            int i = 0;
+            while (true)
+            {
+                int pos = source[i..].IndexOf(oldValue);
+                if (pos < 0)
+                {
+                    break;
+                }
+
+                replacementIndices.Append(i + pos);
+                i += pos + oldValue.Length;
+            }
+
+            if (replacementIndices.Length == 0)
+            {
+                result = default;
+                return false;
+            }
+
+            int length = source.Length + (newValue.Length - oldValue.Length) * replacementIndices.Length;
+            var dest = ArrayPool<T>.Shared.Rent(length);
+
+            Span<T> dstSpan = dest.AsSpan(0, length);
+
+            int thisIdx = 0;
+            int dstIdx = 0;
+
+            for (int r = 0; r < replacementIndices.Length; r++)
+            {
+                int replacementIdx = replacementIndices[r];
+
+                // Copy over the non-matching portion of the original that precedes this occurrence of oldValue.
+                int count = replacementIdx - thisIdx;
+                if (count != 0)
+                {
+                    source.Slice(thisIdx, count).CopyTo(dstSpan[dstIdx..]);
+                    dstIdx += count;
+                }
+                thisIdx = replacementIdx + oldValue.Length;
+
+                // Copy over newValue to replace the oldValue.
+                newValue.CopyTo(dstSpan[dstIdx..]);
+                dstIdx += newValue.Length;
+            }
+
+            // Copy over the final non-matching portion at the end
+            Debug.Assert(source.Length - thisIdx == dstSpan.Length - dstIdx);
+            source[thisIdx..].CopyTo(dstSpan[dstIdx..]);
+
+            replacementIndices.Dispose();
+
+            result = new ArrayPoolBuffer<T>(dest, length);
+            return true;
+        }
+    }
+}

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
 
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Motivation
----------
The current approach of a string replace incurs some additional allocation overhead.

Modifications
-------------
Process the string replacement as UTF8 against the raw bytes of the manifest resource stream rather than deserializing to a string and then generating another string with the namespace replaced.