### PR TITLE
Allow the command line app to roll forward to .NET 9 runtime

### DIFF
--- a/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -1,9 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+
+    <!--
+      If .NET 8 isn't installed, allow the command line tool to run on newer frameworks.
+      This may not always work, but provides better compatibility. This option still prefers
+      to use the .NET 8 runtime as specified in TargetFramework above, and only uses a newer
+      runtime if .NET 8 isn't available.
+    -->
+    <RollForward>Major</RollForward>
 
     <!--
       Since we are highly parallelized and doing a lot of SyntaxNode heap allocations, for multicore


### PR DESCRIPTION
Motivation
----------
It's possible for a system running a build to have only the .NET 9 SDK installed, without the .NET 8 runtime. In this case, setting environment variables to force a roll forward to .NET 9 is required.

Modifications
-------------
Set the roll forward configuration to Major in the command line app's runtimeconfig.json.

Results
-------
SDK-style builds will now automatically roll forward to the .NET 9 runtime to run Yardarm if the .NET 8 runtime is unavailable. For best compatibility, the .NET 8 runtime is still prefered if present.