### PR TITLE
Enable extending JSON serialization settings

### DIFF
--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -9,27 +9,22 @@ using Newtonsoft.Json;
 // ReSharper disable once CheckNamespace
 namespace RootNamespace.Serialization.Json
 {
-    public class JsonTypeSerializer : ITypeSerializer
+    public class JsonTypeSerializer(JsonSerializerSettings settings) : ITypeSerializer
     {
         private static readonly UTF8Encoding s_utf8NoBomEncoding = new(false);
 
-        public static string[] SupportedMediaTypes => new []
-        {
+        public static string[] SupportedMediaTypes =>
+        [
             "application/json",
             "text/json",
             "application/json-patch+json"
-        };
+        ];
 
-        private readonly JsonSerializer _serializer;
+        private readonly JsonSerializer _serializer = JsonSerializer.Create(settings);
 
         public JsonTypeSerializer()
-            : this(new JsonSerializerSettings())
+            : this(CreateDefaultSettings())
         {
-        }
-
-        public JsonTypeSerializer(JsonSerializerSettings settings)
-        {
-            _serializer = JsonSerializer.Create(settings);
         }
 
         public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null)
@@ -76,6 +71,13 @@ namespace RootNamespace.Serialization.Json
             using var reader = new JsonTextReader(new StringReader(str));
 
             return _serializer.Deserialize<T>(reader)!;
+        }
+
+        private static JsonSerializerSettings CreateDefaultSettings()
+        {
+            var settings = new JsonSerializerSettings();
+            // Enrichment point
+            return settings;
         }
     }
 }

