### PR TITLE
Implement BuildRequest on OperationRequest abstract class

### DIFF
--- a/src/main/Yardarm.Client/Requests/BuildRequestContext.cs
+++ b/src/main/Yardarm.Client/Requests/BuildRequestContext.cs
@@ -1,0 +1,16 @@
+﻿using RootNamespace.Serialization;
+using Yardarm.Client.Internal;
+
+namespace RootNamespace.Requests;
+
+public sealed class BuildRequestContext
+{
+    public ITypeSerializerRegistry TypeSerializerRegistry { get; }
+
+    public BuildRequestContext(ITypeSerializerRegistry typeSerializerRegistry)
+    {
+        ThrowHelper.ThrowIfNull(typeSerializerRegistry);
+
+        TypeSerializerRegistry = typeSerializerRegistry;
+    }
+}

--- a/src/main/Yardarm.Client/Requests/OperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/OperationRequest.cs
@@ -1,16 +1,58 @@
-﻿using RootNamespace.Authentication;
+﻿using System;
+using System.Net.Http;
+using RootNamespace.Authentication;
 
-namespace RootNamespace.Requests
+namespace RootNamespace.Requests;
+
+/// <summary>
+/// Base class for operation requests.
+/// </summary>
+public abstract class OperationRequest : IOperationRequest
 {
-    /// <summary>
-    /// Base class for operation requests.
-    /// </summary>
-    public abstract class OperationRequest : IOperationRequest
-    {
-        /// <inheritdoc />
-        public IAuthenticator? Authenticator { get; set; }
+    /// <inheritdoc />
+    public IAuthenticator? Authenticator { get; set; }
 
-        /// <inheritdoc />
-        public bool EnableResponseStreaming { get; set; }
+    /// <inheritdoc />
+    public bool EnableResponseStreaming { get; set; }
+
+    /// <summary>
+    /// The HTTP method of the request.
+    /// </summary>
+    protected abstract HttpMethod Method { get; }
+
+    /// <summary>
+    /// Add headers to the HTTP request message.
+    /// </summary>
+    /// <param name="context">Context of the request.</param>
+    /// <param name="requestMessage">Request message.</param>
+    protected virtual void AddHeaders(BuildRequestContext context, HttpRequestMessage requestMessage)
+    {
     }
+
+    /// <summary>
+    /// Create the content of the HTTP request message.
+    /// </summary>
+    /// <param name="context">Context of the request.</param>
+    /// <returns><see cref="HttpContent"/> or <c>null</c> if no content.</returns>
+    protected virtual HttpContent? BuildContent(BuildRequestContext context) => null;
+
+    /// <summary>
+    /// Builds the HTTP request message.
+    /// </summary>
+    /// <param name="context">Context of the request.</param>
+    /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
+    public virtual HttpRequestMessage BuildRequest(BuildRequestContext context)
+    {
+        var requestMessage = new HttpRequestMessage(Method, BuildUri(context));
+        AddHeaders(context, requestMessage);
+        requestMessage.Content = BuildContent(context);
+        return requestMessage;
+    }
+
+    /// <summary>
+    /// Create the URI of the HTTP request message.
+    /// </summary>
+    /// <param name="context">Context of the request.</param>
+    /// <returns><see cref="Uri"/> of the request.</returns>
+    protected abstract Uri BuildUri(BuildRequestContext context);
 }

--- a/src/main/Yardarm/Generation/Operation/OperationMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Operation/OperationMethodGenerator.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Net;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,147 +13,150 @@ using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.Generation.Operation
+namespace Yardarm.Generation.Operation;
+
+public class OperationMethodGenerator : IOperationMethodGenerator
 {
-    public class OperationMethodGenerator : IOperationMethodGenerator
+    public const string RequestParameterName = "request";
+
+    protected const string AuthenticatorVariableName = "authenticator";
+    protected const string RequestMessageVariableName = "requestMessage";
+
+    protected GenerationContext Context { get; }
+    protected IRequestsNamespace RequestsNamespace { get; }
+    protected IResponsesNamespace ResponsesNamespace { get; }
+
+    public OperationMethodGenerator(GenerationContext context, IRequestsNamespace requestsNamespace, IResponsesNamespace responsesNamespace)
     {
-        public const string RequestParameterName = "request";
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(requestsNamespace);
+        ArgumentNullException.ThrowIfNull(responsesNamespace);
 
-        protected const string AuthenticatorVariableName = "authenticator";
-        protected const string RequestMessageVariableName = "requestMessage";
+        Context = context;
+        RequestsNamespace = requestsNamespace;
+        ResponsesNamespace = responsesNamespace;
+    }
 
-        protected GenerationContext Context { get; }
-        protected IRequestsNamespace RequestsNamespace { get; }
-        protected IResponsesNamespace ResponsesNamespace { get; }
+    public BlockSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation) =>
+        Block(GenerateStatements(operation));
 
-        public OperationMethodGenerator(GenerationContext context, IRequestsNamespace requestsNamespace, IResponsesNamespace responsesNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(requestsNamespace);
-            ArgumentNullException.ThrowIfNull(responsesNamespace);
+    protected virtual IEnumerable<StatementSyntax> GenerateStatements(ILocatedOpenApiElement<OpenApiOperation> operation)
+    {
+        yield return MethodHelpers.ThrowIfArgumentNull(RequestParameterName);
 
-            Context = context;
-            RequestsNamespace = requestsNamespace;
-            ResponsesNamespace = responsesNamespace;
-        }
+        yield return GenerateAuthenticatorVariable();
 
-        public BlockSyntax Generate(ILocatedOpenApiElement<OpenApiOperation> operation) =>
-            Block(GenerateStatements(operation));
+        yield return GenerateRequestMessageVariable(operation);
 
-        protected virtual IEnumerable<StatementSyntax> GenerateStatements(ILocatedOpenApiElement<OpenApiOperation> operation)
-        {
-            yield return MethodHelpers.ThrowIfArgumentNull(RequestParameterName);
-
-            yield return GenerateAuthenticatorVariable();
-
-            yield return GenerateRequestMessageVariable(operation);
-
-            yield return MethodHelpers.IfNotNull(
-                IdentifierName(AuthenticatorVariableName),
-                Block(ExpressionStatement(SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName(AuthenticatorVariableName),
-                            IdentifierName("ApplyAsync")))
-                    .AddArgumentListArguments(
-                        Argument(IdentifierName(RequestMessageVariableName)),
-                        Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName)))))));
-
-            yield return LocalDeclarationStatement(VariableDeclaration(
-                IdentifierName("var"),
-                SingletonSeparatedList(VariableDeclarator(
-                    Identifier("responseMessage"),
-                    null,
-                    EqualsValueClause(
-                        SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
-                            SyntaxHelpers.MemberAccess(TagImplementationTypeGenerator.HttpClientFieldName, "SendAsync"),
-                            ArgumentList(SeparatedList(new[]
-                            {
-                                Argument(IdentifierName(RequestMessageVariableName)),
-                                Argument(ConditionalExpression(
-                                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                        IdentifierName(RequestParameterName),
-                                        IdentifierName("EnableResponseStreaming")),
-                                    WellKnownTypes.System.Net.Http.HttpCompletionOption.ResponseHeadersRead,
-                                    WellKnownTypes.System.Net.Http.HttpCompletionOption.ResponseContentRead)),
-                                Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName))
-                            })))))))));
-
-            // If there is an exception handling the response before we return, for example in the authenticator or in header parsing,
-            // it's important that we dispose the response in the case of HttpCompletionOption.ResponseHeadersRead. Wrap in a
-            // try..catch with a rethrow to ensure that happens.
-
-            yield return TryStatement(
-                Block(
-                    MethodHelpers.IfNotNull(
+        yield return MethodHelpers.IfNotNull(
+            IdentifierName(AuthenticatorVariableName),
+            Block(ExpressionStatement(SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                         IdentifierName(AuthenticatorVariableName),
-                        Block(ExpressionStatement(SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
+                        IdentifierName("ApplyAsync")))
+                .AddArgumentListArguments(
+                    Argument(IdentifierName(RequestMessageVariableName)),
+                    Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName)))))));
+
+        yield return LocalDeclarationStatement(VariableDeclaration(
+            IdentifierName("var"),
+            SingletonSeparatedList(VariableDeclarator(
+                Identifier("responseMessage"),
+                null,
+                EqualsValueClause(
+                    SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
+                        SyntaxHelpers.MemberAccess(TagImplementationTypeGenerator.HttpClientFieldName, "SendAsync"),
+                        ArgumentList(SeparatedList(new[]
+                        {
+                            Argument(IdentifierName(RequestMessageVariableName)),
+                            Argument(ConditionalExpression(
                                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                    IdentifierName(AuthenticatorVariableName),
-                                    IdentifierName("ProcessResponseAsync")),
-                                ArgumentList(SeparatedList(new[] {
-                                    Argument(IdentifierName("responseMessage")),
-                                    Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName))
-                                }))))))),
-                    ReturnStatement(GenerateResponse(operation, IdentifierName("responseMessage")))
-                ),
-                SingletonList(CatchClause(
-                    null,
-                    null,
-                    Block(
-                        ExpressionStatement(InvocationExpression(
+                                    IdentifierName(RequestParameterName),
+                                    IdentifierName("EnableResponseStreaming")),
+                                WellKnownTypes.System.Net.Http.HttpCompletionOption.ResponseHeadersRead,
+                                WellKnownTypes.System.Net.Http.HttpCompletionOption.ResponseContentRead)),
+                            Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName))
+                        })))))))));
+
+        // If there is an exception handling the response before we return, for example in the authenticator or in header parsing,
+        // it's important that we dispose the response in the case of HttpCompletionOption.ResponseHeadersRead. Wrap in a
+        // try..catch with a rethrow to ensure that happens.
+
+        yield return TryStatement(
+            Block(
+                MethodHelpers.IfNotNull(
+                    IdentifierName(AuthenticatorVariableName),
+                    Block(ExpressionStatement(SyntaxHelpers.AwaitConfiguredFalse(InvocationExpression(
                             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName("responseMessage"),
-                                IdentifierName("Dispose")))),
-                        ThrowStatement()
-                    ))),
-                null);
-        }
-
-        protected virtual StatementSyntax GenerateAuthenticatorVariable() =>
-            MethodHelpers.LocalVariableDeclarationWithInitializer(AuthenticatorVariableName,
-                InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName(TagImplementationTypeGenerator.AuthenticatorsFieldName),
-                        IdentifierName("SelectAuthenticator")))
-                    .AddArgumentListArguments(
-                        Argument(IdentifierName(RequestParameterName))));
-
-        protected virtual StatementSyntax GenerateRequestMessageVariable(
-            ILocatedOpenApiElement<OpenApiOperation> operation) =>
-            MethodHelpers.LocalVariableDeclarationWithInitializer(RequestMessageVariableName,
-                BuildRequestMethodGenerator.InvokeBuildRequest(
-                    IdentifierName(RequestParameterName),
-                    IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)));
-
-        protected virtual ExpressionSyntax GenerateResponse(
-            ILocatedOpenApiElement<OpenApiOperation> operation, ExpressionSyntax responseMessage) =>
-            SwitchExpression(
-                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                    responseMessage,
-                    IdentifierName("StatusCode")),
-                SeparatedList(operation
-                    .GetResponseSet()
-                    .GetResponses()
-                    .Select(p => SwitchExpressionArm(
-                        ConstantPattern(ParseStatusCode(p.Key)),
-                        ObjectCreationExpression(
-                                Context.TypeGeneratorRegistry.Get(p).TypeInfo.Name)
-                            .AddArgumentListArguments(
+                                IdentifierName(AuthenticatorVariableName),
+                                IdentifierName("ProcessResponseAsync")),
+                            ArgumentList(SeparatedList(new[] {
                                 Argument(IdentifierName("responseMessage")),
-                                Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))))))
-                .AddArms(SwitchExpressionArm(DiscardPattern(),
+                                Argument(IdentifierName(MethodHelpers.CancellationTokenParameterName))
+                            }))))))),
+                ReturnStatement(GenerateResponse(operation, IdentifierName("responseMessage")))
+            ),
+            SingletonList(CatchClause(
+                null,
+                null,
+                Block(
+                    ExpressionStatement(InvocationExpression(
+                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("responseMessage"),
+                            IdentifierName("Dispose")))),
+                    ThrowStatement()
+                ))),
+            null);
+    }
+
+    protected virtual StatementSyntax GenerateAuthenticatorVariable() =>
+        MethodHelpers.LocalVariableDeclarationWithInitializer(AuthenticatorVariableName,
+            InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    IdentifierName(TagImplementationTypeGenerator.AuthenticatorsFieldName),
+                    IdentifierName("SelectAuthenticator")))
+                .AddArgumentListArguments(
+                    Argument(IdentifierName(RequestParameterName))));
+
+    protected virtual StatementSyntax GenerateRequestMessageVariable(
+        ILocatedOpenApiElement<OpenApiOperation> operation) =>
+        MethodHelpers.LocalVariableDeclarationWithInitializer(RequestMessageVariableName,
+            BuildRequestMethodGenerator.InvokeBuildRequest(
+                IdentifierName(RequestParameterName),
+                ObjectCreationExpression(
+                    RequestsNamespace.BuildRequestContext,
+                    ArgumentList(SingletonSeparatedList(
+                        Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))),
+                    initializer: null)));
+
+    protected virtual ExpressionSyntax GenerateResponse(
+        ILocatedOpenApiElement<OpenApiOperation> operation, ExpressionSyntax responseMessage) =>
+        SwitchExpression(
+            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                responseMessage,
+                IdentifierName("StatusCode")),
+            SeparatedList(operation
+                .GetResponseSet()
+                .GetResponses()
+                .Select(p => SwitchExpressionArm(
+                    ConstantPattern(ParseStatusCode(p.Key)),
                     ObjectCreationExpression(
-                        Context.TypeGeneratorRegistry.Get(operation.GetResponseSet().GetUnknownResponse()).TypeInfo.Name)
+                            Context.TypeGeneratorRegistry.Get(p).TypeInfo.Name)
                         .AddArgumentListArguments(
                             Argument(IdentifierName("responseMessage")),
-                            Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))));
+                            Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))))))
+            .AddArms(SwitchExpressionArm(DiscardPattern(),
+                ObjectCreationExpression(
+                    Context.TypeGeneratorRegistry.Get(operation.GetResponseSet().GetUnknownResponse()).TypeInfo.Name)
+                    .AddArgumentListArguments(
+                        Argument(IdentifierName("responseMessage")),
+                        Argument(IdentifierName(TagImplementationTypeGenerator.TypeSerializerRegistryFieldName)))));
 
