### PR TITLE
Use a custom interpolation handler for paths

### DIFF
--- a/src/main/Yardarm.Benchmarks/PathSerializerInterpolation.cs
+++ b/src/main/Yardarm.Benchmarks/PathSerializerInterpolation.cs
@@ -1,0 +1,25 @@
+﻿using RootNamespace.Serialization;
+
+namespace Yardarm.Benchmarks;
+
+[MemoryDiagnoser]
+public class PathSerializerInterpolation
+{
+    long BusinessLocationId { get; set; } = 123456;
+    Guid CustomerId { get; set; } = Guid.NewGuid();
+
+    [Benchmark(Baseline = true)]
+    public string Serialize()
+    {
+        // We don't use stackalloc for an initial buffer here because this PathSegmentSerializer.Serialize overload returns intermediate strings,
+        // so this is implemented as a call to string.Concat which is faster than using DefaultInterpolatedStringHandler.
+        return $"org/{PathSegmentSerializer.Serialize("id", BusinessLocationId, PathSegmentStyle.Simple, "int64")}/customers/{PathSegmentSerializer.Serialize("customerId", CustomerId, PathSegmentStyle.Simple, "uuid")}";
+    }
+
+    [Benchmark]
+    public string Build()
+    {
+        Span<char> initialBuffer = stackalloc char[256];
+        return PathSegmentSerializer.Build(initialBuffer, $"org/{BusinessLocationId:int64}/customers/{CustomerId:uuid}");
+    }
+}

--- a/src/main/Yardarm.Benchmarks/Program.cs
+++ b/src/main/Yardarm.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+﻿using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/src/main/Yardarm.Benchmarks/Yardarm.Benchmarks.csproj
+++ b/src/main/Yardarm.Benchmarks/Yardarm.Benchmarks.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" VersionOverride="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yardarm.Client\Yardarm.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="BenchmarkDotNet" />
+    <Using Include="BenchmarkDotNet.Attributes" />
+  </ItemGroup>
+
+</Project>

--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -192,6 +192,522 @@ namespace Yardarm.Client.UnitTests.Serialization
 
         #endregion
 
