### PR TITLE
Make registering with custom JSON options easier

### DIFF
--- a/src/main/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/TypeSerializerRegistry.cs
@@ -98,10 +98,23 @@ namespace RootNamespace.Serialization
             return this;
         }
 
-        public static ITypeSerializerRegistry CreateDefaultRegistry() =>
+        /// <summary>
+        /// Returns a new <see cref="ITypeSerializerRegistry"/> with the basic serializers registered such as
+        /// "text/plain", "multipart/form-data", and "application/octet-stream". Does not include any schema-based
+        /// serializers such as JSON or XML.
+        /// </summary>
+        /// <returns>A new <see cref="ITypeSerializerRegistry"/>.</returns>
+        public static ITypeSerializerRegistry CreateBasicRegistry() =>
             new TypeSerializerRegistry()
                 .Add<PlainTextSerializer>(PlainTextSerializer.SupportedMediaTypes)
                 .Add<MultipartFormDataSerializer>(MultipartFormDataSerializer.SupportedMediaTypes)
                 .Add<BinaryStreamSerializer>(BinaryStreamSerializer.SupportedMediaTypes, BinaryStreamSerializer.SupportedSchemaTypes);
+
+        /// <summary>
+        /// Returns a new <see cref="ITypeSerializerRegistry"/> with the all default serializers registered.
+        /// </summary>
+        /// <returns>A new <see cref="ITypeSerializerRegistry"/>.</returns>
+        public static ITypeSerializerRegistry CreateDefaultRegistry() =>
+            CreateBasicRegistry();
     }
 }

--- a/src/main/Yardarm.NewtonsoftJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonCreateDefaultRegistryEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Enrichment;
@@ -18,14 +19,15 @@ namespace Yardarm.NewtonsoftJson
         }
 
         public ExpressionSyntax Enrich(ExpressionSyntax target) =>
-            InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                    target,
+            InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    target.WithTrailingTrivia(TriviaList(CarriageReturnLineFeed, Whitespace("                "))),
                     GenericName(
                         Identifier("Add"),
-                        TypeArgumentList(SingletonSeparatedList<TypeSyntax>(_jsonSerializationNamespace.JsonTypeSerializer)))))
-                .AddArgumentListArguments(
+                        TypeArgumentList(SingletonSeparatedList<TypeSyntax>(_jsonSerializationNamespace.JsonTypeSerializer)))),
+                ArgumentList(SingletonSeparatedList(
                     Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         _jsonSerializationNamespace.JsonTypeSerializer,
-                        IdentifierName("SupportedMediaTypes"))));
+                        IdentifierName("SupportedMediaTypes"))))));
     }
 }

--- a/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Enrichment;
@@ -24,7 +25,7 @@ namespace Yardarm.SystemTextJson
             // Instead create a new instance directly using the default constructor and add it.
             InvocationExpression(
                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                    target,
+                    target.WithTrailingTrivia(TriviaList(CarriageReturnLineFeed, Whitespace("                "))),
                     IdentifierName("Add")),
                 ArgumentList(SeparatedList(new[]
                 {

--- a/src/main/Yardarm/Enrichment/Compilation/DefaultTypeSerializersEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/DefaultTypeSerializersEnricher.cs
@@ -50,7 +50,8 @@ namespace Yardarm.Enrichment.Compilation
 
                     rootNode = rootNode.ReplaceNode(methodDeclaration, newMethodDeclaration);
 
-                    target = target.ReplaceSyntaxTree(syntaxTree,
+                    // Break once we've found what we're looking for
+                    return target.ReplaceSyntaxTree(syntaxTree,
                         syntaxTree.WithRootAndOptions(rootNode, syntaxTree.Options));
                 }
             }


### PR DESCRIPTION
Motivation
----------
Currently it's difficult to use custom JSON options because the consumer msut register all of the serializers and some of the methods aren't even available publicly.

Modifications
-------------
- Add CreateBasicRegistry which provides a baseline registry that can be easily extended with custom JSON options
- Improve formatting of generated source in CreateDefaultRegistry
- Short-circuit for perf when enriching CreateDefaultRegistry