-        [Pure]
-        private static ExpressionSyntax ParseStatusCode(string statusCodeStr) =>
-            // The HttpStatusCode enum available in .NET Core 3.1 used by Yardarm has more values in it than .NET Standard 2.0
-            // for the compiled SDK, so if the spec has any new status codes (i.e. 207) it will cause compilation errors.
-            // Instead cast the numeric value.
-            CastExpression(
-                WellKnownTypes.System.Net.HttpStatusCode.Name,
-                LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(int.Parse(statusCodeStr))));
-    }
+    [Pure]
+    private static ExpressionSyntax ParseStatusCode(string statusCodeStr) =>
+        // The HttpStatusCode enum available in .NET Core 3.1 used by Yardarm has more values in it than .NET Standard 2.0
+        // for the compiled SDK, so if the spec has any new status codes (i.e. 207) it will cause compilation errors.
+        // Instead cast the numeric value.
+        CastExpression(
+            WellKnownTypes.System.Net.HttpStatusCode.Name,
+            LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(int.Parse(statusCodeStr))));
 }

--- a/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/AddHeadersMethodGenerator.cs
@@ -1,139 +1,149 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
-using NuGet.Common;
 using Yardarm.Generation.MediaType;
 using Yardarm.Helpers;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.Generation.Request
