### PR TITLE
Exclude leading slash from paths with no parameters

### DIFF
--- a/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
+++ b/src/main/Yardarm/Generation/Request/BuildUriMethodGenerator.cs
@@ -159,8 +159,8 @@ public class BuildUriMethodGenerator(
         ExpressionSyntax pathExpression;
         if (parsedPath is [] or [{ Type: PathSegmentType.Text }])
         {
-            // No path parameters, just return the path
-            pathExpression = SyntaxHelpers.StringLiteral(path.Key);
+            // No path parameters, just return the path, but use the parsed value that trims the leading slash
+            pathExpression = SyntaxHelpers.StringLiteral(parsedPath.Length > 0 ? parsedPath[0].Value : "");
         }
         else if (Context.CurrentTargetFramework.Version.Major >= 6)
         {


### PR DESCRIPTION
Fixes regression in a77e7161c18ffdf7816cf2fb0e9f044a9f5ce3d3