### PR TITLE
Modernize unit test packages and use MTP v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,13 @@ jobs:
       run: dotnet build --configuration Release -p:Version=${{ needs.version.outputs.version  }} --no-restore
     - name: Test
       working-directory: ./src/main
-      run: dotnet test --configuration Release --no-build --verbosity normal --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+      run: >-
+        dotnet test
+        --configuration Release
+        --no-build
+        --report-github
+        --report-github-summary-include-passed
+        --report-github-summary-include-skipped
     - name: Test Generate
       run: ./scripts/generate.sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     needs: version
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
@@ -47,7 +47,7 @@ jobs:
           8.0.x
           10.0.x
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -93,7 +93,7 @@ jobs:
     needs: version
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v5
@@ -102,7 +102,7 @@ jobs:
           8.0.x
           10.0.x
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v6
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -140,7 +140,7 @@ jobs:
     steps:
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ghcr.io/centeredge/yardarm
         tags: |
@@ -150,18 +150,18 @@ jobs:
           type=sha
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: docker/build-push-action@v6
+    - uses: docker/build-push-action@v7
       with:
         platforms: linux/amd64,linux/arm64
         build-args: VERSION=${{ needs.version.outputs.version }}

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -7,20 +7,13 @@
 
   <PropertyGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="GitHubActionsTestLogger">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/global.json
+++ b/src/global.json
@@ -3,5 +3,8 @@
     "sdk": {
         "version": "10.0.100",
         "rollForward": "latestFeature"
+    },
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
     }
 }

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -25,14 +25,9 @@
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
-    <PackageVersion Include="FluentAssertions" Version="8.7.1" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageVersion Include="xunit.v3" Version="3.1.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.334" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Solution Items/">
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
+    <File Path="../global.json" />
     <File Path="Directory.Packages.props" />
   </Folder>
   <Project Path="Yardarm.Benchmarks/Yardarm.Benchmarks.csproj" />


### PR DESCRIPTION
Motivation
----------
Use latest MTP standards for running tests.

Modifications
-------------
- Update to xUnit with MTP v2
- Update to latest GitHubActionsTestLogger
- Drop legacy packages and use MTP v2 runner for CI
- Remove CopyOnWrite, this is built into modern MSBuild
- Also update GitHub Actions versions