### PR TITLE
Add support for DateOnly and TimeOnly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,7 @@ csharp_indent_case_contents = true
 csharp_indent_case_contents_when_block = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
+csharp_style_namespace_declarations = file_scoped
 
 # Modifier preferences
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/main/Yardarm.CommandLine/Properties/launchSettings.json
+++ b/src/main/Yardarm.CommandLine/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "Generate": {
             "commandName": "Project",
-            "commandLineArgs": "generate --no-restore -n Test.Yardarm -x Yardarm.SystemTextJson.dll Yardarm.MicrosoftExtensionsHttp.dll -f net8.0 --embed -o output/ --intermediate-dir output/obj -v 1.0.0 -i mashtub.json"
+            "commandLineArgs": "generate --no-restore -n Test.Yardarm -x Yardarm.SystemTextJson.dll Yardarm.MicrosoftExtensionsHttp.dll -p LegacyDateTimeHandling=false -f net8.0 --embed -o output/ --intermediate-dir output/obj -v 1.0.0 -i mashtub.json"
         },
         "Restore": {
             "commandName": "Project",

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -63,7 +63,7 @@ namespace Yardarm.Generation.Schema
             Element.Element.Format switch
             {
                 "date" or "full-date" => Context.Options.LegacyDateTimeHandling ? DateTime : DateOnly,
-                "partial-time" or "time" => Context.Options.LegacyDateTimeHandling ? TimeSpan : TimeOnly,
+                "partial-time" => Context.Options.LegacyDateTimeHandling ? TimeSpan : TimeOnly,
                 "date-span" => TimeSpan,
                 "date-time" => DateTimeOffset,
                 "uuid" => Guid,

--- a/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaGenerator.cs
@@ -20,6 +20,10 @@ namespace Yardarm.Generation.Schema
         private static YardarmTypeInfo String => s_string ??= new YardarmTypeInfo(
             PredefinedType(Token(SyntaxKind.StringKeyword)), isGenerated: false);
 
+        private static YardarmTypeInfo? s_dateOnly;
+        private static YardarmTypeInfo DateOnly => s_dateOnly ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("DateOnly")), isGenerated: false);
+
         private static YardarmTypeInfo? s_dateTime;
         private static YardarmTypeInfo DateTime => s_dateTime ??= new YardarmTypeInfo(
             QualifiedName(IdentifierName("System"), IdentifierName("DateTime")), isGenerated: false);
@@ -27,6 +31,10 @@ namespace Yardarm.Generation.Schema
         private static YardarmTypeInfo? s_dateTimeOffset;
         private static YardarmTypeInfo DateTimeOffset => s_dateTimeOffset ??= new YardarmTypeInfo(
             QualifiedName(IdentifierName("System"), IdentifierName("DateTimeOffset")), isGenerated: false);