+        #region TrySerialize Success
+
+        [Fact]
+        public void TrySerialize_String_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize("test", default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("test");
+        }
+
+        [Fact]
+        public void TrySerialize_Integer_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(105, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("105");
+        }
+
+        [Fact]
+        public void TrySerialize_Long_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(105L, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("105");
+        }
+
+        [Fact]
+        public void TrySerialize_Float_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(1.05f, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("1.05");
+        }
+
+        [Fact]
+        public void TrySerialize_Double_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(1.05, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("1.05");
+        }
+
+        [Fact]
+        public void TrySerialize_True_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(true, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("true");
+        }
+
+        [Fact]
+        public void TrySerialize_False_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(false, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("false");
+        }
+
+        [Fact]
+        public void TrySerialize_DateTime_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(new DateTime(2020, 1, 2, 3, 4, 5),
+                default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("2020-01-02T03:04:05.0000000");
+        }
+
+        [Theory]
+        [InlineData("date")]
+        [InlineData("full-date")]
+        public void TrySerialize_Date_ReturnsString(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(new DateTime(2020, 1, 2, 3, 4, 5),
+                format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("2020-01-02");
+        }
+
+        [Fact]
+        public void TrySerialize_DateTimeOffset_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)),
+                default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("2020-01-02T03:04:05.0000000-04:00");
+        }
+
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void TrySerialize_TimeSpan_ReturnsString(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new TimeSpan(0, 3, 4, 5), format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("03:04:05");
+        }
+
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void TrySerialize_TimeSpanMillis_ReturnsString(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new TimeSpan(0, 3, 4, 5, 123), format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("03:04:05.1230000");
+        }
+
+        [Fact]
+        public void TrySerialize_Guid_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Arrange
+
+            var guid = Guid.NewGuid();
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(guid, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be(guid.ToString());
+        }
+
+        [Fact]
+        public void TrySerialize_Enum_ReturnsString()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[256];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(StringComparison.Ordinal, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeTrue();
+            buffer[..charsWritten].ToString().Should().Be("Ordinal");
+        }
+
+        #endregion
+
+        #region TrySerialize Failure
+
+        [Fact]
+        public void TrySerialize_String_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[3];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize("test", default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Integer_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[2];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(105, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Long_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[2];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(105L, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Float_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[3];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(1.05f, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Double_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[3];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(1.05, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_True_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[3];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(true, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_False_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[4];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(false, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_DateTime_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[9];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(new DateTime(2020, 1, 2, 3, 4, 5),
+                default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("date")]
+        [InlineData("full-date")]
+        public void TrySerialize_Date_Fails(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[9];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(new DateTime(2020, 1, 2, 3, 4, 5),
+                format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_DateTimeOffset_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[9];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new DateTimeOffset(2020, 1, 2, 3, 4, 5, TimeSpan.FromHours(-4)),
+                default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void TrySerialize_TimeSpan_Fails(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[7];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new TimeSpan(0, 3, 4, 5), format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Theory]
+        [InlineData("partial-time")]
+        [InlineData("date-span")]
+        public void TrySerialize_TimeSpanMillis_Fails(string format)
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[7];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(
+                new TimeSpan(0, 3, 4, 5, 123), format, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Guid_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[35];
+
+            // Arrange
+
+            var guid = Guid.NewGuid();
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(guid, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        [Fact]
+        public void TrySerialize_Enum_Fails()
+        {
+            // Arrange
+
+            Span<char> buffer = stackalloc char[6];
+
+            // Act
+
+            bool result = LiteralSerializer.TrySerialize(StringComparison.Ordinal, default, buffer, out var charsWritten);
+
+            // Assert
+
+            result.Should().BeFalse();
+            charsWritten.Should().Be(0);
+        }
+
+        #endregion
+
         #region Deserialize
 
         [Fact]

--- a/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/PathSegmentSerializerTests.cs
@@ -438,5 +438,391 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         #endregion
+
+        #region Build
+
+        [Fact]
+        public void Build_Simple_ExpectedResult()
+        {
+            // Arrange
+
+            var id = 5;
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/5/test");
+        }
+
+        [Fact]
+        public void Build_SimpleWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            var dateTime = new DateTime(2020, 1, 2);
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime:date}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/2020-01-02/test");
+        }
+
+        [Fact]
+        public void Build_Label_ExpectedResult()
+        {
+            // Arrange
+
+            var id = 5;
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,1}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.5/.test");
+        }
+
+        [Fact]
+        public void Build_LabelWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            var dateTime = new DateTime(2020, 1, 2);
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,1:date}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.2020-01-02/.test");
+        }
+
+        [Fact]
+        public void Build_Matrix_ExpectedResult()
+        {
+            // Arrange
+
+            var id = 5;
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,4:id}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;id=5/;str=test");
+        }
+
+        [Fact]
+        public void Build_MatrixWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            var dateTime = new DateTime(2020, 1, 2);
+            var str = "test";
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,4:dtdate}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;dt=2020-01-02/;str=test");
+        }
+
+        #endregion
+
+        #region Build List
+
+        [Fact]
+        public void Build_SimpleList_ExpectedResult()
+        {
+            // Arrange
+
+            List<int> id = [5, 6];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/5,6/test,foo");
+        }
+
+        [Fact]
+        public void Build_SimpleListWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            List<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime:date}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/2020-01-02,2020-01-03/test,foo");
+        }
+
+        [Fact]
+        public void Build_LabelList_ExpectedResult()
+        {
+            // Arrange
+
+            List<int> id = [5, 6];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,1}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.5.6/.test.foo");
+        }
+
+        [Fact]
+        public void Build_LabelListWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            List<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,1:date}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.2020-01-02.2020-01-03/.test.foo");
+        }
+
+        [Fact]
+        public void Build_MatrixList_ExpectedResult()
+        {
+            // Arrange
+
+            List<int> id = [5, 6];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,4:id}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;id=5,6/;str=test,foo");
+        }
+
+        [Fact]
+        public void Build_MatrixListWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            List<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,4:dtdate}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;dt=2020-01-02,2020-01-03/;str=test,foo");
+        }
+
+        [Fact]
+        public void Build_MatrixListExploded_ExpectedResult()
+        {
+            // Arrange
+
+            List<int> id = [5, 6];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,-4:id}/{str,-5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;id=5;id=6/;str=test;str=foo");
+        }
+
+        [Fact]
+        public void Build_MatrixListExplodedWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            List<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            List<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,-4:dtdate}/{str,-5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;dt=2020-01-02;dt=2020-01-03/;str=test;str=foo");
+        }
+
+        #endregion
+
+        #region Build IEnumerable<T>
+
+        [Fact]
+        public void Build_SimpleIEnumerable_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<int> id = [5, 6];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/5,6/test,foo");
+        }
+
+        [Fact]
+        public void Build_SimpleIEnumerableWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime:date}/{str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/2020-01-02,2020-01-03/test,foo");
+        }
+
+        [Fact]
+        public void Build_LabelIEnumerable_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<int> id = [5, 6];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,1}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.5.6/.test.foo");
+        }
+
+        [Fact]
+        public void Build_LabelIEnumerableWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,1:date}/{str,1}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/.2020-01-02.2020-01-03/.test.foo");
+        }
+
+        [Fact]
+        public void Build_MatrixIEnumerable_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<int> id = [5, 6];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,4:id}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;id=5,6/;str=test,foo");
+        }
+
+        [Fact]
+        public void Build_MatrixIEnumerableWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,4:dtdate}/{str,5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;dt=2020-01-02,2020-01-03/;str=test,foo");
+        }
+
+        [Fact]
+        public void Build_MatrixIEnumerableExploded_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<int> id = [5, 6];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{id,-4:id}/{str,-5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;id=5;id=6/;str=test;str=foo");
+        }
+
+        [Fact]
+        public void Build_MatrixIEnumerableExplodedWithFormat_ExpectedResult()
+        {
+            // Arrange
+
+            IEnumerable<DateTime> dateTime = [new DateTime(2020, 1, 2), new DateTime(2020, 1, 3)];
+            IEnumerable<string> str = ["test", "foo"];
+
+            // Act
+
+            var result = PathSegmentSerializer.Build($"/api/widget/{dateTime,-4:dtdate}/{str,-5:str}");
+
+            // Assert
+
+            result.Should().Be("/api/widget/;dt=2020-01-02;dt=2020-01-03/;str=test;str=foo");
+        }
+
+        #endregion
     }
 }

