### PR TITLE
Include Yardarm extensions as build inputs

### DIFF
--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -213,6 +213,7 @@
       <CustomAdditionalCompileInputs Include="$(IntermediateOutputPath)$(MSBuildProjectFile).CoreCompileInputs.cache" />
       <CoreCompileCache Include="@(OpenApiSpec)" />
       <CoreCompileCache Include="@(Compile)" />
+      <CoreCompileCache Include="@(YardarmExtension)" />
       <CoreCompileCache Include="EmbedAllSources=$(EmbedAllSources)" />
       <CoreCompileCache Include="GenerateDocumentationFile=$(GenerateDocumentationFile)" />
       <CoreCompileCache Include="Version=$(Version)" />

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -153,6 +153,7 @@
                   @(OpenApiSpec);
                   @(Compile);
                   @(ReferencePathWithRefAssemblies);
+                  @(YardarmExtension);
                   @(Analyzer);
                   @(CustomAdditionalCompileInputs)"
           Outputs="@(DocFileItem);


### PR DESCRIPTION
Motivation
----------
Changes to the Yardarm extension should trigger an compilation in incremental build scenarios. This supports dynamically built extensions.

Modifications
-------------
Add the list of YardarmExtension files to the inputs of the CoreCompile step. Also include the list of extensions in the core compile input cache so that a change in the list triggers a rebuild as well.