### PR TITLE
Add a framework for flexible options to be passed on the command line

### DIFF
--- a/src/main/Yardarm.CommandLine/CommonCommand.cs
+++ b/src/main/Yardarm.CommandLine/CommonCommand.cs
@@ -1,14 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
-using NuGet.Packaging.Core;
 
 namespace Yardarm.CommandLine
 {
@@ -63,6 +57,20 @@ namespace Yardarm.CommandLine
             if (targetFrameworks.Length > 0)
             {
                 settings.TargetFrameworkMonikers = targetFrameworks.ToImmutableArray();
+            }
+        }
+
+        protected void ApplyProperties(YardarmGenerationSettings settings)
+        {
+            foreach (string property in _options.Properties)
+            {
+                string[] parts = property.Split('=', 2);
+                if (parts.Length != 2)
+                {
+                    throw new ArgumentException($"Invalid property '{property}'. Properties must be in the format 'NAME=VALUE'.");
+                }
+
+                settings.Properties[parts[0]] = parts[1];
             }
         }
     }

--- a/src/main/Yardarm.CommandLine/CommonOptions.cs
+++ b/src/main/Yardarm.CommandLine/CommonOptions.cs
@@ -20,5 +20,8 @@ namespace Yardarm.CommandLine
 
         [Option("intermediate-dir", HelpText = "Intermediate output directory")]
         public string IntermediateOutputPath { get; set; }
+
+        [Option('p', "property", Separator = ';', HelpText = "List of property values, separated by semi-colons, in NAME=VALUE format")]
+        public IEnumerable<string> Properties { get; set; }
     }
 }

--- a/src/main/Yardarm.CommandLine/GenerateCommand.cs
+++ b/src/main/Yardarm.CommandLine/GenerateCommand.cs
@@ -62,6 +62,8 @@ namespace Yardarm.CommandLine
 
             ApplyNuGetSettings(settings);
 
+            ApplyProperties(settings);
+
             List<IntermediateStream> streams = await ApplyFileStreamsAsync(settings);
             try
             {

--- a/src/main/Yardarm.CommandLine/RestoreCommand.cs
+++ b/src/main/Yardarm.CommandLine/RestoreCommand.cs
@@ -37,6 +37,8 @@ namespace Yardarm.CommandLine
 
                 ApplyNuGetSettings(settings);
 
+                ApplyProperties(settings);
+
                 settings
                     .AddLogging(builder =>
                     {

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -112,6 +112,11 @@ namespace Yardarm
         /// </summary>
         public List<string>? ReferencedAssemblies { get; set; }
 
+        /// <summary>
+        /// Properties to alter the behavior of the generation process.
+        /// </summary>
+        public Dictionary<string, string> Properties { get; } = [];
+
         public CSharpCompilationOptions CompilationOptions { get; set; } =
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithDeterministic(true)


### PR DESCRIPTION
Motivation
----------
We want to support backward compat switches and other customizations, but they'll need to work for extensions as well so it should be flexible.

Modifications
-------------
Add name/value pair properties which can be passed on the command line, similar to MSBuild.