+namespace Yardarm.Generation.Request;
+
+public class AddHeadersMethodGenerator(
+    IRequestsNamespace requestsNamespace,
+    IMediaTypeSelector mediaTypeSelector,
+    INameFormatterSelector nameFormatterSelector,
+    ISerializationNamespace serializationNamespace)
+    : IRequestMemberGenerator
 {
-    public class AddHeadersMethodGenerator : IRequestMemberGenerator
+    public const string AddHeadersMethodName = "AddHeaders";
+    public const string ContextParameterName = "context";
+    public const string RequestMessageParameterName = "requestMessage";
+
+    protected IMediaTypeSelector MediaTypeSelector { get; } = mediaTypeSelector;
+    protected INameFormatterSelector NameFormatterSelector { get; } = nameFormatterSelector;
+    protected ISerializationNamespace SerializationNamespace { get; } = serializationNamespace;
+
+
+    public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+        ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
     {
-        public const string AddHeadersMethodName = "AddHeaders";
-        public const string RequestMessageParameterName = "requestMessage";
-
-        protected IMediaTypeSelector MediaTypeSelector { get; }
-        protected INameFormatterSelector NameFormatterSelector { get; }
-        protected ISerializationNamespace SerializationNamespace { get; }
-
-        public AddHeadersMethodGenerator(IMediaTypeSelector mediaTypeSelector, INameFormatterSelector nameFormatterSelector,
-            ISerializationNamespace serializationNamespace)
+        if (mediaType is not null)
         {
-            ArgumentNullException.ThrowIfNull(mediaTypeSelector);
-            ArgumentNullException.ThrowIfNull(nameFormatterSelector);
-            ArgumentNullException.ThrowIfNull(serializationNamespace);
-
-            MediaTypeSelector = mediaTypeSelector;
-            NameFormatterSelector = nameFormatterSelector;
-            SerializationNamespace = serializationNamespace;
+            // Only generate for the main request, not media types
+            return [];
         }
 
-        public MethodDeclarationSyntax GenerateHeader(ILocatedOpenApiElement<OpenApiOperation> operation) =>
+        return
+        [
             MethodDeclaration(
-                    PredefinedType(Token(SyntaxKind.VoidKeyword)),
-                    AddHeadersMethodName)
-                .AddParameterListParameters(
-                    Parameter(Identifier(RequestMessageParameterName))
-                        .WithType(WellKnownTypes.System.Net.Http.HttpRequestMessage.Name));
-
-        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
-        {
-            if (mediaType is not null)
-            {
-                // Only generate for the main request, not media types
-                yield break;
-            }
-
-            yield return GenerateHeader(operation)
-                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
-                .WithBody(Block(GenerateStatements(operation)));
-        }
-
-        protected virtual IEnumerable<StatementSyntax> GenerateStatements(
-            ILocatedOpenApiElement<OpenApiOperation> operation)
-        {
-            ILocatedOpenApiElement<OpenApiResponses> responseSet = operation.GetResponseSet();
-            ILocatedOpenApiElement<OpenApiResponse> primaryResponse = responseSet
-                .GetResponses()
-                .OrderBy(p => p.Key)
-                .First();
-
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType = MediaTypeSelector.Select(primaryResponse);
-            if (mediaType != null)
-            {
-                yield return ExpressionStatement(InvocationExpression(
-                        SyntaxHelpers.MemberAccess(RequestMessageParameterName, "Headers", "Accept", "Add"))
-                    .AddArgumentListArguments(
-                        Argument(ObjectCreationExpression(WellKnownTypes.System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Name)
-                            .AddArgumentListArguments(
-                                Argument(SyntaxHelpers.StringLiteral(mediaType.Key))))));
-            }
-
-            var propertyNameFormatter = NameFormatterSelector.GetFormatter(NameKind.Property);
-            foreach (var headerParameter in operation.GetAllParameters()
-                .Where(p => p.Element.In == ParameterLocation.Header)
-                .Select(p => p.Element))
-            {
-                string propertyName = propertyNameFormatter.Format(headerParameter.Name);
-
-                ExpressionSyntax valueExpression;
-                if (headerParameter is {Schema.Type: "array"})
-                {
-                    valueExpression = InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.HeaderSerializer,
-                            IdentifierName("SerializeList")),
-                        ArgumentList(SeparatedList(new[]
-                        {
-                            Argument(IdentifierName(propertyName)),
-                            Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
-                        })));
-                }
-                else
-                {
-                    valueExpression = InvocationExpression(
-                        MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.HeaderSerializer,
-                            IdentifierName("SerializePrimitive")),
-                        ArgumentList(SeparatedList(new []
-                        {
-                            Argument(IdentifierName(propertyName)),
-                            Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
-                        })));
-                }
-
-                StatementSyntax statement = ExpressionStatement(InvocationExpression(
-                        SyntaxHelpers.MemberAccess(RequestMessageParameterName, "Headers", "Add"))
-                    .AddArgumentListArguments(
-                        Argument(SyntaxHelpers.StringLiteral(headerParameter.Name)),
-                        Argument(valueExpression)));
-
-                if (!headerParameter.Required)
-                {
-                    statement = MethodHelpers.IfNotNull(
-                        IdentifierName(propertyName),
-                        Block(statement));
-                }
-
-                yield return statement;
-            }
-        }
-
-        public static InvocationExpressionSyntax InvokeAddHeaders(ExpressionSyntax requestInstance,
-            ExpressionSyntax requestMessageInstance) =>
-            InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        requestInstance,
-                        IdentifierName(AddHeadersMethodName)))
-                .AddArgumentListArguments(Argument(requestMessageInstance));
+                attributeLists: default,
+                modifiers: TokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)),
+                PredefinedType(Token(SyntaxKind.VoidKeyword)),
+                explicitInterfaceSpecifier: null,
+                Identifier(AddHeadersMethodName),
+                typeParameterList: default,
+                ParameterList(SeparatedList(
+                [
+                    Parameter(
+                        attributeLists: default,
+                        modifiers: default,
+                        requestsNamespace.BuildRequestContext,
+                        Identifier(ContextParameterName),
+                        @default: null),
+                    Parameter(
+                        attributeLists: default,
+                        modifiers: default,
+                        WellKnownTypes.System.Net.Http.HttpRequestMessage.Name,
+                        Identifier(RequestMessageParameterName),
+                        @default: null)
+                ])),
+                constraintClauses: default,
+                Block(GenerateStatements(operation)),
+                expressionBody: null),
+        ];
     }
