### PR TITLE
Use CenterEdge action for release versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,27 +11,19 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.gitversion.outputs.semVer }}
+      version: ${{ steps.version.outputs.version }}
+      is-release: ${{ steps.version.outputs.is-release }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 8.0.x
-
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4
-        with:
-          versionSpec: "6.4.0"
       - name: Determine Version
-        id: gitversion
-        uses: gittools/actions/gitversion/execute@v4
+        id: version
+        uses: CenterEdge/actions/dotnet/nuget-version@v1
         with:
-          configFilePath: "GitVersion.yml"
+          tag-prefix: release/
 
   build:
     runs-on: ubuntu-latest
@@ -77,12 +69,12 @@ jobs:
       run: dotnet pack --configuration Release -p:Version=${{ needs.version.outputs.version }}
       # Note: SDK is packed by build above, doesn't need to be packed here
     - name: Push to NuGet.org
-      if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
+      if: ${{ needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
         dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Push to GitHub Packages
-      if: ${{ startsWith(github.ref, 'refs/pull/') || startsWith(github.ref, 'refs/tags/release/') }}
+      if: ${{ startsWith(github.ref, 'refs/pull/') || needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
         dotnet nuget push **/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/CenterEdge/index.json --skip-duplicate
@@ -123,12 +115,12 @@ jobs:
 
     # Note: SDK is packed by build above, doesn't need to be packed here
     - name: Push to NuGet.org
-      if: ${{ startsWith(github.ref, 'refs/tags/release/') }}
+      if: ${{ needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
         dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Push to GitHub Packages
-      if: ${{ startsWith(github.ref, 'refs/pull/') || startsWith(github.ref, 'refs/tags/release/') }}
+      if: ${{ startsWith(github.ref, 'refs/pull/') || needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
         dotnet nuget push **/*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/CenterEdge/index.json --skip-duplicate
@@ -165,6 +157,9 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64
         build-args: VERSION=${{ needs.version.outputs.version }}
-        push: ${{ startsWith(github.ref, 'refs/tags/release/') }}
+        push: ${{ needs.version.outputs.is-release == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        annotations: ${{ steps.meta.outputs.annotations }}
+        provenance: true
+        sbom: true

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,0 @@
-workflow: GitHubFlow/v1


### PR DESCRIPTION
GitVersion isn't working correctly for pre-releases and is frankly overkill. Also enable provenance on the Docker image build.