### PR TITLE
Use RFC3339 for NodaTime OffsetTime serialization

### DIFF
--- a/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
+++ b/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
@@ -19,12 +19,14 @@ internal sealed class YardarmNodaTimeJsonConverterFactory : JsonConverterFactory
 {
     public static JsonConverter<OffsetTime> OffsetTimeConverter { get; } =
         new NodaPatternConverter<OffsetTime>(OffsetTimePattern.Rfc3339);
+    public static JsonConverter<OffsetTime?> NullableOffsetTimeConverter { get; } =
+        new NodaNullableConverter<OffsetTime>(OffsetTimeConverter);
 
     private readonly NodaTimeDefaultJsonConverterFactory _innerFactory = new();
 
     public override bool CanConvert(Type typeToConvert)
     {
-        if (typeToConvert == typeof(OffsetTime))
+        if (typeToConvert == typeof(OffsetTime) || typeToConvert == typeof(OffsetTime?))
         {
             return true;
         }
@@ -38,7 +40,43 @@ internal sealed class YardarmNodaTimeJsonConverterFactory : JsonConverterFactory
         {
             return OffsetTimeConverter;
         }
+        if (typeToConvert == typeof(OffsetTime?))
+        {
+            return NullableOffsetTimeConverter;
+        }
 
         return _innerFactory.CreateConverter(typeToConvert, options);
+    }
+
+    /// <summary>
+    /// Creates a new NodaNullableConverter.
+    /// </summary>
+    /// <param name="innerConverter">Inner converter for serializing and deserializing when not null.</param>
+    private sealed class NodaNullableConverter<T>(JsonConverter<T> innerConverter) : JsonConverter<T?>
+        where T : struct
+    {
+        /// <inheritdoc />
+        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            return innerConverter.Read(ref reader, typeToConvert, options);
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+        {
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                innerConverter.Write(writer, value.Value, options);
+            }
+        }
     }
 }

--- a/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
+++ b/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
+using NodaTime.Text;
+
+namespace RootNamespace.Serialization.Json;
+
+/// <summary>
+/// Extends <see cref="NodaTimeDefaultJsonConverterFactory"/> to support
+/// Yardarm-specific conversions.
+/// </summary>
+/// <remarks>
+/// In particular, uses RFC3339 style formatting for <see cref="OffsetTime"/> which always outputs the
+/// minutes of the time zone offset, even if they are zero. This is required for OpenAPI 3.1 compliance.
+/// </remarks>
+internal sealed class YardarmNodaTimeJsonConverterFactory : JsonConverterFactory
+{
+    public static JsonConverter<OffsetTime> OffsetTimeConverter { get; } =
+        new NodaPatternConverter<OffsetTime>(OffsetTimePattern.Rfc3339);
+
+    private readonly NodaTimeDefaultJsonConverterFactory _innerFactory = new();
+
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (typeToConvert == typeof(OffsetTime))
+        {
+            return true;
+        }
+
+        return _innerFactory.CanConvert(typeToConvert);
+    }
+
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (typeToConvert == typeof(OffsetTime))
+        {
+            return OffsetTimeConverter;
+        }
+
+        return _innerFactory.CreateConverter(typeToConvert, options);
+    }
+}

