### PR TITLE
Switch to System.Linq.AsyncEnumerable

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <PackageVersion Include="System.Net.Http.Json" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />

--- a/src/main/Yardarm/Enrichment/EnrichmentExtensions.cs
+++ b/src/main/Yardarm/Enrichment/EnrichmentExtensions.cs
@@ -32,7 +32,7 @@ public static class EnrichmentExtensions
             enrichers
                 .Sort()
                 .ToAsyncEnumerable()
-                .AggregateAwaitWithCancellationAsync(target, (p, enricher, ct) => enricher.EnrichAsync(p, ct),
+                .AggregateAsync(target, (p, enricher, ct) => enricher.EnrichAsync(p, ct),
                     cancellationToken);
 
         public ValueTask<TTarget> EnrichAsync<TContext>(IEnumerable<IAsyncEnricher<TTarget, TContext>> enrichers,
@@ -40,7 +40,7 @@ public static class EnrichmentExtensions
             enrichers
                 .Sort()
                 .ToAsyncEnumerable()
-                .AggregateAwaitWithCancellationAsync(target, (p, enricher, ct) => enricher.EnrichAsync(p, context, ct),
+                .AggregateAsync(target, (p, enricher, ct) => enricher.EnrichAsync(p, context, ct),
                     cancellationToken);
     }
 }

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -14,13 +14,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"  />
-    <PackageReference Include="Microsoft.Extensions.Logging"  />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="NuGet.Commands" />
-    <PackageReference Include="System.Linq.Async" />
+    <PackageReference Include="System.Linq.AsyncEnumerable" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
Functionality previously found in System.Linq.Async is now in-box in .NET 10 in a (mostly) compatible form. We can use it while targeting .NET 8 via the new System.Linq.AsyncEnumerable package.

Modifications
-------------
- Switch the package references
- Fix a couple of method names that are different