### PR TITLE
Make NodaTime JsonSourceGenerationOptionsEnricher public

### DIFF
--- a/src/main/Yardarm.NodaTime/JsonSourceGenerationOptionsEnricher.cs
+++ b/src/main/Yardarm.NodaTime/JsonSourceGenerationOptionsEnricher.cs
@@ -5,12 +5,12 @@ using Yardarm.Enrichment;
 using Yardarm.Names;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.NodaTime.Internal;
+namespace Yardarm.NodaTime;
 
 /// <summary>
 /// Enriches the JsonSerializerOptionsAttribute on the JsonSerizalizerContext class when System.Text.Json is used.
 /// </summary>
-internal sealed class JsonSourceGenerationOptionsEnricher(
+public sealed class JsonSourceGenerationOptionsEnricher(
     ISerializationNamespace serializationNamespace)
     : IEnricher<AttributeSyntax>
 {

--- a/src/main/Yardarm.NodaTime/NodaTimeExtension.cs
+++ b/src/main/Yardarm.NodaTime/NodaTimeExtension.cs
@@ -19,7 +19,7 @@ public sealed class NodaTimeExtension : YardarmExtension
         services
             .AddTypeGeneratorFactory<OpenApiSchema, NodaTimeSchemaGeneratorFactory>()
             .AddRegistrationEnricher<JsonSerializerSettingsEnricher>("JsonSerializerSettings")
-            .AddKeyedTransient<IEnricher<AttributeSyntax>, JsonSourceGenerationOptionsEnricher>("JsonSourceGenerationOptions")
+            .AddKeyedTransient<IEnricher<AttributeSyntax>, NodaTimeJsonSourceGenerationOptionsEnricher>("JsonSourceGenerationOptions")
             .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
             .AddSingleton<IDependencyGenerator, NodaTimeDependencyGenerator>()
             .AddDefaultLiteralConverterEnricher<DefaultLiteralConverterEnricher>();

--- a/src/main/Yardarm.NodaTime/NodaTimeJsonSourceGenerationOptionsEnricher.cs
+++ b/src/main/Yardarm.NodaTime/NodaTimeJsonSourceGenerationOptionsEnricher.cs
@@ -10,7 +10,7 @@ namespace Yardarm.NodaTime;
 /// <summary>
 /// Enriches the JsonSerializerOptionsAttribute on the JsonSerizalizerContext class when System.Text.Json is used.
 /// </summary>
-public sealed class JsonSourceGenerationOptionsEnricher(
+public sealed class NodaTimeJsonSourceGenerationOptionsEnricher(
     ISerializationNamespace serializationNamespace)
     : IEnricher<AttributeSyntax>
 {


### PR DESCRIPTION
Motivation
----------
Allow other extensions to reference the NodaTime enricher so they may ensure they run before or after.

Modifications
-------------
Make the class public and rename it to a name less likely to collide or confuse consumers.