+
+        private static YardarmTypeInfo? s_timeOnly;
+        private static YardarmTypeInfo TimeOnly => s_timeOnly ??= new YardarmTypeInfo(
+            QualifiedName(IdentifierName("System"), IdentifierName("TimeOnly")), isGenerated: false);
 
         private static YardarmTypeInfo? s_timeSpan;
         private static YardarmTypeInfo TimeSpan => s_timeSpan ??= new YardarmTypeInfo(
@@ -54,8 +62,9 @@ namespace Yardarm.Generation.Schema
         protected override YardarmTypeInfo GetTypeInfo() =>
             Element.Element.Format switch
             {
-                "date" or "full-date" => DateTime,
-                "partial-time" or "date-span" => TimeSpan,
+                "date" or "full-date" => Context.Options.LegacyDateTimeHandling ? DateTime : DateOnly,
+                "partial-time" or "time" => Context.Options.LegacyDateTimeHandling ? TimeSpan : TimeOnly,
+                "date-span" => TimeSpan,
                 "date-time" => DateTimeOffset,
                 "uuid" => Guid,
                 "uri" => Uri,

--- a/src/main/Yardarm/Generation/Schema/StringSchemaOptionsConfigurator.cs
+++ b/src/main/Yardarm/Generation/Schema/StringSchemaOptionsConfigurator.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.Extensions.Options;
+using NuGet.Frameworks;
+using Yardarm.Internal;
+using Yardarm.Packaging;
+
+namespace Yardarm.Generation.Schema;
+
+internal class StringSchemaOptionsConfigurator(
+    YardarmGenerationSettings settings)
+    : IConfigureOptions<GenerationOptions>
+{
+    public void Configure(GenerationOptions options)
+    {
+        // Use legacy handling for DateOnly and TimeOnly if explicitly requested
+        if (settings.Properties.TryGetValue("LegacyDateTimeHandling", out string? legacyDateTimeHandling) &&
+            string.Equals(legacyDateTimeHandling, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            options.LegacyDateTimeHandling = true;
+            return;
+        }
+
+        // Also, use legacy handling if any target framework is less than .NET 6. This is because .NET Standard or
+        // earlier .NET Core versions do not support DateOnly and TimeOnly. Because public APIs should be forward
+        // compatible from older targets, we need to use legacy handling for all targets if any target is unsupported
+        // to ensure consistent API surface.
+        foreach (string moniker in settings.TargetFrameworkMonikers)
+        {
+            var framework = NuGetFramework.Parse(moniker);
+            if (framework.Framework != NuGetFrameworkConstants.NetCoreApp || framework.Version.Major < 6)
+            {
+                options.LegacyDateTimeHandling = true;
+                return;
+            }
+        }
+    }
+}

--- a/src/main/Yardarm/GenerationContext.cs
+++ b/src/main/Yardarm/GenerationContext.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using NuGet.Frameworks;
 using Yardarm.Generation;
+using Yardarm.Internal;
 using Yardarm.Names;
 using Yardarm.Packaging;
 using Yardarm.Spec;
@@ -43,6 +45,9 @@ namespace Yardarm
         public IReadOnlySet<string> PreprocessorSymbols =>
             _preprocessorSymbols ??= GetPreprocessorSymbols(CurrentTargetFramework);
 
+        private readonly IOptions<GenerationOptions> _options;
+        internal GenerationOptions Options => _options.Value;
+
         public GenerationContext(IServiceProvider serviceProvider) : base(serviceProvider)
         {
             _openApiDocument = new Lazy<OpenApiDocument>(serviceProvider.GetRequiredService<OpenApiDocument>);
@@ -52,6 +57,7 @@ namespace Yardarm
                 new Lazy<INameFormatterSelector>(serviceProvider.GetRequiredService<INameFormatterSelector>);
             _typeGeneratorRegistry =
                 new Lazy<ITypeGeneratorRegistry>(serviceProvider.GetRequiredService<ITypeGeneratorRegistry>);
+            _options = serviceProvider.GetRequiredService<IOptions<GenerationOptions>>();
         }
 
         private static HashSet<string> GetPreprocessorSymbols(NuGetFramework targetFramework) =>

--- a/src/main/Yardarm/Internal/GenerationOptions.cs
+++ b/src/main/Yardarm/Internal/GenerationOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Yardarm.Internal;
+
+internal class GenerationOptions
+{
+    public bool LegacyDateTimeHandling { get; set; }
+}

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging"  />
     <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>

--- a/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ namespace Yardarm
     {
         public static IServiceCollection AddYardarm(this IServiceCollection services, YardarmGenerationSettings settings, OpenApiDocument? document)
         {
+            services.AddOptions();
             services.AddDefaultEnrichers();
 
             if (settings.ReferencedAssemblies is null || settings.ReferencedAssemblies.Count == 0)
@@ -138,6 +139,8 @@ namespace Yardarm
             }
 
             services.TryAddSingleton<IOpenApiElementRegistry, OpenApiElementRegistry>();
+
+            services.ConfigureOptions<StringSchemaOptionsConfigurator>();
 
             return services;
         }

--- a/src/main/Yardarm/YardarmGenerationSettings.cs
+++ b/src/main/Yardarm/YardarmGenerationSettings.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+using NuGet.Configuration;
 using NuGet.Packaging.Core;
 using Yardarm.Packaging;
 
@@ -97,8 +98,7 @@ namespace Yardarm
         /// </summary>
         public bool NoRestore { get; set; }
 
-        public ImmutableArray<string> TargetFrameworkMonikers { get; set; } =
-            new[] {"netstandard2.0"}.ToImmutableArray();
+        public ImmutableArray<string> TargetFrameworkMonikers { get; set; } = ["netstandard2.0"];
 
         public Stream? NuGetOutput { get; set; }
 
@@ -115,7 +115,7 @@ namespace Yardarm
         /// <summary>
         /// Properties to alter the behavior of the generation process.
         /// </summary>
-        public Dictionary<string, string> Properties { get; } = [];
+        public Dictionary<string, string> Properties { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public CSharpCompilationOptions CompilationOptions { get; set; } =
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)


### PR DESCRIPTION
Motivation
----------
For "date", "partial-date", and "partial-time" string formats, DateOnly and TimeOnly are a better fit when available in .NET 6 or later.

Modifications
-------------
- Add a dependency on Microsoft.Extensions.Options
- Create a new internal option to control date/time handling, and initialize based on command-line properties and target frameworks
- Use the new option to choose schema types
- Treat "time" format the same as "partial-time"
- Make command line properties case-insensitive

Breaking Change
---------------
When building targeting only .NET 6 or later, the default type used for "date", "partial-date", and "partial-time" is now DateOnly or TimeOnly instead of DateTime or TimeSpan. This may cause backward compatibility issues in generated SDKs. Use the command line switch `-p LegacyDateTimeHandling=true` to restore the previous behavior. This is not necessary if targeting .NET Standard 2.0.