--- a/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializerSettingsEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializerSettingsEnricher.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using Yardarm.Enrichment;
+using Yardarm.Enrichment.Compilation;
+using Yardarm.Enrichment.Registration;
+
+namespace Yardarm.NewtonsoftJson.Internal;
+
+/// <summary>
+/// Enrich the default JsonSerializerSettings in the JsonTypeSerializer class with additional settings
+/// from extensions registered as <see cref="IRegistrationEnricher"/> with the key <c>JsonSerializerSettings</c>.
+/// </summary>
+internal class JsonSerializerSettingsEnricher(
+    [FromKeyedServices(JsonSerializerSettingsEnricher.RegistrationEnricherKey)] IEnumerable<IRegistrationEnricher> enrichers)
+    : IResourceFileEnricher
+{
+    public const string RegistrationEnricherKey = "JsonSerializerSettings";
+
+    public bool ShouldEnrich(string resourceName) =>
+        resourceName == "Yardarm.NewtonsoftJson.Client.Serialization.Json.JsonTypeSerializer.cs";
+
+    public CompilationUnitSyntax Enrich(CompilationUnitSyntax target, ResourceFileEnrichmentContext context)
+    {
+        ClassDeclarationSyntax? classDeclaration = target
+            .DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(p => p.Identifier.ValueText == "JsonTypeSerializer");
+
+        MethodDeclarationSyntax? methodDeclaration = classDeclaration?
+            .ChildNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(p => p.Identifier.ValueText == "CreateDefaultSettings");
+
+        if (methodDeclaration?.Body is { } body)
+        {
+            MethodDeclarationSyntax newMethodDeclaration = methodDeclaration.WithBody(
+                body.Enrich(enrichers));
+
+            target = target.ReplaceNode(methodDeclaration, newMethodDeclaration);
+        }
+
+        return target;
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Yardarm.Enrichment;
+using Yardarm.Enrichment.Compilation;
 using Yardarm.Generation;
 using Yardarm.NewtonsoftJson.Internal;
 using Yardarm.Packaging;
@@ -15,6 +16,7 @@ namespace Yardarm.NewtonsoftJson
         {
             services
                 .AddCreateDefaultRegistryEnricher<JsonCreateDefaultRegistryEnricher>()
+                .AddResourceFileEnricher<JsonSerializerSettingsEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonAdditionalPropertiesEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using Yardarm.Enrichment;
 using Yardarm.Generation;
 using Yardarm.SystemTextJson.Helpers;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -14,35 +15,37 @@ namespace Yardarm.SystemTextJson.Internal
     /// Creates an empty <see cref="JsonSerializerContext"/> which will later be enriched with
     /// <see cref="JsonSerializableAttribute"/> attributes.
     /// </summary>
-    internal class JsonSerializerContextGenerator : ISyntaxTreeGenerator
+    internal class JsonSerializerContextGenerator(
+        IJsonSerializationNamespace jsonSerializationNamespace,
+        [FromKeyedServices(JsonSerializerContextGenerator.AttributeEnricherKey)] IEnumerable<IEnricher<AttributeSyntax>> enrichers)
+        : ISyntaxTreeGenerator
     {
+        public const string AttributeEnricherKey = "JsonSourceGenerationOptions";
+
         public static SyntaxAnnotation GeneratorAnnotation { get; } = new(
             GeneratorSyntaxNodeExtensions.GeneratorAnnotationName,
             typeof(JsonSerializerContextGenerator).FullName);
 
         public static SyntaxToken TypeName { get; } = Identifier("ModelSerializerContext");
 
-        private readonly IJsonSerializationNamespace _jsonSerializationNamespace;
-
-        public JsonSerializerContextGenerator(IJsonSerializationNamespace jsonSerializationNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(jsonSerializationNamespace);
-
-            _jsonSerializationNamespace = jsonSerializationNamespace;
-        }
-
         public IEnumerable<SyntaxTree> Generate()
         {
+            AttributeSyntax sourceGenerationOptionsAttribute = Attribute(
+                SystemTextJsonTypes.Serialization.JsonSourceGenerationOptionsAttributeName,
+                AttributeArgumentList(SingletonSeparatedList(
+                    AttributeArgument(
+                        nameEquals: NameEquals("NumberHandling"),
+                        nameColon: null,
+                        expression: SystemTextJsonTypes.Serialization.JsonNumberHandling.AllowReadingFromString))));
+
+            // Enrich the JsonSourceGenerationOptions attribute with any additional enrichers registered
+            // by another extension via IEnricher<AttributeSyntax> with the key "JsonSourceGenerationOptions".
+            sourceGenerationOptionsAttribute = sourceGenerationOptionsAttribute.Enrich(enrichers);
+
             // Create a partial class inherited from JsonSerializerContext with the attributes applied
-            var classDeclaration =
+            ClassDeclarationSyntax classDeclaration =
                 ClassDeclaration(
-                    SingletonList(AttributeList(SingletonSeparatedList(Attribute(
-                        SystemTextJsonTypes.Serialization.JsonSourceGenerationOptionsAttributeName,
-                        AttributeArgumentList(SingletonSeparatedList(
-                            AttributeArgument(
-                                nameEquals: NameEquals("NumberHandling"),
-                                nameColon: null,
-                                expression: SystemTextJsonTypes.Serialization.JsonNumberHandling.AllowReadingFromString))))))),
+                    SingletonList(AttributeList(SingletonSeparatedList(sourceGenerationOptionsAttribute))),
                     TokenList(Token(SyntaxKind.InternalKeyword), Token(SyntaxKind.PartialKeyword)),
                     TypeName,
                     null,
@@ -52,15 +55,17 @@ namespace Yardarm.SystemTextJson.Internal
                     default)
                 .WithAdditionalAnnotations(GeneratorAnnotation);
 
-            yield return CSharpSyntaxTree.Create(CompilationUnit(
+            return [
+                CSharpSyntaxTree.Create(CompilationUnit(
                 default,
                 default,
                 default,
                 SingletonList<MemberDeclarationSyntax>(NamespaceDeclaration(
-                    _jsonSerializationNamespace.Name,
+                    jsonSerializationNamespace.Name,
                     default,
                     default,
-                    SingletonList<MemberDeclarationSyntax>(classDeclaration)))));
+                    SingletonList<MemberDeclarationSyntax>(classDeclaration)))))
+            ];
         }
     }
 }


### PR DESCRIPTION
This allows additional extensions to extend the default Newtonsoft.Json JsonSerializerSettings or the System.Text.Json
JsonSourceGenerationOptions attribute in order to customize JSON serialization/deserialization behaviors. In particular, this can be used to register additional JSON converters.