+
+    protected virtual IEnumerable<StatementSyntax> GenerateStatements(
+        ILocatedOpenApiElement<OpenApiOperation> operation)
+    {
+        ILocatedOpenApiElement<OpenApiResponses> responseSet = operation.GetResponseSet();
+        ILocatedOpenApiElement<OpenApiResponse> primaryResponse = responseSet
+            .GetResponses()
+            .OrderBy(p => p.Key)
+            .First();
+
+        ILocatedOpenApiElement<OpenApiMediaType>? mediaType = MediaTypeSelector.Select(primaryResponse);
+        if (mediaType != null)
+        {
+            yield return ExpressionStatement(InvocationExpression(
+                    SyntaxHelpers.MemberAccess(RequestMessageParameterName, "Headers", "Accept", "Add"))
+                .AddArgumentListArguments(
+                    Argument(ObjectCreationExpression(WellKnownTypes.System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Name)
+                        .AddArgumentListArguments(
+                            Argument(SyntaxHelpers.StringLiteral(mediaType.Key))))));
+        }
+
+        INameFormatter propertyNameFormatter = NameFormatterSelector.GetFormatter(NameKind.Property);
+        foreach (var headerParameter in operation.GetAllParameters()
+            .Where(p => p.Element.In == ParameterLocation.Header)
+            .Select(p => p.Element))
+        {
+            string propertyName = propertyNameFormatter.Format(headerParameter.Name);
+
+            ExpressionSyntax valueExpression;
+            if (headerParameter is {Schema.Type: "array"})
+            {
+                valueExpression = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SerializationNamespace.HeaderSerializer,
+                        IdentifierName("SerializeList")),
+                    ArgumentList(SeparatedList(
+                    [
+                        Argument(IdentifierName(propertyName)),
+                        Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
+                    ])));
+            }
+            else
+            {
+                valueExpression = InvocationExpression(
+                    MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SerializationNamespace.HeaderSerializer,
+                        IdentifierName("SerializePrimitive")),
+                    ArgumentList(SeparatedList(
+                    [
+                        Argument(IdentifierName(propertyName)),
+                        Argument(SyntaxHelpers.StringLiteral(headerParameter.Schema.Format))
+                    ])));
+            }
+
+            StatementSyntax statement = ExpressionStatement(InvocationExpression(
+                    SyntaxHelpers.MemberAccess(RequestMessageParameterName, "Headers", "Add"))
+                .AddArgumentListArguments(
+                    Argument(SyntaxHelpers.StringLiteral(headerParameter.Name)),
+                    Argument(valueExpression)));
+
+            if (!headerParameter.Required)
+            {
+                statement = MethodHelpers.IfNotNull(
+                    IdentifierName(propertyName),
+                    Block(statement));
+            }
+
+            yield return statement;
+        }
+    }
+
+    public static InvocationExpressionSyntax InvokeAddHeaders(ExpressionSyntax requestInstance,
+        ExpressionSyntax contextInstance,
+        ExpressionSyntax requestMessageInstance) =>
+        InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    requestInstance,
+                    IdentifierName(AddHeadersMethodName)))
+            .AddArgumentListArguments(Argument(contextInstance), Argument(requestMessageInstance));
 }

--- a/src/main/Yardarm/Generation/Request/BuildRequestMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildRequestMethodGenerator.cs
@@ -58,13 +58,14 @@ public class BuildRequestMethodGenerator(
                 constraintClauses: default,
                 body: null,
                 expressionBody: ArrowExpressionClause(InvocationExpression(
-                IdentifierName(BuildRequestMethodName),
-                ArgumentList(SingletonSeparatedList(
-                    Argument(ObjectCreationExpression(
-                        requestsNamespace.BuildRequestContext,
-                        ArgumentList(SingletonSeparatedList(
-                            Argument(IdentifierName(TypeSerializerRegistryParameterName)))),
-                        initializer: null)))))))
+                    IdentifierName(BuildRequestMethodName),
+                    ArgumentList(SingletonSeparatedList(
+                        Argument(ObjectCreationExpression(
+                            requestsNamespace.BuildRequestContext,
+                            ArgumentList(SingletonSeparatedList(
+                                Argument(IdentifierName(TypeSerializerRegistryParameterName)))),
+                            initializer: null)))))),
+                Token(SyntaxKind.SemicolonToken))
         ];
     }
 

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -253,16 +253,23 @@ public class BuildUriMethodGenerator(
 
             yield return ReturnStatement(ObjectCreationExpression(
                 WellKnownTypes.System.Uri.Name,
-                ArgumentList(SingletonSeparatedList(
+                ArgumentList(SeparatedList(
+                [
                     Argument(InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName(queryStringBuilderVariableName), IdentifierName("ToString")))))),
+                        IdentifierName(queryStringBuilderVariableName), IdentifierName("ToString")))),
+                    Argument(WellKnownTypes.System.UriKind.RelativeOrAbsolute),
+                ])),
                 initializer: null));
         }
         else
         {
             yield return ReturnStatement(ObjectCreationExpression(
                 WellKnownTypes.System.Uri.Name,
-                ArgumentList(SingletonSeparatedList(Argument(pathExpression))),
+                ArgumentList(SeparatedList(
+                [
+                    Argument(pathExpression),
+                    Argument(WellKnownTypes.System.UriKind.RelativeOrAbsolute),
+                ])),
                 initializer: null));
         }
     }

--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -11,266 +11,282 @@ using Yardarm.Spec;
 using Yardarm.Spec.Path;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.Generation.Request
