### PR TITLE
Allow consumers to apply HttpRequestOptions

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -27,10 +27,10 @@
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.334" />

--- a/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Net.Http;
+using RootNamespace.Requests;
+using RootNamespace.Serialization;
+using Xunit;
+
+namespace Yardarm.Client.UnitTests.Requests;
+
+public class OperationRequestTests
+{
+    [Fact]
+    public void BuildRequest_AppliesOptions()
+    {
+        // Arrange
+
+        var request = new TestOperationRequest();
+        request.Options.Set(s_testOptionKey, "TestValue");
+
+        var context = new BuildRequestContext(TypeSerializerRegistry.CreateDefaultRegistry());
+
+        // Act
+
+        var requestMessage = request.BuildRequest(context);
+
+        // Assert
+
+        Assert.True(requestMessage.Options.TryGetValue(s_testOptionKey, out string value));
+        Assert.Equal("TestValue", value);
+    }
+
+    [Fact]
+    public void BuildRequest_SucceedsWithNoOptions()
+    {
+        // Arrange
+
+        var request = new TestOperationRequest();
+        var context = new BuildRequestContext(TypeSerializerRegistry.CreateDefaultRegistry());
+
+        // Act
+
+        var requestMessage = request.BuildRequest(context);
+
+        // Assert
+
+        Assert.False(requestMessage.Options.TryGetValue(s_testOptionKey, out _));
+    }
+
+    private sealed class TestOperationRequest : OperationRequest
+    {
+        protected override HttpMethod Method => HttpMethod.Get;
+        protected override Uri BuildUri(BuildRequestContext context) => new("https://example.com");
+    }
+
+    private static readonly HttpRequestOptionsKey<string> s_testOptionKey = new("TestOption");
+}

--- a/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
@@ -45,11 +45,28 @@ public class OperationRequestTests
         Assert.False(requestMessage.Options.TryGetValue(s_testOptionKey, out _));
     }
 
+    [Fact]
+    public void Options_DefaultInterfaceMember_UsesDimImplementation()
+    {
+        // Arrange
+        IOperationRequest request = new DimOperationRequest();
+
+        // Act
+        request.Options.Set(s_testOptionKey, "TestValue");
+
+        // Assert
+        Assert.True(request.Options.TryGetValue(s_testOptionKey, out var value));
+        Assert.Equal("TestValue", value);
+    }
+
     private sealed class TestOperationRequest : OperationRequest
     {
         protected override HttpMethod Method => HttpMethod.Get;
         protected override Uri BuildUri(BuildRequestContext context) => new("https://example.com");
     }
 
+    private sealed class DimOperationRequest : IOperationRequest
+    {
+    }
     private static readonly HttpRequestOptionsKey<string> s_testOptionKey = new("TestOption");
 }

--- a/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using RootNamespace.Authentication;
 using RootNamespace.Requests;
 using RootNamespace.Serialization;
 using Xunit;
@@ -67,6 +68,9 @@ public class OperationRequestTests
 
     private sealed class DimOperationRequest : IOperationRequest
     {
+        public IAuthenticator Authenticator { get; set; }
+        public bool EnableResponseStreaming { get; set; }
     }
+
     private static readonly HttpRequestOptionsKey<string> s_testOptionKey = new("TestOption");
 }

--- a/src/main/Yardarm.Client/Requests/IOperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/IOperationRequest.cs
@@ -1,28 +1,51 @@
 ﻿using RootNamespace.Authentication;
 using RootNamespace.Responses;
 
