### PR TITLE
Allow consumers to apply HttpRequestOptions

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -27,10 +27,10 @@
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="FluentAssertions" Version="8.7.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.334" />

--- a/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Requests/OperationRequestTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Net.Http;
+using RootNamespace.Authentication;
+using RootNamespace.Requests;
+using RootNamespace.Serialization;
+using Xunit;
+
+namespace Yardarm.Client.UnitTests.Requests;
+
+public class OperationRequestTests
+{
+    [Fact]
+    public void BuildRequest_AppliesOptions()
+    {
+        // Arrange
+
+        var request = new TestOperationRequest();
+        request.Options.Set(s_testOptionKey, "TestValue");
+
+        var context = new BuildRequestContext(TypeSerializerRegistry.CreateDefaultRegistry());
+
+        // Act
+
+        var requestMessage = request.BuildRequest(context);
+
+        // Assert
+
+        Assert.True(requestMessage.Options.TryGetValue(s_testOptionKey, out string value));
+        Assert.Equal("TestValue", value);
+    }
+
+    [Fact]
+    public void BuildRequest_SucceedsWithNoOptions()
+    {
+        // Arrange
+
+        var request = new TestOperationRequest();
+        var context = new BuildRequestContext(TypeSerializerRegistry.CreateDefaultRegistry());
+
+        // Act
+
+        var requestMessage = request.BuildRequest(context);
+
+        // Assert
+
+        Assert.False(requestMessage.Options.TryGetValue(s_testOptionKey, out _));
+    }
+
+    [Fact]
+    public void Options_DefaultInterfaceMember_UsesDimImplementation()
+    {
+        // Arrange
+        IOperationRequest request = new DimOperationRequest();
+
+        // Act
+        request.Options.Set(s_testOptionKey, "TestValue");
+
+        // Assert
+        Assert.True(request.Options.TryGetValue(s_testOptionKey, out var value));
+        Assert.Equal("TestValue", value);
+    }
+
+    private sealed class TestOperationRequest : OperationRequest
+    {
+        protected override HttpMethod Method => HttpMethod.Get;
+        protected override Uri BuildUri(BuildRequestContext context) => new("https://example.com");
+    }
+
+    private sealed class DimOperationRequest : IOperationRequest
+    {
+        public IAuthenticator Authenticator { get; set; }
+        public bool EnableResponseStreaming { get; set; }
+    }
+
+    private static readonly HttpRequestOptionsKey<string> s_testOptionKey = new("TestOption");
+}

--- a/src/main/Yardarm.Client/Requests/IOperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/IOperationRequest.cs
@@ -1,6 +1,12 @@
 ﻿using RootNamespace.Authentication;
 using RootNamespace.Responses;
 
+#if NET5_0_OR_GREATER
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+#endif
+
 namespace RootNamespace.Requests;
 
 public interface IOperationRequest
@@ -24,4 +30,22 @@ public interface IOperationRequest
     /// </para>
     /// </remarks>
     public bool EnableResponseStreaming { get; set; }
+
+#if NET5_0_OR_GREATER
+    /// <summary>
+    /// Options to apply to the <see cref="HttpRequestMessage"/>.
+    /// </summary>
+    // This includes a DIM for backward compatibility, it should normally be unused.
+    public HttpRequestOptions Options => OperationRequestExtensions.OptionsTable.GetValue(this, static _ => []);
+#endif
 }
+
+#if NET5_0_OR_GREATER
+internal static class OperationRequestExtensions
+{
+    private static ConditionalWeakTable<IOperationRequest, HttpRequestOptions>? s_optionsTable = null;
+
+    public static ConditionalWeakTable<IOperationRequest, HttpRequestOptions> OptionsTable =>
+        s_optionsTable ?? Interlocked.CompareExchange(ref s_optionsTable, [], null) ?? s_optionsTable;
+}
+#endif

--- a/src/main/Yardarm.Client/Requests/OperationRequest.cs
+++ b/src/main/Yardarm.Client/Requests/OperationRequest.cs
@@ -2,6 +2,10 @@
 using System.Net.Http;
 using RootNamespace.Authentication;
 
+#if NET5_0_OR_GREATER
+using System.Collections.Generic;
+#endif
+
 namespace RootNamespace.Requests;
 
 /// <summary>
@@ -21,6 +25,13 @@ public abstract class OperationRequest : IOperationRequest
 
     /// <inheritdoc />
     public bool EnableResponseStreaming { get; set; }
+
+#if NET5_0_OR_GREATER
+    private HttpRequestOptions? _options;
+
+    /// <inheritdoc />
+    public HttpRequestOptions Options => _options ??= new();
+#endif
 
     /// <summary>
     /// The HTTP method of the request.
@@ -60,6 +71,11 @@ public abstract class OperationRequest : IOperationRequest
     {
         var requestMessage = new HttpRequestMessage(Method, BuildUri(context));
         ApplyHttpVersion(requestMessage);
+
+#if NET5_0_OR_GREATER
+        ApplyOptions(requestMessage);
+#endif
+
         AddHeaders(context, requestMessage);
         requestMessage.Content = BuildContent(context);
         return requestMessage;
@@ -82,4 +98,19 @@ public abstract class OperationRequest : IOperationRequest
     /// <param name="context">Context of the request.</param>
     /// <returns><see cref="Uri"/> of the request.</returns>
     protected abstract Uri BuildUri(BuildRequestContext context);
+
+#if NET5_0_OR_GREATER
+    private void ApplyOptions(HttpRequestMessage requestMessage)
+    {
+        if (_options is HttpRequestOptions options)
+        {
+            var destination = (IDictionary<string, object?>)requestMessage.Options;
+
+            foreach (KeyValuePair<string, object?> option in options)
+            {
+                destination[option.Key] = option.Value;
+            }
+        }
+    }
+#endif
 }


### PR DESCRIPTION
Motivation
----------
This allows additional information to be applied to the outgoing HttpRequestMessage which can then be used by HttpMessageHandlers in the outgoing request pipeline to change request behaviors.

Modifications
-------------
Add the options to IOperationRequest and OperationRequest when targeting .NET 5 or later. .NET 5 is required for HttpRequestOptions.