+namespace Yardarm.Generation.Request;
+
+public class BuildUriMethodGenerator(
+    GenerationContext context,
+    ISerializationNamespace serializationNamespace,
+    IRequestsNamespace requestsNamespace)
+    : IRequestMemberGenerator
 {
-    public class BuildUriMethodGenerator : IRequestMemberGenerator
+    public const string BuildUriMethodName = "BuildUri";
+    public const string ContextParameterName = "context";
+
+    protected GenerationContext Context { get; } = context;
+    protected ISerializationNamespace SerializationNamespace { get; } = serializationNamespace;
+
+    public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+        ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
     {
-        public const string BuildUriMethodName = "BuildUri";
-
-        protected GenerationContext Context { get; }
-        protected ISerializationNamespace SerializationNamespace { get; }
-
-        public BuildUriMethodGenerator(GenerationContext context, ISerializationNamespace serializationNamespace)
+        if (mediaType is not null)
         {
-            ArgumentNullException.ThrowIfNull(context);
-            ArgumentNullException.ThrowIfNull(serializationNamespace);
-
-            Context = context;
-            SerializationNamespace = serializationNamespace;
+            // Only generate for the main request, not media types
+            return [];
         }
 
-        public MethodDeclarationSyntax GenerateHeader(ILocatedOpenApiElement<OpenApiOperation> operation) =>
+        return
+        [
             MethodDeclaration(
-                PredefinedType(Token(SyntaxKind.StringKeyword)),
-                BuildUriMethodName);
+                attributeLists: default,
+                modifiers: TokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)),
+                WellKnownTypes.System.Uri.Name,
+                explicitInterfaceSpecifier: null,
+                Identifier(BuildUriMethodName),
+                typeParameterList: default,
+                ParameterList(SingletonSeparatedList(
+                    Parameter(
+                        attributeLists: default,
+                        modifiers: default,
+                        requestsNamespace.BuildRequestContext,
+                        Identifier(ContextParameterName),
+                        @default: null))),
+                constraintClauses: default,
+                Block(GenerateBody(operation, mediaType)),
+                expressionBody: null)
+        ];
+    }
 
-        public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
+    private Func<PathSegment, InterpolationSyntax> CreateLegacyParameterInterpolationBuilder(
+        Dictionary<string, OpenApiParameter> allParameters,
+        INameFormatter propertyNameFormatter)
+    {
+        // Uses less performant string interpolation that generates intermediate strings
+        // for target frameworks < .NET 6.0
+
+        return pathSegment =>
         {
-            if (mediaType is not null)
+            allParameters.TryGetValue(pathSegment.Value, out var parameter);
+
+            if (parameter?.Schema?.Type == "array")
             {
-                // Only generate for the main request, not media types
-                yield break;
+                return Interpolation(InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        SerializationNamespace.PathSegmentSerializer,
+                        IdentifierName("SerializeList")),
+                    ArgumentList(SeparatedList([
+                        Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                        Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                        Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
+                        Argument(GetStyleExpression(parameter)),
+                        Argument(GetExplodeExpression(parameter)),
+                        Argument(SyntaxHelpers.StringLiteral(parameter.Schema?.Format))
+                    ]))));
+            }
+            else
+            {
+                return Interpolation(InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        SerializationNamespace.PathSegmentSerializer,
+                        IdentifierName("Serialize")),
+                    ArgumentList(SeparatedList([
+                        Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
+                        Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
+                        Argument(GetStyleExpression(parameter)),
+                        Argument(SyntaxHelpers.StringLiteral(parameter?.Schema?.Format))
+                    ]))));
+            }
+        };
+    }
+
+    private static Func<PathSegment, InterpolationSyntax> CreateModernParameterInterpolationBuilder(
+        Dictionary<string, OpenApiParameter> allParameters,
+        INameFormatter propertyNameFormatter)
+    {
+        // Uses more performant string interpolation, passing explode, style, and name via the
+        // alignment and format values. See PathSegmentInterpolatedStringHandler for details.
+
+        return pathSegment =>
+        {
+            allParameters.TryGetValue(pathSegment.Value, out var parameter);
+
+            int alignment = 0;
+            string? format = null;
+
+            if (parameter is not null)
+            {
+                format = parameter.Schema?.Format;
+
+                if (parameter.Style == ParameterStyle.Label)
+                {
+                    alignment = 1;
+                }
+                else if (parameter.Style == ParameterStyle.Matrix)
+                {
+                    alignment = 2 + pathSegment.Value.Length;
+                    if (parameter.Explode)
+                    {
+                        alignment = -alignment;
+                    }
+
+                    format = $"{pathSegment.Value}{format}";
+                }
             }
 
-            yield return GenerateHeader(operation)
-                .AddModifiers(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.VirtualKeyword))
-                .WithBody(Block(GenerateBody(operation, mediaType)));
+            return Interpolation(
+                IdentifierName(propertyNameFormatter.Format(pathSegment.Value)),
+                alignment != 0
+                    ? InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(alignment)))
+                    : null,
+                format is not null
+                    ? InterpolationFormatClause(Token(SyntaxKind.ColonToken), Token(default, SyntaxKind.InterpolatedStringTextToken, format, format, default))
+                    : null);
+        };
+    }
+
+    public IEnumerable<StatementSyntax> GenerateBody(ILocatedOpenApiElement<OpenApiOperation> operation,
+        ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
+    {
+        var propertyNameFormatter = Context.NameFormatterSelector.GetFormatter(NameKind.Property);
+
+        var path = (LocatedOpenApiElement<OpenApiPathItem>)operation.Parent!;
+
+        var allParameters = operation.GetAllParameters()
+            .Select(p => p.Element)
+            .ToDictionary(p => p.Name, p => p);
+
+        ExpressionSyntax pathExpression;
+        if (Context.CurrentTargetFramework.Version.Major >= 6)
+        {
+            pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
+                CreateModernParameterInterpolationBuilder(allParameters, propertyNameFormatter));
+
+            // Yield a 256 character stackalloc for an initial buffer
+            yield return LocalDeclarationStatement(VariableDeclaration(
+                type: QualifiedName(
+                    IdentifierName("System"),
+                    GenericName(
+                        Identifier("Span"),
+                        TypeArgumentList(SingletonSeparatedList<TypeSyntax>(PredefinedType(Token(SyntaxKind.CharKeyword)))))),
+                variables: SingletonSeparatedList(VariableDeclarator(
+                    Identifier("initialBuffer"),
+                    argumentList: null,
+                    initializer: EqualsValueClause(
+                        StackAllocArrayCreationExpression(
+                            ArrayType(PredefinedType(Token(SyntaxKind.CharKeyword)))
+                            .WithRankSpecifiers(SingletonList(
+                            ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
+                                LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(256))
+                            ))))))))));
+
+            // Wrap in a call to PathSegmentSerializer.Serialize to ensure the handler is used
+            pathExpression = InvocationExpression(
+                MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                    SerializationNamespace.PathSegmentSerializer,
+                    IdentifierName("Build")),
+                ArgumentList(SeparatedList([
+                    Argument(IdentifierName("initialBuffer")),
+                    Argument(pathExpression)
+                ])));
+        }
+        else
+        {
+            pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
+                CreateLegacyParameterInterpolationBuilder(allParameters, propertyNameFormatter));
         }
 