--- a/src/main/Yardarm.NodaTime.UnitTests/Serialization/Json/YardarmNodaTimeJsonConverterFactoryTests.cs
+++ b/src/main/Yardarm.NodaTime.UnitTests/Serialization/Json/YardarmNodaTimeJsonConverterFactoryTests.cs
@@ -1,0 +1,167 @@
+﻿using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RootNamespace.Serialization.Json;
+
+namespace Yardarm.NodaTime.UnitTests.Serialization.Json;
+
+public class YardarmNodaTimeJsonConverterFactoryTests
+{
+    #region OffsetTime
+
+    [Fact]
+    public void CanConvert_OffsetTime_ReturnsTrue()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+        Assert.True(factory.CanConvert(typeof(OffsetTime)));
+    }
+
+    [Fact]
+    public void CanConvert_NullableOffsetTime_ReturnsTrue()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+        Assert.True(factory.CanConvert(typeof(OffsetTime?)));
+    }
+
+    [Fact]
+    public void Convert_OffsetTime_ReturnsOffsetWithMinutes()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime>>(factory.CreateConverter(typeof(OffsetTime), JsonSerializerOptions.Default));
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            converter.Write(writer, new OffsetTime(LocalTime.Midnight, Offset.FromHours(1)), JsonSerializerOptions.Default);
+            writer.Flush();
+        }
+
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Equal("\"00:00:00\\u002B01:00\"", json);
+    }
+
+    [Fact]
+    public void Convert_OffsetTime_ReadsWithMinutes()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime>>(factory.CreateConverter(typeof(OffsetTime), JsonSerializerOptions.Default));
+
+        var json = "\"00:00:00\\u002B01:00\""u8;
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+
+        var result = converter.Read(ref reader, typeof(OffsetTime), JsonSerializerOptions.Default);
+
+        Assert.Equal(new OffsetTime(LocalTime.Midnight, Offset.FromHours(1)), result);
+    }
+
+    [Fact]
+    public void Convert_OffsetTime_ReadsZ()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime>>(factory.CreateConverter(typeof(OffsetTime), JsonSerializerOptions.Default));
+
+        var json = "\"00:00:00Z\""u8;
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+
+        var result = converter.Read(ref reader, typeof(OffsetTime), JsonSerializerOptions.Default);
+
+        Assert.Equal(new OffsetTime(LocalTime.Midnight, Offset.Zero), result);
+    }
+
+    #endregion
+
+    #region NullableOffsetTime
+
+    [Fact]
+    public void Convert_NullableOffsetTime_ReturnsOffsetWithMinutes()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime?>>(factory.CreateConverter(typeof(OffsetTime?), JsonSerializerOptions.Default));
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            converter.Write(writer, new OffsetTime(LocalTime.Midnight, Offset.FromHours(1)), JsonSerializerOptions.Default);
+            writer.Flush();
+        }
+
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Equal("\"00:00:00\\u002B01:00\"", json);
+    }
+
+    [Fact]
+    public void Convert_NullableOffsetTime_WritesNull()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime?>>(factory.CreateConverter(typeof(OffsetTime?), JsonSerializerOptions.Default));
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            converter.Write(writer, null, JsonSerializerOptions.Default);
+            writer.Flush();
+        }
+
+        var json = Encoding.UTF8.GetString(stream.ToArray());
+        Assert.Equal("null", json);
+    }
+
+    [Fact]
+    public void Convert_NullableOffsetTime_ReadsWithMinutes()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime?>>(factory.CreateConverter(typeof(OffsetTime?), JsonSerializerOptions.Default));
+
+        var json = "\"00:00:00\\u002B01:00\""u8;
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+
+        var result = converter.Read(ref reader, typeof(OffsetTime?), JsonSerializerOptions.Default);
+
+        Assert.NotNull(result);
+        Assert.Equal(new OffsetTime(LocalTime.Midnight, Offset.FromHours(1)), result.Value);
+    }
+
+    [Fact]
+    public void Convert_NullableOffsetTime_ReadsZ()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime?>>(factory.CreateConverter(typeof(OffsetTime?), JsonSerializerOptions.Default));
+
+        var json = "\"00:00:00Z\""u8;
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+
+        var result = converter.Read(ref reader, typeof(OffsetTime?), JsonSerializerOptions.Default);
+
+        Assert.NotNull(result);
+        Assert.Equal(new OffsetTime(LocalTime.Midnight, Offset.Zero), result.Value);
+    }
+
+    [Fact]
+    public void Convert_NullableOffsetTime_ReadsNull()
+    {
+        var factory = new YardarmNodaTimeJsonConverterFactory();
+
+        var converter = Assert.IsAssignableFrom<JsonConverter<OffsetTime?>>(factory.CreateConverter(typeof(OffsetTime?), JsonSerializerOptions.Default));
+
+        var json = "null"u8;
+        var reader = new Utf8JsonReader(json);
+        reader.Read();
+
+        var result = converter.Read(ref reader, typeof(OffsetTime?), JsonSerializerOptions.Default);
+
+        Assert.Null(result);
+    }
+
+    #endregion
+}

