### PR TITLE
Improve DI registration of named http clients

### DIFF
--- a/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ApiBuilderExtensionsEnricher.cs
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/Internal/ApiBuilderExtensionsEnricher.cs
@@ -66,6 +66,7 @@ namespace Yardarm.MicrosoftExtensionsHttp.Internal
                         ArgumentList(SeparatedList(new[]
                         {
                             Argument(IdentifierName("configureClient")),
+                            Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(interfaceName.ToString()))),
                             Argument(IdentifierName("skipIfAlreadyRegistered"))
                         }))),
                     Token(SyntaxKind.SemicolonToken))


### PR DESCRIPTION
- Add overload to AddApi<TClient, TImplementation> that accepts a name to match AddApi<TClient>
- For default registration via AddAllApis or AddAllOtherApis use the full type name with namespace rather than just the interface name

Fixes #247