-        private Func<PathSegment, InterpolationSyntax> CreateLegacyParameterInterpolationBuilder(
-            Dictionary<string, OpenApiParameter> allParameters,
-            INameFormatter propertyNameFormatter)
+        OpenApiParameter[] queryParameters = allParameters.Values
+            .Where(p => (p.In ?? ParameterLocation.Query) == ParameterLocation.Query)
+            .ToArray();
+
+        if (queryParameters.Length > 0)
         {
-            // Uses less performant string interpolation that generates intermediate strings
-            // for target frameworks < .NET 6.0
+            const string queryStringBuilderVariableName = "queryStringBuilder";
 
-            return pathSegment =>
+            yield return LocalDeclarationStatement(VariableDeclaration(SerializationNamespace.QueryStringBuilder,
+                SingletonSeparatedList(VariableDeclarator(
+                    Identifier(queryStringBuilderVariableName),
+                    null,
+                    EqualsValueClause(ImplicitObjectCreationExpression(
+                        Token(SyntaxKind.NewKeyword),
+                        ArgumentList(SingletonSeparatedList(
+                            Argument(pathExpression))),
+                        null))))));
+
+            foreach (OpenApiParameter queryParameter in queryParameters)
             {
-                allParameters.TryGetValue(pathSegment.Value, out var parameter);
-
-                if (parameter?.Schema?.Type == "array")
+                if (queryParameter.Schema.Type == "array")
                 {
-                    return Interpolation(InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.PathSegmentSerializer,
-                            IdentifierName("SerializeList")),
-                        ArgumentList(SeparatedList([
-                            Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
-                                Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
-                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
-                                Argument(GetStyleExpression(parameter)),
-                                Argument(GetExplodeExpression(parameter)),
-                                Argument(SyntaxHelpers.StringLiteral(parameter.Schema?.Format))
+                    yield return ExpressionStatement(InvocationExpression(MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName(queryStringBuilderVariableName),
+                            IdentifierName("AppendList")),
+                        ArgumentList(SeparatedList(
+                        [
+                            Argument(SyntaxHelpers.StringLiteral(Uri.EscapeDataString(queryParameter.Name))),
+                            Argument(IdentifierName(propertyNameFormatter.Format(queryParameter.Name))),
+                            Argument(LiteralExpression(queryParameter.Explode ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
+                            Argument(queryParameter.Style switch
+                            {
+                                ParameterStyle.SpaceDelimited => SyntaxHelpers.StringLiteral("%20"),
+                                ParameterStyle.PipeDelimited => SyntaxHelpers.StringLiteral("|"),
+                                _ => SyntaxHelpers.StringLiteral(",")
+                            }),
+                            Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
+                            Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
                         ]))));
                 }
                 else
                 {
-                    return Interpolation(InvocationExpression(
-                        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            SerializationNamespace.PathSegmentSerializer,
-                            IdentifierName("Serialize")),
-                        ArgumentList(SeparatedList([
-                            Argument(SyntaxHelpers.StringLiteral(pathSegment.Value)),
-                                Argument(IdentifierName(propertyNameFormatter.Format(pathSegment.Value))),
-                                Argument(GetStyleExpression(parameter)),
-                                Argument(SyntaxHelpers.StringLiteral(parameter?.Schema?.Format))
+                    yield return ExpressionStatement(InvocationExpression(MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName(queryStringBuilderVariableName),
+                            IdentifierName("AppendPrimitive")),
+                        ArgumentList(SeparatedList(
+                        [
+                            Argument(SyntaxHelpers.StringLiteral(Uri.EscapeDataString(queryParameter.Name))),
+                            Argument(IdentifierName(propertyNameFormatter.Format(queryParameter.Name))),
+                            Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
+                            Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
                         ]))));
                 }
-            };
-        }
+            }
 
-        private static Func<PathSegment, InterpolationSyntax> CreateModernParameterInterpolationBuilder(
-            Dictionary<string, OpenApiParameter> allParameters,
-            INameFormatter propertyNameFormatter)
+            yield return ReturnStatement(ObjectCreationExpression(
+                WellKnownTypes.System.Uri.Name,
+                ArgumentList(SingletonSeparatedList(
+                    Argument(InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        IdentifierName(queryStringBuilderVariableName), IdentifierName("ToString")))))),
+                initializer: null));
+        }
+        else
         {
-            // Uses more performant string interpolation, passing explode, style, and name via the
-            // alignment and format values. See PathSegmentInterpolatedStringHandler for details.
-
-            return pathSegment =>
-            {
-                allParameters.TryGetValue(pathSegment.Value, out var parameter);
-
-                int alignment = 0;
-                string? format = null;
-
-                if (parameter is not null)
-                {
-                    format = parameter.Schema?.Format;
-
-                    if (parameter.Style == ParameterStyle.Label)
-                    {
-                        alignment = 1;
-                    }
-                    else if (parameter.Style == ParameterStyle.Matrix)
-                    {
-                        alignment = 2 + pathSegment.Value.Length;
-                        if (parameter.Explode)
-                        {
-                            alignment = -alignment;
-                        }
-
-                        format = $"{pathSegment.Value}{format}";
-                    }
-                }
-
-                return Interpolation(
-                    IdentifierName(propertyNameFormatter.Format(pathSegment.Value)),
-                    alignment != 0
-                        ? InterpolationAlignmentClause(Token(SyntaxKind.CommaToken), LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(alignment)))
-                        : null,
-                    format is not null
-                        ? InterpolationFormatClause(Token(SyntaxKind.ColonToken), Token(default, SyntaxKind.InterpolatedStringTextToken, format, format, default))
-                        : null);
-            };
+            yield return ReturnStatement(ObjectCreationExpression(
+                WellKnownTypes.System.Uri.Name,
+                ArgumentList(SingletonSeparatedList(Argument(pathExpression))),
+                initializer: null));
         }
+    }
 
-        public IEnumerable<StatementSyntax> GenerateBody(ILocatedOpenApiElement<OpenApiOperation> operation,
-            ILocatedOpenApiElement<OpenApiMediaType>? mediaType)
-        {
-            var propertyNameFormatter = Context.NameFormatterSelector.GetFormatter(NameKind.Property);
-
-            var path = (LocatedOpenApiElement<OpenApiPathItem>)operation.Parent!;
-
-            var allParameters = operation.GetAllParameters()
-                .Select(p => p.Element)
-                .ToDictionary(p => p.Name, p => p);
-
-            ExpressionSyntax pathExpression;
-            if (Context.CurrentTargetFramework.Version.Major >= 6)
-            {
-                pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
-                    CreateModernParameterInterpolationBuilder(allParameters, propertyNameFormatter));
-
-                // Yield a 256 character stackalloc for an initial buffer
-                yield return LocalDeclarationStatement(VariableDeclaration(
-                    type: QualifiedName(
-                        IdentifierName("System"),
-                        GenericName(
-                            Identifier("Span"),
-                            TypeArgumentList(SingletonSeparatedList<TypeSyntax>(PredefinedType(Token(SyntaxKind.CharKeyword)))))),
-                    variables: SingletonSeparatedList(VariableDeclarator(
-                        Identifier("initialBuffer"),
-                        argumentList: null,
-                        initializer: EqualsValueClause(
-                            StackAllocArrayCreationExpression(
-                                ArrayType(PredefinedType(Token(SyntaxKind.CharKeyword)))
-                                .WithRankSpecifiers(SingletonList(
-                                ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
-                                    LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(256))
-                                ))))))))));
-
-                // Wrap in a call to PathSegmentSerializer.Serialize to ensure the handler is used
-                pathExpression = InvocationExpression(
-                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        SerializationNamespace.PathSegmentSerializer,
-                        IdentifierName("Build")),
-                    ArgumentList(SeparatedList([
-                        Argument(IdentifierName("initialBuffer")),
-                        Argument(pathExpression)
-                    ])));
-            }
-            else
-            {
-                pathExpression = PathParser.Parse(path.Key).ToInterpolatedStringExpression(
-                    CreateLegacyParameterInterpolationBuilder(allParameters, propertyNameFormatter));
-            }
-
-            OpenApiParameter[] queryParameters = allParameters.Values
-                .Where(p => (p.In ?? ParameterLocation.Query) == ParameterLocation.Query)
-                .ToArray();
-
-            if (queryParameters.Length > 0)
-            {
-                const string queryStringBuilderVariableName = "queryStringBuilder";
-
-                yield return LocalDeclarationStatement(VariableDeclaration(SerializationNamespace.QueryStringBuilder,
-                    SingletonSeparatedList(VariableDeclarator(
-                        Identifier(queryStringBuilderVariableName),
-                        null,
-                        EqualsValueClause(ImplicitObjectCreationExpression(
-                            Token(SyntaxKind.NewKeyword),
-                            ArgumentList(SingletonSeparatedList(Argument(pathExpression))),
-                            null))))));
-
-                foreach (var queryParameter in queryParameters)
-                {
-                    if (queryParameter.Schema.Type == "array")
-                    {
-                        yield return ExpressionStatement(InvocationExpression(MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName(queryStringBuilderVariableName),
-                                IdentifierName("AppendList")),
-                            ArgumentList(SeparatedList(new ArgumentSyntax[]
-                            {
-                                Argument(SyntaxHelpers.StringLiteral(Uri.EscapeDataString(queryParameter.Name))),
-                                Argument(IdentifierName(propertyNameFormatter.Format(queryParameter.Name))),
-                                Argument(LiteralExpression(queryParameter.Explode ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
-                                Argument(queryParameter.Style switch
-                                {
-                                    ParameterStyle.SpaceDelimited => SyntaxHelpers.StringLiteral("%20"),
-                                    ParameterStyle.PipeDelimited => SyntaxHelpers.StringLiteral("|"),
-                                    _ => SyntaxHelpers.StringLiteral(",")
-                                }),
-                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
-                                Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
-                            }))));
-                    }
-                    else
-                    {
-                        yield return ExpressionStatement(InvocationExpression(MemberAccessExpression(
-                                SyntaxKind.SimpleMemberAccessExpression,
-                                IdentifierName(queryStringBuilderVariableName),
-                                IdentifierName("AppendPrimitive")),
-                            ArgumentList(SeparatedList(new ArgumentSyntax[]
-                            {
-                                Argument(SyntaxHelpers.StringLiteral(Uri.EscapeDataString(queryParameter.Name))),
-                                Argument(IdentifierName(propertyNameFormatter.Format(queryParameter.Name))),
-                                Argument(LiteralExpression(queryParameter.AllowReserved ? SyntaxKind.TrueLiteralExpression: SyntaxKind.FalseLiteralExpression)),
-                                Argument(SyntaxHelpers.StringLiteral(queryParameter.Schema.Format))
-                            }))));
-                    }
-                }
-
-                yield return ReturnStatement(
-                    InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                        IdentifierName(queryStringBuilderVariableName), IdentifierName("ToString"))));
-            }
-            else
-            {
-                yield return ReturnStatement(pathExpression);
-            }
-        }
-
-        public static InvocationExpressionSyntax InvokeBuildUri(ExpressionSyntax requestInstance) =>
-            InvocationExpression(
+    public static InvocationExpressionSyntax InvokeBuildUri(ExpressionSyntax requestInstance,
+        ExpressionSyntax contextInstance) =>
+        InvocationExpression(
                 MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                     requestInstance,
-                    IdentifierName(BuildUriMethodName)));
+                    IdentifierName(BuildUriMethodName)))
+            .AddArgumentListArguments(Argument(contextInstance));
 
