### PR TITLE
Cleanup NuGet package references

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -2,28 +2,36 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
+
+  <!-- Yardarm Dependencies-->
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.29" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.29" />
+    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.9" />
+  </ItemGroup>
+
+  <!-- Client Dependencies -->
+  <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.0" />
     <PackageVersion Include="System.Net.Http.Json" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
+
+  <!-- Test Dependencies -->
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />

--- a/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Yardarm\Yardarm.csproj" />
   </ItemGroup>
 

--- a/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Yardarm\Yardarm.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Motivation
----------
Cleanup versions prior to the 0.7 release.

Modifications
-------------
- Update all internal use packages to the latest
- Organize client packages into a separate section for clarity