### PR TITLE
Remove System.Net.Primitives dependency

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -19,7 +19,6 @@
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Net.Http.Json" Version="9.0.0" />
-    <PackageVersion Include="System.Net.Primitives" Version="4.3.1" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="System.Linq.Async" />
-    <PackageReference Include="System.Net.Primitives" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
This dependency is unnecesary and causing security warnings on the transitive System.Private.Uri dependency.

Modifications
-------------
Remove the dependency.