--- a/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿#if FORTESTS
 using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Yardarm.Benchmarks")]
 [assembly: InternalsVisibleTo("Yardarm.Client.UnitTests")]
 [assembly: InternalsVisibleTo("Yardarm.MicrosoftExtensionsHttp.Client")]
 [assembly: InternalsVisibleTo("Yardarm.NewtonsoftJson.Client")]

--- a/src/main/Yardarm.Client/Serialization/PathSegmentInterpolatedStringHandler.cs
+++ b/src/main/Yardarm.Client/Serialization/PathSegmentInterpolatedStringHandler.cs
@@ -1,0 +1,453 @@
+﻿#if NET6_0_OR_GREATER
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// Some code ported from DefaultInterpolatedStringHandler
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace RootNamespace.Serialization;
+
+[InterpolatedStringHandler]
+internal ref struct PathSegmentInterpolatedStringHandler
+{
+    private const int GuessedLengthPerHole = 11;
+    private const int MinimumArrayPoolLength = 256;
+
+    private char[]? _arrayToReturnToPool;
+    /// <summary>The span to write into.</summary>
+    private Span<char> _chars;
+    /// <summary>Position at which to write the next character.</summary>
+    private int _pos;
+
+    public PathSegmentInterpolatedStringHandler(int literalLength, int formattedCount)
+    {
+        _chars = _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(GetDefaultLength(literalLength, formattedCount));
+        _pos = 0;
+    }
+
+    public PathSegmentInterpolatedStringHandler(int literalLength, int formattedCount, Span<char> initialBuffer)
+    {
+        _chars = initialBuffer;
+        _arrayToReturnToPool = null;
+        _pos = 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] // becomes a constant when inputs are constant
+    private static int GetDefaultLength(int literalLength, int formattedCount) =>
+        Math.Max(MinimumArrayPoolLength, literalLength + (formattedCount * GuessedLengthPerHole));
+
+    private readonly ReadOnlySpan<char> Text => _chars.Slice(0, _pos);
+
+    public override readonly string ToString() => new(Text);
+
+    public string ToStringAndClear()
+    {
+        string result = new(Text);
+
+        char[]? toReturn = _arrayToReturnToPool;
+        this = default; // defensive clear
+        if (toReturn is not null)
+        {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+
+        return result;
+    }
+
+    public void AppendLiteral(string value)
+    {
+        if (value.TryCopyTo(_chars.Slice(_pos)))
+        {
+            _pos += value.Length;
+        }
+        else
+        {
+            GrowThenCopyString(value);
+        }
+    }
+
+    #region AppendFormatted
+
+    // We apply a "struct" constraint to ensure that IEnumerable<T> cases aren't routed through the AppendFormattted<T>(T value) overloads.
+    // C# will prefer them for List<T>, T[], etc if the constraint is not present. However, this means we also need separate overloads for T?
+    // to handle nullable cases which won't match the non-nullable T overload. Reference types will either use the string or object overloads
+    // unless they are IEnumerable<T>, in which case they will use the IEnumerable<T> or List<T> overloads.
+    //
+    // alignment is a not used to represent padding and alignment, and instead encodes the PathSegmentStyle, explode boolean, and the length
+    // of the name for PathSegmentStyle.Matrix
+    //   0 = PathSegmentStyle.Simple
+    //   1 = PathSegmentStyle.Label
+    //   -1 = Unused, but reserved for future use
+    //   >= 2 or <= -2 = PathSegmentStyle.Matrix, length of the name is ABS(alignment) - 2
+    //   If negative, indicates that the list should be exploded
+    //
+    // format is the format in terms of the LiteralSerializer formats, not standard .NET formats.
+    // For PathSegmentStyle.Matrix, the beginning of the format is the name and the remainder is the format for LiteralSerializer.
+
+    public void AppendFormatted<T>(T value) where T : struct
+    {
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, format: default, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    public void AppendFormatted<T>(T value, string? format) where T : struct
+    {
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, format, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    public void AppendFormatted<T>(T value, int alignment, string? format = null) where T : struct
+    {
+        var trimmedFormat = AppendStyle(alignment, format);
+
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, trimmedFormat, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    public void AppendFormatted<T>(T? value) where T : struct
+    {
+        if (value is not null)
+        {
+            int charsWritten;
+            while (!LiteralSerializer.TrySerialize(value.GetValueOrDefault(), format: default, _chars.Slice(_pos), out charsWritten))
+            {
+                Grow();
+            }
+
+            _pos += charsWritten;
+        }
+    }
+
+    public void AppendFormatted<T>(T? value, string? format) where T : struct
+    {
+        if (value is not null)
+        {
+            int charsWritten;
+            while (!LiteralSerializer.TrySerialize(value.GetValueOrDefault(), format, _chars.Slice(_pos), out charsWritten))
+            {
+                Grow();
+            }
+
+            _pos += charsWritten;
+        }
+    }
+
+    public void AppendFormatted<T>(T? value, int alignment, string? format = null) where T : struct
+    {
+        var trimmedFormat = AppendStyle(alignment, format);
+
+        if (value is not null)
+        {
+            int charsWritten;
+            while (!LiteralSerializer.TrySerialize(value.GetValueOrDefault(), trimmedFormat, _chars.Slice(_pos), out charsWritten))
+            {
+                Grow();
+            }
+
+            _pos += charsWritten;
+        }
+    }
+
+    public void AppendFormatted<T>(List<T>? values, int alignment = 0, string? format = null)
+    {
+        // Store the current position so we can use it for exploded matrix separators
+        var posCache = _pos;
+
+        var trimmedFormat = AppendStyle(alignment, format);
+
+        if (values is null || values.Count == 0)
+        {
+            // short circuit
+            return;
+        }
+
+        // Compute the separator. We can't use a ROS<char> because _chars may be replaced if a Grow occurs and
+        // the buffer is returned to the ArrayPool, so we make a copy in the exploded Matrix case.
+        var separator = alignment switch
+        {
+            0 or >= 2 => ",",
+            <= -2 => new string(_chars[posCache.._pos]), // Exploded matrix repeats ";name=" as the separator
+            _ => "." // Label is always "." separator
+        };
+
+        for (int i=0; i<values.Count; i++)
+        {
+            if (i > 0)
+            {
+                AppendLiteral(separator);
+            }
+
+            T value = values[i];
+            int charsWritten;
+            while (!LiteralSerializer.TrySerialize(value, trimmedFormat, _chars.Slice(_pos), out charsWritten))
+            {
+                Grow();
+            }
+
+            _pos += charsWritten;
+        }
+    }
+
+    // Fallback in cases where the enumerable is not a List<T>. This is less performant because the foreach loop
+    // must enumerate using an enumerator rather than using List<T> optimizations.
+    public void AppendFormatted<T>(IEnumerable<T>? values, int alignment = 0, string? format = null)
+    {
+        // Store the current position so we can use it for exploded matrix separators
+        var posCache = _pos;
+
+        var trimmedFormat = AppendStyle(alignment, format);
+
+        if (values is null)
+        {
+            // short circuit
+            return;
+        }
+
+        var separator = alignment switch
+        {
+            0 or >= 2 => ",",
+            <= -2 => new string(_chars[posCache.._pos]), // Exploded matrix repeats ";name=" as the separator
+            _ => "." // Label is always "." separator
+        };
+
+
+        IEnumerator<T> enumerator = values.GetEnumerator();
+        try
+        {
+            if (!enumerator.MoveNext())
+            {
+                return;
+            }
+
+            while (true)
+            {
+                int charsWritten;
+                while (!LiteralSerializer.TrySerialize(enumerator.Current, trimmedFormat, _chars.Slice(_pos), out charsWritten))
+                {
+                    Grow();
+                }
+
+                _pos += charsWritten;
+
+                if (!enumerator.MoveNext())
+                {
+                    break;
+                }
+
+                AppendLiteral(separator);
+            }
+        }
+        finally
+        {
+            enumerator?.Dispose();
+        }
+    }
+
+    public void AppendFormatted(scoped ReadOnlySpan<char> value)
+    {
+        // Fast path for when the value fits in the current buffer
+        if (value.TryCopyTo(_chars.Slice(_pos)))
+        {
+            _pos += value.Length;
+        }
+        else
+        {
+            GrowThenCopySpan(value);
+        }
+    }
+
+    // Reduces IL size at the callsite when there is no alignment
+    public void AppendFormatted(scoped ReadOnlySpan<char> value, string? format) => AppendFormatted(value);
+
+    public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment, string? format = null)
+    {
+        AppendStyle(alignment, format);
+
+        AppendFormatted(value);
+    }
+
+    public void AppendFormatted(string? value)
+    {
+        if (value is not null)
+        {
+            AppendLiteral(value);
+        }
+    }
+
+    // Reduces IL size at the callsite when there is no alignment
+    public void AppendFormatted(string? value, string? format) => AppendFormatted(value);
+
+    public void AppendFormatted(string? value, int alignment, string? format = null)
+    {
+        AppendStyle(alignment, format);
+
+        if (value is not null)
+        {
+            AppendLiteral(value);
+        }
+    }
+
+    public void AppendFormatted(object value)
+    {
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, format: default, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    public void AppendFormatted(object value, string? format)
+    {
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, format, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    public void AppendFormatted(object value, int alignment, string? format = null)
+    {
+        var trimmedFormat = AppendStyle(alignment, format);
+
+        int charsWritten;
+        while (!LiteralSerializer.TrySerialize(value, trimmedFormat, _chars.Slice(_pos), out charsWritten))
+        {
+            Grow();
+        }
+
+        _pos += charsWritten;
+    }
+
+    private ReadOnlySpan<char> AppendStyle(int alignment, ReadOnlySpan<char> format)
+    {
+        switch (alignment)
+        {
+            case 0:
+                break;
+
+            case 1: // PathSegmentStyle.Label, ignores explode negation
+                EnsureCapacityForAdditionalCharsAndSlice(1)[0] = '.';
+                _pos++;
+                break;
+
+            default: // PathSegmentStyle.Matrix, inverse of alignment is the portion of the format that stores the name
+                // For matrix, style is name length + 2, and name is stored at the beginning of the format. But we must
+                // also add 2 characters, so style is effectively the total length.
+                int style = Math.Abs(alignment);
+
+                var nameSpan = EnsureCapacityForAdditionalCharsAndSlice(style);
+                nameSpan[0] = ';';
+                format.Slice(0, style - 2).CopyTo(nameSpan.Slice(1));
+                nameSpan[^1] = '=';
+
+                _pos += style;
+
+                // Update the format to exclude the name
+                return format.Slice(style - 2);
+        }
+
+        return format;
+    }
+
+    #endregion
+
+    #region Grow
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private Span<char> EnsureCapacityForAdditionalCharsAndSlice(int additionalChars)
+    {
+        if (_chars.Length - _pos < additionalChars)
+        {
+            Grow(additionalChars);
+        }
+
+        return _chars.Slice(_pos, additionalChars);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void GrowThenCopyString(string value)
+    {
+        Grow(value.Length);
+        value.CopyTo(_chars.Slice(_pos));
+        _pos += value.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void GrowThenCopySpan(scoped ReadOnlySpan<char> value)
+    {
+        Grow(value.Length);
+        value.CopyTo(_chars.Slice(_pos));
+        _pos += value.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)] // keep consumers as streamlined as possible
+    private void Grow(int additionalChars)
+    {
+        // This method is called when the remaining space (_chars.Length - _pos) is
+        // insufficient to store a specific number of additional characters.  Thus, we
+        // need to grow to at least that new total. GrowCore will handle growing by more
+        // than that if possible.
+        Debug.Assert(additionalChars > _chars.Length - _pos);
+        GrowCore((uint)_pos + (uint)additionalChars);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)] // keep consumers as streamlined as possible
+    private void Grow()
+    {
+        // This method is called when the remaining space in _chars isn't sufficient to continue
+        // the operation.  Thus, we need at least one character beyond _chars.Length.  GrowCore
+        // will handle growing by more than that if possible.
+        GrowCore((uint)_chars.Length + 1);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)] // but reuse this grow logic directly in both of the above grow routines
+    private void GrowCore(uint requiredMinCapacity)
+    {
+        // We want the max of how much space we actually required and doubling our capacity (without going beyond the max allowed length). We
+        // also want to avoid asking for small arrays, to reduce the number of times we need to grow, and since we're working with unsigned
+        // ints that could technically overflow if someone tried to, for example, append a huge string to a huge string, we also clamp to int.MaxValue.
+        // Even if the array creation fails in such a case, we may later fail in ToStringAndClear.
+
+        uint newCapacity = Math.Max(requiredMinCapacity, Math.Min((uint)_chars.Length * 2, 0x3FFFFFDF));
+        int arraySize = (int)Math.Clamp(newCapacity, MinimumArrayPoolLength, int.MaxValue);
+
+        char[] newArray = ArrayPool<char>.Shared.Rent(arraySize);
+        _chars.Slice(0, _pos).CopyTo(newArray);
+
+        char[]? toReturn = _arrayToReturnToPool;
+        _chars = _arrayToReturnToPool = newArray;
+
+        if (toReturn is not null)
+        {
+            ArrayPool<char>.Shared.Return(toReturn);
+        }
+    }
+
+    #endregion
+}
+
+#endif

--- a/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
+++ b/src/main/Yardarm.Client/Serialization/PathSegmentSerializer.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization
@@ -24,6 +27,18 @@ namespace RootNamespace.Serialization
                     $";{name}={LiteralSerializer.JoinList(explode ? $";{name}=" : ",", values, format)}",
                 _ => throw new InvalidEnumArgumentException(nameof(style), (int)style, typeof(PathSegmentStyle))
             };
+
+#if NET6_0_OR_GREATER
+
+        public static string Build(PathSegmentInterpolatedStringHandler handler) =>
+            handler.ToStringAndClear();
+
+#pragma warning disable IDE0060 // Remove unused parameter
+        public static string Build(Span<char> initialBuffer, [InterpolatedStringHandlerArgument(nameof(initialBuffer))] PathSegmentInterpolatedStringHandler handler) =>
+            handler.ToStringAndClear();
+#pragma warning restore IDE0060 // Remove unused parameter
+
+#endif
 
         private static string SerializeSimple<T>(T value, string? format = null)
         {

--- a/src/main/Yardarm.sln
+++ b/src/main/Yardarm.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.MicrosoftExtensions
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yardarm.MicrosoftExtensionsHttp.Client", "Yardarm.MicrosoftExtensionsHttp.Client\Yardarm.MicrosoftExtensionsHttp.Client.csproj", "{AB9CA15B-AE6E-421B-9662-E6264B4EA1CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yardarm.Benchmarks", "Yardarm.Benchmarks\Yardarm.Benchmarks.csproj", "{A92143CD-F939-445D-B408-7493E36BB662}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0F27CDEF-318E-4305-AE2B-AA44C670E7C2}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Packages.props = Directory.Packages.props
@@ -86,6 +88,10 @@ Global
 		{AB9CA15B-AE6E-421B-9662-E6264B4EA1CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AB9CA15B-AE6E-421B-9662-E6264B4EA1CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AB9CA15B-AE6E-421B-9662-E6264B4EA1CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A92143CD-F939-445D-B408-7493E36BB662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A92143CD-F939-445D-B408-7493E36BB662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A92143CD-F939-445D-B408-7493E36BB662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A92143CD-F939-445D-B408-7493E36BB662}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -174,7 +174,7 @@ namespace Yardarm.Generation.Request
                 pathExpression = InvocationExpression(
                     MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         SerializationNamespace.PathSegmentSerializer,
-                        IdentifierName("Serialize")),
+                        IdentifierName("Build")),
                     ArgumentList(SeparatedList([
                         Argument(IdentifierName("initialBuffer")),
                         Argument(pathExpression)

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -47,6 +48,93 @@ namespace Yardarm.Generation.Request
                 .WithBody(Block(GenerateBody(operation, mediaType)));
         }
 
+        private Func<PathSegment, InterpolationSyntax> CreateLegacyParameterInterpolationBuilder(
+            Dictionary<string, OpenApiParameter> allParameters,
+            INameFormatter propertyNameFormatter)
+        {
+            // Uses less performant string interpolation that generates intermediate strings
+            // for target frameworks < .NET 6.0
+
+            return pathSegment =>
+            {
+                allParameters.TryGetValue(pathSegment.Value, out var parameter);
+
+                if (parameter?.Schema?.Type == "array")
+                {
+                    return Interpolation(InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            SerializationNamespace.PathSegmentSerializer,
+                            IdentifierName("SerializeList")),
+                        ArgumentList(SeparatedList([
+                            Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                                Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
+                                Argument(GetStyleExpression(parameter)),
+                                Argument(GetExplodeExpression(parameter)),
+                                Argument(SyntaxHelpers.StringLiteral(parameter.Schema?.Format))
+                        ]))));
+                }
+                else
+                {
+                    return Interpolation(InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            SerializationNamespace.PathSegmentSerializer,
+                            IdentifierName("Serialize")),
+                        ArgumentList(SeparatedList([
+                            Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
+                                Argument(GetStyleExpression(parameter)),
+                                Argument(SyntaxHelpers.StringLiteral(parameter?.Schema?.Format))
+                        ]))));
+                }
+            };
+        }
+
+        private static Func<PathSegment, InterpolationSyntax> CreateModernParameterInterpolationBuilder(
+            Dictionary<string, OpenApiParameter> allParameters,
+            INameFormatter propertyNameFormatter)
+        {
+            // Uses more performant string interpolation, passing explode, style, and name via the
+            // alignment and format values. See PathSegmentInterpolatedStringHandler for details.
+
+            return pathSegment =>
+            {
+                allParameters.TryGetValue(pathSegment.Value, out var parameter);
+
+                int alignment = 0;
+                string? format = null;
+
+                if (parameter is not null)
+                {
+                    format = parameter.Schema?.Format;
+
+                    if (parameter.Style == ParameterStyle.Label)
+                    {
+                        alignment = 1;
+                    }
+                    else if (parameter.Style == ParameterStyle.Matrix)
+                    {
+                        alignment = 2 + pathSegment.Value.Length;
+                        if (parameter.Explode)
+                        {
+                            alignment = -alignment;
+                        }
+
+                        format = $"{pathSegment.Value}{format}";
+                    }
+                }
+
+                return Interpolation(
+                    IdentifierName(propertyNameFormatter.Format(pathSegment.Value)),
+                    alignment != 0
+                        ? InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(alignment)))
+                        : null,
+                    format is not null
+                        ? InterpolationFormatClause(Token(SyntaxKind.ColonToken), Token(default, SyntaxKind.InterpolatedStringTextToken, format, format, default))
+                        : null);
+            };
+        }
+
         public IEnumerable<StatementSyntax> GenerateBody(ILocatedOpenApiElement<OpenApiOperation> operation,
             ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
         {
@@ -58,39 +146,45 @@ namespace Yardarm.Generation.Request
                 .Select(p => p.Element)
                 .ToDictionary(p => p.Name, p => p);
 
-            ExpressionSyntax pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
-                pathSegment =>
-                {
-                    allParameters.TryGetValue(pathSegment.Value, out var parameter);
+            ExpressionSyntax pathExpression;
+            if (Context.CurrentTargetFramework.Version.Major >= 6)
+            {
+                pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
+                    CreateModernParameterInterpolationBuilder(allParameters, propertyNameFormatter));
 
-                    if (parameter?.Schema?.Type == "array")
-                    {
-                        return InvocationExpression(
-                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                SerializationNamespace.PathSegmentSerializer,
-                                IdentifierName("SerializeList")),
-                            ArgumentList(SeparatedList([
-                                Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
-                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
-                                Argument(GetStyleExpression(parameter)),
-                                Argument(GetExplodeExpression(parameter)),
-                                Argument(SyntaxHelpers.StringLiteral(parameter.Schema?.Format))
-                            ])));
-                    }
-                    else
-                    {
-                        return InvocationExpression(
-                            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                SerializationNamespace.PathSegmentSerializer,
-                                IdentifierName("Serialize")),
-                            ArgumentList(SeparatedList([
-                                Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
-                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
-                                Argument(GetStyleExpression(parameter)),
-                                Argument(SyntaxHelpers.StringLiteral(parameter?.Schema?.Format))
-                            ])));
-                    }
-                });
+                // Yield a 256 character stackalloc for an initial buffer
+                yield return LocalDeclarationStatement(VariableDeclaration(
+                    type: QualifiedName(
+                        IdentifierName("System"),
+                        GenericName(
+                            Identifier("Span"),
+                            TypeArgumentList(SingletonSeparatedList<TypeSyntax>(PredefinedType(Token(SyntaxKind.CharKeyword)))))),
+                    variables: SingletonSeparatedList(VariableDeclarator(
+                        Identifier("initialBuffer"),
+                        argumentList: null,
+                        initializer: EqualsValueClause(
+                            StackAllocArrayCreationExpression(
+                                ArrayType(PredefinedType(Token(SyntaxKind.CharKeyword)))
+                                .WithRankSpecifiers(SingletonList(
+                                ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
+                                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(256))
+                                ))))))))));
+
+                // Wrap in a call to PathSegmentSerializer.Serialize to ensure the handler is used
+                pathExpression = InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        SerializationNamespace.PathSegmentSerializer,
+                        IdentifierName("Serialize")),
+                    ArgumentList(SeparatedList([
+                        Argument(IdentifierName("initialBuffer")),
+                        Argument(pathExpression)
+                    ])));
+            }
+            else
+            {
+                pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
+                    CreateLegacyParameterInterpolationBuilder(allParameters, propertyNameFormatter));
+            }
 
             OpenApiParameter[] queryParameters = allParameters.Values
                 .Where(p => (p.In ?? ParameterLocation.Query) == ParameterLocation.Query)