-        protected ExpressionSyntax GetStyleExpression(OpenApiParameter? parameter) =>
-            MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                SerializationNamespace.PathSegmentStyle,
-                parameter?.Style switch
-                {
-                    ParameterStyle.Label => IdentifierName("Label"),
-                    ParameterStyle.Matrix => IdentifierName("Matrix"),
-                    _ => IdentifierName("Simple")
-                });
+    protected ExpressionSyntax GetStyleExpression(OpenApiParameter? parameter) =>
+        MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+            SerializationNamespace.PathSegmentStyle,
+            parameter?.Style switch
+            {
+                ParameterStyle.Label => IdentifierName("Label"),
+                ParameterStyle.Matrix => IdentifierName("Matrix"),
+                _ => IdentifierName("Simple")
+            });
 
-        protected ExpressionSyntax GetExplodeExpression(OpenApiParameter parameter) =>
-            parameter.Explode
-                ? LiteralExpression(SyntaxKind.TrueLiteralExpression)
-                : LiteralExpression(SyntaxKind.FalseLiteralExpression);
-    }
+    protected ExpressionSyntax GetExplodeExpression(OpenApiParameter parameter) =>
+        parameter.Explode
+            ? LiteralExpression(SyntaxKind.TrueLiteralExpression)
+            : LiteralExpression(SyntaxKind.FalseLiteralExpression);
 }

--- a/src/main/Yardarm/Generation/Request/HttpMethodPropertyGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/HttpMethodPropertyGenerator.cs
@@ -21,12 +21,10 @@ internal class HttpMethodPropertyGenerator : IRequestMemberGenerator
                 WellKnownTypes.System.Net.Http.HttpMethod.Name,
                 explicitInterfaceSpecifier: null,
                 Identifier(MethodPropertyName),
-                AccessorList(SingletonList(
-                    AccessorDeclaration(
-                        SyntaxKind.GetAccessorDeclaration,
-                        attributeLists: default,
-                        modifiers: default,
-                        ArrowExpressionClause(GetRequestMethod(operation))))))
+                accessorList: null,
+                ArrowExpressionClause(GetRequestMethod(operation)),
+                initializer: null,
+                Token(SyntaxKind.SemicolonToken))
         ];
 
     private static ExpressionSyntax GetRequestMethod(ILocatedOpenApiElement<OpenApiOperation> operation) =>

