### PR TITLE
Allow embedding symbols in the nupkg file

### DIFF
--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -270,8 +270,9 @@ namespace Yardarm.CommandLine
                     var nupkgStream = new IntermediateStream(_options.OutputPackageFile);
                     streams.Add(nupkgStream);
                     settings.NuGetOutput = nupkgStream.Stream;
+                    settings.EmbedSymbols = _options.EmbedSymbols;
 
-                    if (!_options.NoSymbolsPackageFile && !string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
+                    if (!_options.NoSymbolsPackageFile && !_options.EmbedSymbols && !string.IsNullOrEmpty(_options.OutputSymbolsPackageFile))
                     {
                         var snupkgStream = new IntermediateStream(_options.OutputSymbolsPackageFile);
                         streams.Add(snupkgStream);

--- a/src/main/Yardarm.CommandLine/GenerateOptions.cs
+++ b/src/main/Yardarm.CommandLine/GenerateOptions.cs
@@ -73,6 +73,9 @@ namespace Yardarm.CommandLine
         [Option("no-snupkg", HelpText = "Suppress output of .snupkg symbols package file", SetName = "nuget")]
         public bool NoSymbolsPackageFile { get; set; }
 
+        [Option("embed-symbols", HelpText = "Embed symbols in the primary nupkg. Useful for NuGet servers that don't support snupkg such as GitHub Packages. Implies \"--no-snupkg\".", SetName = "nuget")]
+        public bool EmbedSymbols { get; set; }
+
         [Option("repository-type", Default="git", HelpText = "Type of repository for NuGet packaging")]
         public string RepositoryType { get; set; }
 

--- a/src/main/Yardarm/Packaging/NuGetPacker.cs
+++ b/src/main/Yardarm/Packaging/NuGetPacker.cs
@@ -71,6 +71,13 @@ namespace Yardarm.Packaging
                             result.TargetFramework));
                     }
 
+                    if (_settings.EmbedSymbols && result.PdbOutput is not null)
+                    {
+                        files.Add(new StreamPackageFile(result.PdbOutput,
+                            $"lib/{result.TargetFramework.GetShortFolderName()}/{_settings.AssemblyName}.pdb",
+                            result.TargetFramework));
+                    }
+
                     return files;
                 }));
 

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -45,6 +45,12 @@ namespace Yardarm
         /// </summary>
         public bool EmbedAllSources { get; set; }
 
+        /// <summary>
+        /// If true, embed symbols in the <see cref="NuGetOutput"/>. Useful when uploading to NuGet
+        /// servers that don't support snupkg such as GitHub Packages.
+        /// </summary>
+        public bool EmbedSymbols { get; set; }
+
         public Stream DllOutput
         {
             get => _dllOutput ??= new MemoryStream();


### PR DESCRIPTION
Useful when uploading to NuGet servers that don't support snupkg such as GitHub Packages.