--- a/src/main/Yardarm/Spec/Path/PathParser.cs
+++ b/src/main/Yardarm/Spec/Path/PathParser.cs
@@ -57,7 +57,7 @@ namespace Yardarm.Spec.Path
         }
 
         public static InterpolatedStringExpressionSyntax ToInterpolatedStringExpression(
-            this IEnumerable<PathSegment> pathSegments, Func<PathSegment, ExpressionSyntax> parameterInterpreter) =>
+            this IEnumerable<PathSegment> pathSegments, Func<PathSegment, InterpolationSyntax> parameterInterpreter) =>
             InterpolatedStringExpression(Token(SyntaxKind.InterpolatedStringStartToken),
                 List(pathSegments.Select(p => p.ToInterpolatedStringContentSyntax(parameterInterpreter))));
     }

--- a/src/main/Yardarm/Spec/Path/PathSegment.cs
+++ b/src/main/Yardarm/Spec/Path/PathSegment.cs
@@ -29,10 +29,10 @@ namespace Yardarm.Spec.Path
 
         public override int GetHashCode() => HashCode.Combine(Value, (int) Type);
 
-        public InterpolatedStringContentSyntax ToInterpolatedStringContentSyntax(Func<PathSegment, ExpressionSyntax> parameterInterpreter) =>
+        public InterpolatedStringContentSyntax ToInterpolatedStringContentSyntax(Func<PathSegment, InterpolationSyntax> parameterInterpreter) =>
             Type == PathSegmentType.Text