--- a/src/main/Yardarm/Generation/Request/HttpMethodPropertyGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/HttpMethodPropertyGenerator.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Helpers;
+using Yardarm.Spec;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.Generation.Request;
+
+internal class HttpMethodPropertyGenerator : IRequestMemberGenerator
+{
+    public const string MethodPropertyName = "Method";
+
+    public IEnumerable<MemberDeclarationSyntax> Generate(ILocatedOpenApiElement<OpenApiOperation> operation,
+        ILocatedOpenApiElement<OpenApiMediaType>? mediaType) =>
+        [
+            PropertyDeclaration(
+                attributeLists: default,
+                TokenList(Token(SyntaxKind.ProtectedKeyword), Token(SyntaxKind.OverrideKeyword)),
+                WellKnownTypes.System.Net.Http.HttpMethod.Name,
+                explicitInterfaceSpecifier: null,
+                Identifier(MethodPropertyName),
+                AccessorList(SingletonList(
+                    AccessorDeclaration(
+                        SyntaxKind.GetAccessorDeclaration,
+                        attributeLists: default,
+                        modifiers: default,
+                        ArrowExpressionClause(GetRequestMethod(operation))))))
+        ];
+
+    private static ExpressionSyntax GetRequestMethod(ILocatedOpenApiElement<OpenApiOperation> operation) =>
+        operation.Key switch
+        {
+            "Delete" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Delete")),
+            "Get" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Get")),
+            "Head" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Head")),
+            "Options" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Options")),
+            "Post" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Post")),
+            "Put" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Put")),
+            "Trace" => QualifiedName(WellKnownTypes.System.Net.Http.HttpMethod.Name, IdentifierName("Trace")),
+            _ => ObjectCreationExpression(WellKnownTypes.System.Net.Http.HttpMethod.Name,
+                ArgumentList(SingletonSeparatedList(
+                    Argument(SyntaxHelpers.StringLiteral(operation.Key.ToUpperInvariant())))),
+                initializer: null)
+        };
+}

--- a/src/main/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.cs
@@ -324,6 +324,13 @@ namespace Yardarm.Helpers
             public static NameSyntax Type { get; } = QualifiedName(
                 System.Name,
                 IdentifierName("Type"));
+
+            public static class Uri
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    System.Name,
+                    IdentifierName("Uri"));
+            }
         }
     }
 }

--- a/src/main/Yardarm/Helpers/WellKnownTypes.cs
+++ b/src/main/Yardarm/Helpers/WellKnownTypes.cs
@@ -331,6 +331,18 @@ namespace Yardarm.Helpers
                     System.Name,
                     IdentifierName("Uri"));
             }
+
+            public static class UriKind
+            {
+                public static NameSyntax Name { get; } = QualifiedName(
+                    System.Name,
+                    IdentifierName("UriKind"));
+
+                public static ExpressionSyntax RelativeOrAbsolute { get; } =
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
+                        Name,
+                        IdentifierName("RelativeOrAbsolute"));
+            }
         }
     }
 }

--- a/src/main/Yardarm/Names/IRequestsNamespace.cs
+++ b/src/main/Yardarm/Names/IRequestsNamespace.cs
@@ -1,11 +1,11 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Yardarm.Names
+namespace Yardarm.Names;
+
+// ReSharper disable InconsistentNaming
+public interface IRequestsNamespace : IKnownNamespace
 {
-    // ReSharper disable InconsistentNaming
-    public interface IRequestsNamespace : IKnownNamespace
-    {
-        NameSyntax IOperationRequest { get; }
-        NameSyntax OperationRequest { get; }
-    }
+    NameSyntax IOperationRequest { get; }
+    NameSyntax OperationRequest { get; }
+    NameSyntax BuildRequestContext { get; }
 }

--- a/src/main/Yardarm/Names/Internal/RequestsNamespace.cs
+++ b/src/main/Yardarm/Names/Internal/RequestsNamespace.cs
@@ -2,28 +2,32 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.Names.Internal
+namespace Yardarm.Names.Internal;
+
+// ReSharper disable InconsistentNaming
+internal class RequestsNamespace : IRequestsNamespace
 {
-    // ReSharper disable InconsistentNaming
-    internal class RequestsNamespace : IRequestsNamespace
+    public NameSyntax Name { get; }
+    public NameSyntax IOperationRequest { get; }
+    public NameSyntax OperationRequest { get; }
+    public NameSyntax BuildRequestContext { get; }
+
+    public RequestsNamespace(IRootNamespace rootNamespace)
     {
-        public NameSyntax Name { get; }
-        public NameSyntax IOperationRequest { get; }
-        public NameSyntax OperationRequest { get; }
+        ArgumentNullException.ThrowIfNull(rootNamespace);
 
-        public RequestsNamespace(IRootNamespace rootNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(rootNamespace);
+        Name = QualifiedName(rootNamespace.Name, IdentifierName("Requests"));
 
-            Name = QualifiedName(rootNamespace.Name, IdentifierName("Requests"));
+        IOperationRequest = QualifiedName(
+            Name,
+            IdentifierName("IOperationRequest"));
 
-            IOperationRequest = QualifiedName(
-                Name,
-                IdentifierName("IOperationRequest"));
+        OperationRequest = QualifiedName(
+            Name,
+            IdentifierName("OperationRequest"));
 
-            OperationRequest = QualifiedName(
-                Name,
-                IdentifierName("OperationRequest"));
-        }
+        BuildRequestContext = QualifiedName(
+            Name,
+            IdentifierName("BuildRequestContext"));
     }
 }

--- a/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
+++ b/src/main/Yardarm/YardarmCoreServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ namespace Yardarm
             services.AddSingleton<IRequestMemberGenerator, BuildContentMethodGenerator>();
             services.AddSingleton<IRequestMemberGenerator, BuildRequestMethodGenerator>();
             services.AddSingleton<IRequestMemberGenerator, BuildUriMethodGenerator>();
+            services.AddSingleton<IRequestMemberGenerator, HttpMethodPropertyGenerator>();
             services.AddSingleton<IRequestMemberGenerator, SerializationDataPropertyGenerator>();
             services.AddSingleton<IResponseMethodGenerator, GetBodyMethodGenerator>();
             services.AddSingleton<IResponseMethodGenerator, BodyConstructorMethodGenerator>();


### PR DESCRIPTION
Motivation
----------
Provide more centralized logic with less repitition and make request building more extensible in the future. Also allow access to the `ITypeSerializerRegistry` when building headers and URIs.

Modifications
-------------
- Add virtual or abstract methods to `OperationRequest` for building the request, with a default implementation of `BuildRequest` that calls other methods.
- Leave the legacy `BuildRequest` method on each inherited request class, but mark it obsolete and forward to the `OperationRequest` implementation.
- Pass the `ITypeSerializer` wrapped within a `BuildRequestContext` to all of the methods.
- Return `Uri` instead of `string` from `BuildUri` for clarity

Breaking Change
---------------
The method signatures for the protected methods BuildUri, BuildContent, and AddHeaders have changed. This may affect consumers inheriting from request classes to override these methods. However, this should be a one-time breaking change, in the future we can add additional required parameters to BuildRequestContext.