### PR TITLE
Update client packages to latest patch versions

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -24,10 +24,10 @@
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
+    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Net.Http.Json" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Net.Http.Json" Version="9.0.17" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.17" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 

--- a/src/main/Yardarm.NodaTime/Internal/NodaTimeDependencyGenerator.cs
+++ b/src/main/Yardarm.NodaTime/Internal/NodaTimeDependencyGenerator.cs
@@ -21,7 +21,7 @@ internal sealed class NodaTimeDependencyGenerator(
                 {
                     Name = "NodaTime.Serialization.SystemTextJson",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("1.3.0")
+                    VersionRange = VersionRange.Parse("1.4.0")
                 }
             };
         }
@@ -33,7 +33,7 @@ internal sealed class NodaTimeDependencyGenerator(
                 {
                     Name = "NodaTime.Serialization.JsonNet",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("3.2.0")
+                    VersionRange = VersionRange.Parse("3.3.0")
                 }
             };
         }

--- a/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -19,7 +19,7 @@ public class JsonDependencyGenerator : IDependencyGenerator
                 {
                     Name = "System.Text.Json",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("9.0.0")
+                    VersionRange = VersionRange.Parse("9.0.17")
                 }
             };
         }
@@ -33,7 +33,7 @@ public class JsonDependencyGenerator : IDependencyGenerator
                 {
                     Name = "System.Net.Http.Json",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("9.0.0")
+                    VersionRange = VersionRange.Parse("9.0.17")
                 }
             };
         }


### PR DESCRIPTION
Motivation
----------
Ensure clients have any bug fixes.

Modifications
-------------
Update all client packages to their latest patch version, but not the latest major version. The major version is left unchanged to increase compatibility with clients targeting downlevel runtimes, we only increase major versions with new features are required or versions are deprecated.

NodaTime serialization was bumped by a minor version to get some new features.