### PR TITLE
Allow customization of JSON serialization/deserialization

### DIFF
--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonTypeSerializer.cs
@@ -6,7 +6,6 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -50,6 +49,32 @@ public class JsonTypeSerializer : ITypeSerializer
 
         _options = context.Options;
     }
+
+    private JsonTypeSerializer(JsonSerializerContext context, Action<JsonSerializerOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (configureOptions is null)
+        {
+            _options = context.Options;
+        }
+        else
+        {
+            var options = new JsonSerializerOptions(context.Options);
+            configureOptions(options);
+            options.MakeReadOnly();
+
+            _options = options;
+        }
+    }
+
+    /// <summary>
+    /// Create a new <see cref="JsonTypeSerializer"/> instance with the default configuration.
+    /// </summary>
+    /// <param name="configureOptions">Optional callback to extend the default <see cref="JsonSerializerOptions"/>.</param>
+    /// <returns>A new <see cref="JsonTypeSerializer"/> instance.</returns>
+    public static JsonTypeSerializer CreateDefault(Action<JsonSerializerOptions>? configureOptions = null) =>
+        new(ModelSerializerContext.Default, configureOptions);
 
     public HttpContent Serialize<T>(T value, string mediaType, ISerializationData? serializationData = null) =>
         JsonContent.Create(value, _options.GetTypeInfo(typeof(T)), new MediaTypeHeaderValue(mediaType) {CharSet = Encoding.UTF8.WebName});

--- a/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
@@ -20,7 +20,7 @@ public class JsonCreateDefaultRegistryEnricher : ReturnValueRegistrationEnricher
     protected override ExpressionSyntax EnrichReturnValue(ExpressionSyntax target) =>
         // Don't use the Add<T> overload here because it will cause trimming to retain
         // all constructors. This will then cause IL2026 warnings if trimming is enabled.
-        // Instead create a new instance directly using the default constructor and add it.
+        // Instead create a new instance using the CreateDefault static method and add it.
         InvocationExpression(
             MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                 target,

--- a/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonCreateDefaultRegistryEnricher.cs
@@ -2,7 +2,6 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Enrichment.Registration;
-using Yardarm.SystemTextJson.Internal;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Yardarm.SystemTextJson;
@@ -31,11 +30,8 @@ public class JsonCreateDefaultRegistryEnricher : ReturnValueRegistrationEnricher
                 Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
                     _jsonSerializationNamespace.JsonTypeSerializer,
                     IdentifierName("SupportedMediaTypes"))),
-                Argument(ObjectCreationExpression(_jsonSerializationNamespace.JsonTypeSerializer,
-                    ArgumentList(SingletonSeparatedList(
-                        Argument(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression,
-                            QualifiedName(_jsonSerializationNamespace.Name, IdentifierName(JsonSerializerContextGenerator.TypeName)),
-                            IdentifierName("Default"))))),
-                        null))
+                Argument(InvocationExpression(
+                    MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, _jsonSerializationNamespace.JsonTypeSerializer, IdentifierName("CreateDefault")),
+                    ArgumentList()))
             ])));
 }


### PR DESCRIPTION
Motivation
----------
Currently System.Text.Json serialization and deserialization may be customized by passing a JsonSerializerOptions instance. However, it's necessary to build this from scratch. There's no easy way for the SDK consumer to extend the default settings generated by the SDK.

Modifications
-------------
- Add a CreateDefault static method to JsonTypeSerializer that creates the default serializer and accepts an optional callback to further customize the options.
- Use the new method when registered on the default TypeSerializerRegistry.