### PR TITLE
Create system to register LiteralConverters

### DIFF
--- a/src/main/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/CompilationEnricherServiceCollectionExtensions.cs
@@ -13,8 +13,9 @@ namespace Yardarm.Enrichment.Compilation
                 .AddCompilationEnricher<ResourceFileCompilationEnricher>()
                 .AddCompilationEnricher<SyntaxTreeCompilationEnricher>()
                 .AddCompilationEnricher<OpenApiCompilationEnricher>()
-                .AddCompilationEnricher<DefaultTypeSerializersEnricher>()
-                .AddCompilationEnricher<FormatCompilationEnricher>();
+                .AddCompilationEnricher<FormatCompilationEnricher>()
+                .AddResourceFileEnricher<DefaultTypeSerializersEnricher>()
+                .AddResourceFileEnricher<DefaultLiteralConvertersEnricher>();
 
         public static IServiceCollection AddAssemblyInfoEnricher<T>(this IServiceCollection services)
             where T : class, IAssemblyInfoEnricher =>

--- a/src/main/Yardarm/Enrichment/Compilation/DefaultLiteralConvertersEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/DefaultLiteralConvertersEnricher.cs
@@ -1,23 +1,24 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Yardarm.Enrichment.Compilation;
 
-public class DefaultTypeSerializersEnricher(
-    IEnumerable<ICreateDefaultRegistryEnricher> createDefaultRegistryEnrichers) :
-    IResourceFileEnricher
+public class DefaultLiteralConvertersEnricher(
+    IEnumerable<IDefaultLiteralConverterEnricher> createDefaultRegistryEnrichers)
+    : IResourceFileEnricher
 {
     public bool ShouldEnrich(string resourceName) =>
-        resourceName == "Yardarm.Client.Serialization.TypeSerializerRegistry.cs";
+        resourceName == "Yardarm.Client.Serialization.Literals.LiteralConverterRegistry.cs";
 
     public CompilationUnitSyntax Enrich(CompilationUnitSyntax target, ResourceFileEnrichmentContext context)
     {
         ClassDeclarationSyntax? classDeclaration = target
             .DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
-            .FirstOrDefault(p => p.Identifier.ValueText == "TypeSerializerRegistry");
+            .FirstOrDefault(p => p.Identifier.ValueText == "LiteralConverterRegistry");
 
         MethodDeclarationSyntax? methodDeclaration = classDeclaration?
             .ChildNodes()

--- a/src/main/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/FormatCompilationEnricher.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.Extensions.Logging;
-using Yardarm.Generation;
 
 namespace Yardarm.Enrichment.Compilation
 {
@@ -27,13 +26,12 @@ namespace Yardarm.Enrichment.Compilation
         private readonly ILogger<FormatCompilationEnricher> _logger;
 
         public Type[] ExecuteAfter { get; } =
-        {
+        [
             typeof(VersionAssemblyInfoEnricher),
             typeof(SyntaxTreeCompilationEnricher),
-            typeof(DefaultTypeSerializersEnricher),
             typeof(OpenApiCompilationEnricher),
             typeof(ResourceFileCompilationEnricher)
-        };
+        ];
 
         public FormatCompilationEnricher(YardarmGenerationSettings settings,
             ILogger<FormatCompilationEnricher> logger)

--- a/src/main/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/OpenApiCompilationEnricher.cs
@@ -25,9 +25,9 @@ namespace Yardarm.Enrichment.Compilation
         private readonly ConcurrentBag<SyntaxTree> _toAdd = [];
 
         public Type[] ExecuteAfter { get; } =
-        {
-            typeof(DefaultTypeSerializersEnricher)
-        };
+        [
+            typeof(ResourceFileCompilationEnricher),
+        ];
 
         public OpenApiCompilationEnricher(IOpenApiElementRegistry elementRegistry,
             IEnumerable<IOpenApiSyntaxNodeEnricher> enrichers)

--- a/src/main/Yardarm/Enrichment/EnricherServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/Enrichment/EnricherServiceCollectionExtensions.cs
@@ -25,6 +25,10 @@ namespace Yardarm.Enrichment
             where T : class, ICreateDefaultRegistryEnricher =>
             services.AddTransient<ICreateDefaultRegistryEnricher, T>();
 
+        public static IServiceCollection AddDefaultLiteralConverterEnricher<T>(this IServiceCollection services)
+            where T : class, IDefaultLiteralConverterEnricher =>
+            services.AddTransient<IDefaultLiteralConverterEnricher, T>();
+
         public static IServiceCollection AddOpenApiSyntaxNodeEnricher<T>(this IServiceCollection services)
             where T : class, IOpenApiSyntaxNodeEnricher =>
             services.AddTransient<IOpenApiSyntaxNodeEnricher, T>();

--- a/src/main/Yardarm/Enrichment/IDefaultLiteralConverterEnricher.cs
+++ b/src/main/Yardarm/Enrichment/IDefaultLiteralConverterEnricher.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Yardarm.Enrichment;
+
+/// <summary>
+/// Enriches the body of the CreateDefaultRegistry method in the LiteralConverterRegistry class.
+/// </summary>
+public interface IDefaultLiteralConverterEnricher : IEnricher<ExpressionSyntax>
+{
+}


### PR DESCRIPTION
This will make it much easier for extensions to register their literal converters.

Also, refactor `DefaultTypeSerializerEnricher` to implement `IResourceFileEnricher` executed by the
`ResourceFileCompilationEnricher`.