### PR TITLE
Upgrade to NuGet 7.6

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-    <PackageVersion Include="NuGet.Commands" Version="7.0.1" />
+    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />

--- a/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
+++ b/src/main/Yardarm.CommandLine/CollectDependenciesCommand.cs
@@ -49,11 +49,6 @@ namespace Yardarm.CommandLine
                 var generator = new YardarmProcessor(settings);
                 var packageSpec = await generator.GetPackageSpecAsync(cancellationToken);
 
-                foreach (var dependency in packageSpec.Dependencies.Where(p => !p.AutoReferenced))
-                {
-                    AddItem(GeneratePackageReference(dependency));
-                }
-
                 foreach (var framework in packageSpec.TargetFrameworks)
                 {
                     foreach (var dependency in framework.Dependencies.Where(p => !p.AutoReferenced))

--- a/src/main/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
+++ b/src/main/Yardarm/Packaging/DefaultPackageSpecGenerator.cs
@@ -35,7 +35,6 @@ namespace Yardarm.Packaging
             {
                 Name = _settings.AssemblyName,
                 FilePath = _settings.AssemblyName,
-                Dependencies = new List<LibraryDependency>()
             }.Enrich(Enrichers);
 
         private static TargetFrameworkInformation CreateTargetFrameworkInformation(NuGetFramework frameworkName)
@@ -74,6 +73,7 @@ namespace Yardarm.Packaging
             return new TargetFrameworkInformation
             {
                 FrameworkName = frameworkName,
+                TargetAlias = frameworkName.GetShortFolderName(),
                 FrameworkReferences = frameworkDependencies,
                 DownloadDependencies = downloadDependencies
             };

--- a/src/main/Yardarm/Packaging/Internal/SourceGeneratorLoadContext.cs
+++ b/src/main/Yardarm/Packaging/Internal/SourceGeneratorLoadContext.cs
@@ -43,8 +43,7 @@ namespace Yardarm.Packaging.Internal
             TargetFrameworkInformation? frameworkInformation = packageSpec.TargetFrameworks
                 .FirstOrDefault(p => p.FrameworkName == targetFramework);
 
-            foreach (LibraryDependency directDependency in packageSpec.Dependencies
-                         .Concat(frameworkInformation?.Dependencies ?? Enumerable.Empty<LibraryDependency>()))
+            foreach (LibraryDependency directDependency in frameworkInformation?.Dependencies ?? [])
             {
                 // Get the exact version we restored
                 NuGetVersion? version = lockFileTarget.Libraries


### PR DESCRIPTION
Motivation
----------
Resolve a security vulnerability in NuGet 7.0.1.

Modifications
-------------
- Upgrade the package version
- Remove handling of top-level package dependencies, they are no longer present and are only found in target framework dependencies now
- Ensure package restore fills the new TargetAlias on dependencies