### PR TITLE
Performance improvents to LiteralSerializer

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/HeaderSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/HeaderSerializerTests.cs
@@ -15,7 +15,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive("test");
+            string result = HeaderSerializer.SerializePrimitive("test");
 
             // Assert
 
@@ -27,7 +27,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(105);
+            string result = HeaderSerializer.SerializePrimitive(105);
 
             // Assert
 
@@ -39,7 +39,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(105L);
+            string result = HeaderSerializer.SerializePrimitive(105L);
 
             // Assert
 
@@ -51,7 +51,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(1.05f);
+            string result = HeaderSerializer.SerializePrimitive(1.05f);
 
             // Assert
 
@@ -63,7 +63,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(1.05);
+            string result = HeaderSerializer.SerializePrimitive(1.05);
 
             // Assert
 
@@ -75,7 +75,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(true);
+            string result = HeaderSerializer.SerializePrimitive(true);
 
             // Assert
 
@@ -87,7 +87,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(false);
+            string result = HeaderSerializer.SerializePrimitive(false);
 
             // Assert
 
@@ -99,7 +99,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(new DateTime(2020, 1, 2, 3, 4, 5));
+            string result = HeaderSerializer.SerializePrimitive(new DateTime(2020, 1, 2, 3, 4, 5));
 
             // Assert
 
@@ -111,7 +111,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializePrimitive(new DateTime(2020, 1, 2, 3, 4, 5), "date");
+            string result = HeaderSerializer.SerializePrimitive(new DateTime(2020, 1, 2, 3, 4, 5), "date");
 
             // Assert
 