-                ? (InterpolatedStringContentSyntax) InterpolatedStringText(
+                ? InterpolatedStringText(
                     Token(TriviaList(), SyntaxKind.InterpolatedStringTextToken, Value, Value, TriviaList()))
-                : Interpolation(parameterInterpreter.Invoke(this));
+                : parameterInterpreter.Invoke(this);
     }
 }


### PR DESCRIPTION
Motivation
----------
Improved performance and reduced heap allocations building URLs for requests. While parts of this could be backported to downlevel frameworks, it's generally not worth the effort, so it only applies to .NET 6 and newer.

Modifications
-------------
- Add `TrySerialize` to `LiteralSerializer` that writes to a `Span<char>`
- Create a custom interpolated string handler for building URIs
- Add an overload to `PathSegmentSerializer` that accepts a `PathSegmentInterpolatedStringHandler`
- Use the new overload when building the `BuildUri` method when targeting .NET 6 and later
- Add a benchmark project

Breaking Changes
--------------------
- `PathParser.ToInterpolatedStringExpression` and `PathSegment.ToInterpolatedStringContentSyntax` now take an interpreter that returns an `InterpolationSyntax` instead of an `ExpressionSyntax`

Results
-------
The benchmark below is for a relatively simple URI with two path segments, one a long and the other a GUID. The Build benchmark uses the overload that stackallocs an initialBuffer.

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.2033) Unknown processor
.NET SDK 8.0.403
  [Host]     : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2

| Method    | Mean     | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
|---------- |---------:|---------:|---------:|------:|-------:|----------:|------------:|
| Serialize | 28.92 ns | 0.176 ns | 0.156 ns |  1.00 | 0.0216 |     272 B |        1.00 |
| Build     | 24.10 ns | 0.153 ns | 0.136 ns |  0.83 | 0.0108 |     136 B |        0.50 |