--- a/src/main/Yardarm.NodaTime/Helpers/NodaTimeTypes.cs
+++ b/src/main/Yardarm.NodaTime/Helpers/NodaTimeTypes.cs
@@ -39,9 +39,6 @@ internal static class NodaTimeTypes
         {
             public static NameSyntax Name { get; } =
                 QualifiedName(Serialization.Name, IdentifierName("SystemTextJson"));
-
-            public static NameSyntax NodaTimeDefaultJsonConverterFactory { get; } =
-                QualifiedName(Name, IdentifierName("NodaTimeDefaultJsonConverterFactory"));
         }
 
         public static class JsonNet

--- a/src/main/Yardarm.NodaTime/Internal/ClientGenerator.cs
+++ b/src/main/Yardarm.NodaTime/Internal/ClientGenerator.cs
@@ -1,10 +1,29 @@
-﻿using Yardarm.Generation;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Yardarm.Generation;
 using Yardarm.Names;
 
 namespace Yardarm.NodaTime.Internal;
 
-internal sealed class ClientGenerator(GenerationContext generationContext, IRootNamespace rootNamespace)
+internal sealed partial class ClientGenerator(GenerationContext generationContext, IRootNamespace rootNamespace)
     : ResourceSyntaxTreeGenerator(generationContext, rootNamespace)
 {
     protected override string ResourcePrefix => "Yardarm.NodaTime.Client.";
+
+    public override IEnumerable<Regex> GetResourceNameExclusions()
+    {
+        foreach (Regex exclusion in base.GetResourceNameExclusions())
+        {
+            yield return exclusion;
+        }
+
+        if (!generationContext.Settings.Extensions.Any(p => p.Name == "SystemTextJsonExtension"))
+        {
+            yield return NodaTimeJsonConverterFactory();
+        }
+    }
+
+    [GeneratedRegex(@"YardarmNodaTimeJsonConverterFactory\.cs$")]
+    private static partial Regex NodaTimeJsonConverterFactory();
 }

--- a/src/main/Yardarm.NodaTime/Internal/JsonSourceGenerationOptionsEnricher.cs
+++ b/src/main/Yardarm.NodaTime/Internal/JsonSourceGenerationOptionsEnricher.cs
@@ -2,7 +2,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Enrichment;
-using Yardarm.NodaTime.Helpers;
+using Yardarm.Names;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.NodaTime.Internal;
@@ -10,7 +10,9 @@ namespace Yardarm.NodaTime.Internal;
 /// <summary>
 /// Enriches the JsonSerializerOptionsAttribute on the JsonSerizalizerContext class when System.Text.Json is used.
 /// </summary>
-internal sealed class JsonSourceGenerationOptionsEnricher : IEnricher<AttributeSyntax>
+internal sealed class JsonSourceGenerationOptionsEnricher(
+    ISerializationNamespace serializationNamespace)
+    : IEnricher<AttributeSyntax>
 {
     public AttributeSyntax Enrich(AttributeSyntax target)
     {
@@ -18,7 +20,9 @@ internal sealed class JsonSourceGenerationOptionsEnricher : IEnricher<AttributeS
             .FirstOrDefault(p => p.NameEquals?.Name.Identifier.ValueText == "Converters");
 
         TypeOfExpressionSyntax typeOfExpression =
-            TypeOfExpression(NodaTimeTypes.Serialization.SystemTextJson.NodaTimeDefaultJsonConverterFactory);
+            TypeOfExpression(QualifiedName(
+                QualifiedName(serializationNamespace.Name, IdentifierName("Json")),
+                IdentifierName("YardarmNodaTimeJsonConverterFactory")));
         ExpressionSyntax expression = currentArgument?.Expression switch
         {
             CollectionExpressionSyntax collectionExpression =>


### PR DESCRIPTION
Motivation
----------
OpenAPI 3.1 follows RFC3339 for date/time formats, which is based on ISO8601 but doesn't allow excluding minutes from the time zone offset such as `-04` instead of `-04:00`. The default NodaTime serializers for System.Text.Json do this for OffsetDateTime, but not for OffsetTime. This causes output serialized by the SDK to fail to deserialize when received by strict deserializers.

Modifications
-------------
Add an intermediate JsonConvertFactory that returns a converter with an RFC3339 format string for OffsetTime. It forwards to the default implementation for all other NodaTime types.