@@ -127,7 +127,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializeList(
+            string result = HeaderSerializer.SerializeList(
                 new List<string> { "abc", "def", "ghi" });
 
             // Assert
@@ -140,7 +140,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.SerializeList(
+            string result = HeaderSerializer.SerializeList(
                 new List<DateTime> {
                     new(2020, 01, 02, 3, 4, 5),
                     new(2021, 01, 02, 3, 4, 5)
@@ -160,7 +160,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.DeserializePrimitive<string>(
+            string result = HeaderSerializer.DeserializePrimitive<string>(
                 ["test"]);
 
             // Assert
@@ -173,7 +173,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = HeaderSerializer.Instance.DeserializePrimitive<string>(
+            string result = HeaderSerializer.DeserializePrimitive<string>(
                 ["test", "value"]);
 
             // Assert
@@ -186,7 +186,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            int result = HeaderSerializer.Instance.DeserializePrimitive<int>(
+            int result = HeaderSerializer.DeserializePrimitive<int>(
                 ["105"]);
 
             // Assert
@@ -199,7 +199,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            long result = HeaderSerializer.Instance.DeserializePrimitive<long>(
+            long result = HeaderSerializer.DeserializePrimitive<long>(
                 ["105"]);
 
             // Assert
@@ -212,7 +212,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            float result = HeaderSerializer.Instance.DeserializePrimitive<float>(
+            float result = HeaderSerializer.DeserializePrimitive<float>(
                 ["1.05"]);
 
             // Assert
@@ -225,7 +225,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            double result = HeaderSerializer.Instance.DeserializePrimitive<double>(
+            double result = HeaderSerializer.DeserializePrimitive<double>(
                 ["1.05"]);
 
             // Assert
@@ -238,7 +238,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            bool result = HeaderSerializer.Instance.DeserializePrimitive<bool>(
+            bool result = HeaderSerializer.DeserializePrimitive<bool>(
                 ["true"]);
 
             // Assert
@@ -251,7 +251,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            bool result = HeaderSerializer.Instance.DeserializePrimitive<bool>(
+            bool result = HeaderSerializer.DeserializePrimitive<bool>(
                 ["false"]);
 
             // Assert
@@ -264,7 +264,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = HeaderSerializer.Instance.DeserializePrimitive<DateTime>(
+            var result = HeaderSerializer.DeserializePrimitive<DateTime>(
                 ["2020-01-02"], "date");
 
             // Assert
@@ -277,7 +277,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act/Assert
 
-            var action = () => HeaderSerializer.Instance.DeserializePrimitive<DateTime>(
+            var action = () => HeaderSerializer.DeserializePrimitive<DateTime>(
                 ["2020-01-02T03:04:05-04:00"], "date");
             action.Should().Throw<FormatException>();
         }
@@ -289,7 +289,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = HeaderSerializer.Instance.DeserializePrimitive<DateTimeOffset>(
+            var result = HeaderSerializer.DeserializePrimitive<DateTimeOffset>(
                 ["2020-01-02T03:04:05-04:00"], format);
 
             // Assert
@@ -306,7 +306,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            List<string> result = HeaderSerializer.Instance.DeserializeList<string>(
+            List<string> result = HeaderSerializer.DeserializeList<string>(
                 ["abc", "def", "ghi"]);
 
             // Assert
@@ -319,7 +319,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            List<int> result = HeaderSerializer.Instance.DeserializeList<int>(
+            List<int> result = HeaderSerializer.DeserializeList<int>(
                 ["1", "3", "5"]);
 
             // Assert

--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -14,7 +14,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize("test");
+            string result = LiteralSerializer.Serialize("test");
 
             // Assert
 
@@ -26,7 +26,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(105);
+            string result = LiteralSerializer.Serialize(105);
 
             // Assert
 
@@ -38,7 +38,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(105L);
+            string result = LiteralSerializer.Serialize(105L);
 
             // Assert
 
@@ -50,7 +50,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(1.05f);
+            string result = LiteralSerializer.Serialize(1.05f);
 
             // Assert
 
@@ -62,7 +62,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(1.05);
+            string result = LiteralSerializer.Serialize(1.05);
 
             // Assert
 
@@ -74,7 +74,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(true);
+            string result = LiteralSerializer.Serialize(true);
 
             // Assert
 
@@ -86,7 +86,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(false);
+            string result = LiteralSerializer.Serialize(false);
 
             // Assert
 
@@ -98,7 +98,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5));
+            string result = LiteralSerializer.Serialize(new DateTime(2020, 1, 2, 3, 4, 5));
 
             // Assert
 
@@ -112,7 +112,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(new DateTime(2020, 1, 2, 3, 4, 5), format);
+            string result = LiteralSerializer.Serialize(new DateTime(2020, 1, 2, 3, 4, 5), format);
 
             // Assert
 
@@ -124,7 +124,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(
+            string result = LiteralSerializer.Serialize(
                 new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)));
 
             // Assert
@@ -139,7 +139,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(
+            string result = LiteralSerializer.Serialize(
                 new TimeSpan(0, 3, 4, 5), format);
 
             // Assert
@@ -154,7 +154,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(
+            string result = LiteralSerializer.Serialize(
                 new TimeSpan(0, 3, 4, 5, 123), format);
 
             // Assert
@@ -171,7 +171,7 @@ namespace Yardarm.Client.UnitTests.Serialization
 
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(guid);
+            string result = LiteralSerializer.Serialize(guid);
 
             // Assert
 
@@ -183,7 +183,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Serialize(StringComparison.Ordinal);
+            string result = LiteralSerializer.Serialize(StringComparison.Ordinal);
 
             // Assert
 
@@ -199,7 +199,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            string result = LiteralSerializer.Instance.Deserialize<string>("test");
+            string result = LiteralSerializer.Deserialize<string>("test");
 
             // Assert
 
@@ -211,7 +211,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            int result = LiteralSerializer.Instance.Deserialize<int>("105");
+            int result = LiteralSerializer.Deserialize<int>("105");
 
             // Assert
 
@@ -223,7 +223,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            long result = LiteralSerializer.Instance.Deserialize<long>("105");
+            long result = LiteralSerializer.Deserialize<long>("105");
 
             // Assert
 
@@ -235,7 +235,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            float result = LiteralSerializer.Instance.Deserialize<float>("1.05");
+            float result = LiteralSerializer.Deserialize<float>("1.05");
 
             // Assert
 
@@ -247,7 +247,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            double result = LiteralSerializer.Instance.Deserialize<double>("1.05");
+            double result = LiteralSerializer.Deserialize<double>("1.05");
 
             // Assert
 
@@ -259,7 +259,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            bool result = LiteralSerializer.Instance.Deserialize<bool>("true");
+            bool result = LiteralSerializer.Deserialize<bool>("true");
 
             // Assert
 
@@ -271,7 +271,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            bool result = LiteralSerializer.Instance.Deserialize<bool>("false");
+            bool result = LiteralSerializer.Deserialize<bool>("false");
 
             // Assert
 
@@ -285,7 +285,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<DateTime>("2020-01-02", format);
+            var result = LiteralSerializer.Deserialize<DateTime>("2020-01-02", format);
 
             // Assert
 
@@ -299,7 +299,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02", format);
+            var result = LiteralSerializer.Deserialize<TimeSpan>("13:01:02", format);
 
             // Assert
 
@@ -313,7 +313,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<TimeSpan>("13:01:02.234000", format);
+            var result = LiteralSerializer.Deserialize<TimeSpan>("13:01:02.234000", format);
 
             // Assert
 
@@ -325,7 +325,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act/Assert
 
-            var action = () => LiteralSerializer.Instance.Deserialize<DateTime>(
+            var action = () => LiteralSerializer.Deserialize<DateTime>(
                 "2020-01-02T03:04:05-04:00", "date");
             action.Should().Throw<FormatException>();
         }
@@ -337,7 +337,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = LiteralSerializer.Instance.Deserialize<DateTimeOffset>(
+            var result = LiteralSerializer.Deserialize<DateTimeOffset>(
                 "2020-01-02T03:04:05-04:00", format);
 
             // Assert
@@ -353,7 +353,7 @@ namespace Yardarm.Client.UnitTests.Serialization
             const string guid = "00000001-0002-0003-0004-000000000005";
             // Act
 
-            Guid result = LiteralSerializer.Instance.Deserialize<Guid>(guid);
+            Guid result = LiteralSerializer.Deserialize<Guid>(guid);
 
             // Assert
 
@@ -365,7 +365,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            StringComparison result = LiteralSerializer.Instance.Deserialize<StringComparison>("Ordinal");
+            StringComparison result = LiteralSerializer.Deserialize<StringComparison>("Ordinal");
 
             // Assert
 
@@ -381,7 +381,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         {
             // Act
 
-            var result = LiteralSerializer.Instance.JoinList(",",
+            var result = LiteralSerializer.JoinList(",",
                 new[] {new DateTime(2020, 1, 2), new DateTime(2021, 2, 3)},
                 "date");
 

--- a/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
@@ -278,7 +278,7 @@ namespace Yardarm.Client.UnitTests.Serialization
 
             // Assert
 
-            result.Should().Be(".abc,def,ghi");
+            result.Should().Be(".abc.def.ghi");
         }
 
         [Fact]

--- a/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/HeaderSerializer.cs
@@ -1,24 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using Yardarm.Client.Internal;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
 {
-    public class HeaderSerializer
+    public static class HeaderSerializer
     {
-        public static HeaderSerializer Instance { get; } = new(LiteralSerializer.Instance);
-
-        private readonly LiteralSerializer _literalSerializer;
-
-        public HeaderSerializer(LiteralSerializer literalSerializer)
-        {
-            ThrowHelper.ThrowIfNull(literalSerializer);
-
-            _literalSerializer = literalSerializer;
-        }
-
-        public string SerializePrimitive<T>(T value, string? format = null)
+        public static string SerializePrimitive<T>(T value, string? format = null)
         {
             if (value == null)
             {
@@ -31,20 +19,20 @@ namespace RootNamespace.Serialization
                 return str;
             }
 
-            return _literalSerializer.Serialize(value, format);
+            return LiteralSerializer.Serialize(value, format);
         }
 
-        public string SerializeList<T>(IEnumerable<T>? list, string? format = null)
+        public static string SerializeList<T>(IEnumerable<T>? list, string? format = null)
         {
             if (list == null)
             {
                 return "";
             }
 
-            return _literalSerializer.JoinList(",", list, format);
+            return LiteralSerializer.JoinList(",", list, format);
         }
 
-        public T DeserializePrimitive<T>(IEnumerable<string> values, string? format = null)
+        public static T DeserializePrimitive<T>(IEnumerable<string> values, string? format = null)
         {
             // Rejoin the values from the header into a simple string
 #if NET6_0_OR_GREATER
@@ -60,14 +48,14 @@ namespace RootNamespace.Serialization
             }
 
             // We're not dealing with a list, so join the values back together
-            return _literalSerializer.Deserialize<T>(value, format);
+            return LiteralSerializer.Deserialize<T>(value, format);
         }
 
-        public List<T> DeserializeList<T>(IEnumerable<string> values, string? format = null)
+        public static List<T> DeserializeList<T>(IEnumerable<string> values, string? format = null)
         {
             ThrowHelper.ThrowIfNull(values);
 
-            return _literalSerializer.DeserializeList<T>(values, format);
+            return LiteralSerializer.DeserializeList<T>(values, format);
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
 {
-    internal class PathSegmentSerializer
+    internal static class PathSegmentSerializer
     {
         public static string Serialize<T>(string name, T value, PathSegmentStyle style = PathSegmentStyle.Simple, string? format = null) =>
             style switch
@@ -20,10 +18,10 @@ namespace RootNamespace.Serialization
         public static string SerializeList<T>(string name, IEnumerable<T> values, PathSegmentStyle style = PathSegmentStyle.Simple, bool explode = false, string? format = null) =>
             style switch
             {
-                PathSegmentStyle.Simple => LiteralSerializer.Instance.JoinList(",", values,  format),
-                PathSegmentStyle.Label => "." + LiteralSerializer.Instance.JoinList(explode ? "." : ",", values, format),
+                PathSegmentStyle.Simple => LiteralSerializer.JoinList(",", values,  format),
+                PathSegmentStyle.Label => "." + LiteralSerializer.JoinList(".", values, format),
                 PathSegmentStyle.Matrix =>
-                    $";{name}={LiteralSerializer.Instance.JoinList(explode ? $";{name}=" : ",", values, format)}",
+                    $";{name}={LiteralSerializer.JoinList(explode ? $";{name}=" : ",", values, format)}",
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
 
@@ -40,7 +38,7 @@ namespace RootNamespace.Serialization
                 return str;
             }
 
-            return LiteralSerializer.Instance.Serialize(value, format);
+            return LiteralSerializer.Serialize(value, format);
         }
 
         private static string SerializeLabel<T>(T value, string? format)
@@ -56,7 +54,7 @@ namespace RootNamespace.Serialization
                 return "." + str;
             }
 
-            return "." + LiteralSerializer.Instance.Serialize(value, format);
+            return "." + LiteralSerializer.Serialize(value, format);
         }
 
         private static string SerializeMatrix<T>(string name, T value, string? format)
@@ -72,7 +70,7 @@ namespace RootNamespace.Serialization
                 return $";{name}={str}";
             }
 
-            return $";{name}={LiteralSerializer.Instance.Serialize(value, format)}";
+            return $";{name}={LiteralSerializer.Serialize(value, format)}";
         }
     }
 }

--- a/src/main/Yardarm.Client/Serialization/QueryStringBuilder.cs
+++ b/src/main/Yardarm.Client/Serialization/QueryStringBuilder.cs
@@ -114,8 +114,8 @@ namespace RootNamespace.Serialization
 
         private static string EscapeValue<T>(T value, bool allowReserved, string? format) =>
             allowReserved
-                ? LiteralSerializer.Instance.Serialize(value, format)
-                : Uri.EscapeDataString(LiteralSerializer.Instance.Serialize(value, format));
+                ? LiteralSerializer.Serialize(value, format)
+                : Uri.EscapeDataString(LiteralSerializer.Serialize(value, format));
 
         [return: NotNullIfNotNull(nameof(uri))]
         public static Uri? AppendQueryParameter(Uri? uri, string name, string value)

--- a/src/main/Yardarm.sln
+++ b/src/main/Yardarm.sln
@@ -27,6 +27,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.MicrosoftExtensions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.MicrosoftExtensionsHttp.Client", "Yardarm.MicrosoftExtensionsHttp.Client\Yardarm.MicrosoftExtensionsHttp.Client.csproj", "{AB9CA15B-AE6E-421B-9662-E6264B4EA1CA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0F27CDEF-318E-4305-AE2B-AA44C670E7C2}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/main/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Responses/HeaderParsingEnricher.cs
@@ -84,7 +84,7 @@ namespace Yardarm.Enrichment.Responses
                 if (schemaElement is {Element.Type: "array"})
                 {
                     deserializeExpression = InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            _serializationNamespace.HeaderSerializerInstance,
+                            _serializationNamespace.HeaderSerializer,
                             GenericName("DeserializeList")
                                 .AddTypeArgumentListArguments(typeName)),
                         ArgumentList(SeparatedList(new []
@@ -96,7 +96,7 @@ namespace Yardarm.Enrichment.Responses
                 else
                 {
                     deserializeExpression = InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            _serializationNamespace.HeaderSerializerInstance,
+                            _serializationNamespace.HeaderSerializer,
                             GenericName("DeserializePrimitive")
                                 .AddTypeArgumentListArguments(typeName)),
                         ArgumentList(SeparatedList(new [] {

--- a/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -89,7 +89,7 @@ namespace Yardarm.Generation.Request
                     valueExpression = InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.HeaderSerializerInstance,
+                            SerializationNamespace.HeaderSerializer,
                             IdentifierName("SerializeList")),
                         ArgumentList(SeparatedList(new[]
                         {
@@ -102,7 +102,7 @@ namespace Yardarm.Generation.Request
                     valueExpression = InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.HeaderSerializerInstance,
+                            SerializationNamespace.HeaderSerializer,
                             IdentifierName("SerializePrimitive")),
                         ArgumentList(SeparatedList(new []
                         {

--- a/src/main/Yardarm/Names/ISerializationNamespace.cs
+++ b/src/main/Yardarm/Names/ISerializationNamespace.cs
@@ -6,7 +6,6 @@ namespace Yardarm.Names
     public interface ISerializationNamespace : IKnownNamespace
     {
         NameSyntax HeaderSerializer { get; }
-        ExpressionSyntax HeaderSerializerInstance { get; }
         NameSyntax ISerializationData { get; }
         NameSyntax ITypeSerializer { get; }
         NameSyntax ITypeSerializerRegistry { get; }

--- a/src/main/Yardarm/Names/Internal/SerializationNamespace.cs
+++ b/src/main/Yardarm/Names/Internal/SerializationNamespace.cs
@@ -9,7 +9,6 @@ namespace Yardarm.Names.Internal
     internal class SerializationNamespace : ISerializationNamespace
     {
         public NameSyntax HeaderSerializer { get; }
-        public ExpressionSyntax HeaderSerializerInstance { get; }
         public NameSyntax Name { get; }
         public NameSyntax ISerializationData { get; }
         public NameSyntax ITypeSerializer { get; }
@@ -31,10 +30,6 @@ namespace Yardarm.Names.Internal
             HeaderSerializer = QualifiedName(
                 Name,
                 IdentifierName("HeaderSerializer"));
-
-            HeaderSerializerInstance = MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                HeaderSerializer,
-                IdentifierName("Instance"));
 
             ISerializationData = QualifiedName(
                 Name,


### PR DESCRIPTION
- No longer boxes when serializing some value types such as int, long, and Guid
- Don't unnecessarily load CultureInfo.InvariantCulture for Guid
- Use "." separator for PathSegmentStyle.Label regardless of the value of "explode" (this correctly follows the specification)

**Breaking changes
- LiteralSerializer and HeaderSerializer are now static classes