-namespace RootNamespace.Requests
-{
-    public interface IOperationRequest
-    {
-        /// <summary>
-        /// Optionally override the default authenticator for this request.
-        /// </summary>
-        public IAuthenticator? Authenticator { get; set; }
+#if NET5_0_OR_GREATER
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+#endif
 
-        /// <summary>
-        /// If true, the request will return after response headers are received and the response body will be streamed.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// This is particularly useful for large response bodies. However, when using response streaming the response body
-        /// will not be buffered and may only be read once.
-        /// </para>
-        /// <para>
-        /// Additionally, it is imperative that <see cref="IOperationResponse.Dispose" /> be called when the response is no
-        /// longer needed to avoid leaking connections. This is particularly important for .NET 4.x consumers.
-        /// </para>
-        /// </remarks>
-        public bool EnableResponseStreaming { get; set; }
-    }
+namespace RootNamespace.Requests;
+
+public interface IOperationRequest
+{
+    /// <summary>
+    /// Optionally override the default authenticator for this request.
+    /// </summary>
+    public IAuthenticator? Authenticator { get; set; }
+
+    /// <summary>
+    /// If true, the request will return after response headers are received and the response body will be streamed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is particularly useful for large response bodies. However, when using response streaming the response body
+    /// will not be buffered and may only be read once.
+    /// </para>
+    /// <para>
+    /// Additionally, it is imperative that <see cref="IOperationResponse.Dispose" /> be called when the response is no
+    /// longer needed to avoid leaking connections. This is particularly important for .NET 4.x consumers.
+    /// </para>
+    /// </remarks>
+    public bool EnableResponseStreaming { get; set; }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Options to apply to the <see cref="HttpRequestMessage"/>.
+    /// </summary>
+    // This includes a DIM for backward compatibility, it should normally be unused.
+    public HttpRequestOptions Options => OperationRequestExtensions.OptionsTable.GetValue(this, static _ => []);
+#endif
 }
+
+#if NET5_0_OR_GREATER
+internal static class OperationRequestExtensions
+{
+    private static ConditionalWeakTable<IOperationRequest, HttpRequestOptions>? s_optionsTable = null;
+
+    public static ConditionalWeakTable<IOperationRequest, HttpRequestOptions> OptionsTable =>
+        s_optionsTable ?? Interlocked.CompareExchange(ref s_optionsTable, [], null) ?? s_optionsTable;
+}
+#endif

--- a/src/main/Yardarm.Client/Requests/OperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/OperationRequest.cs
@@ -2,6 +2,10 @@
 using System.Net.Http;
 using RootNamespace.Authentication;
 
+#if NET5_0_OR_GREATER
+using System.Collections.Generic;
+#endif
+
 namespace RootNamespace.Requests;
 
 /// <summary>
@@ -14,6 +18,13 @@ public abstract class OperationRequest : IOperationRequest
 
     /// <inheritdoc />
     public bool EnableResponseStreaming { get; set; }
+
+#if NET5_0_OR_GREATER
+    private HttpRequestOptions? _options;
+
+    /// <inheritdoc />
+    public HttpRequestOptions Options => _options ??= new();
+#endif
 
     /// <summary>
     /// The HTTP method of the request.
@@ -44,6 +55,11 @@ public abstract class OperationRequest : IOperationRequest
     public virtual HttpRequestMessage BuildRequest(BuildRequestContext context)
     {
         var requestMessage = new HttpRequestMessage(Method, BuildUri(context));
+
+#if NET5_0_OR_GREATER
+        ApplyOptions(requestMessage);
+#endif
+
         AddHeaders(context, requestMessage);
         requestMessage.Content = BuildContent(context);
         return requestMessage;
@@ -55,4 +71,19 @@ public abstract class OperationRequest : IOperationRequest
     /// <param name="context">Context of the request.</param>
     /// <returns><see cref="Uri"/> of the request.</returns>
     protected abstract Uri BuildUri(BuildRequestContext context);
+
+#if NET5_0_OR_GREATER
+    private void ApplyOptions(HttpRequestMessage requestMessage)
+    {
+        if (_options is HttpRequestOptions options)
+        {
+            var destination = (IDictionary<string, object?>)requestMessage.Options;
+
+            foreach (KeyValuePair<string, object?> option in options)
+            {
+                destination[option.Key] = option.Value;
+            }
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Motivation
----------
This allows additional information to be applied to the outgoing HttpRequestMessage which can then be used by HttpMessageHandlers in the outgoing request pipeline to change request behaviors.

Modifications
-------------
Add the options to IOperationRequest and OperationRequest when targeting .NET 5 or later. .NET 5 is required for HttpRequestOptions.