### PR TITLE
Make a common NullableConverter<T> for System.Text.Json

### DIFF
--- a/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
+++ b/src/main/Yardarm.NodaTime.Client/Serialization/Json/YardarmNodaTimeJsonConverterFactory.cs
@@ -20,7 +20,7 @@ internal sealed class YardarmNodaTimeJsonConverterFactory : JsonConverterFactory
     public static JsonConverter<OffsetTime> OffsetTimeConverter { get; } =
         new NodaPatternConverter<OffsetTime>(OffsetTimePattern.Rfc3339);
     public static JsonConverter<OffsetTime?> NullableOffsetTimeConverter { get; } =
-        new NodaNullableConverter<OffsetTime>(OffsetTimeConverter);
+        new NullableConverter<OffsetTime>(OffsetTimeConverter);
 
     private readonly NodaTimeDefaultJsonConverterFactory _innerFactory = new();
 
@@ -46,37 +46,5 @@ internal sealed class YardarmNodaTimeJsonConverterFactory : JsonConverterFactory
         }
 
         return _innerFactory.CreateConverter(typeToConvert, options);
-    }
-
-    /// <summary>
-    /// Creates a new NodaNullableConverter.
-    /// </summary>
-    /// <param name="innerConverter">Inner converter for serializing and deserializing when not null.</param>
-    private sealed class NodaNullableConverter<T>(JsonConverter<T> innerConverter) : JsonConverter<T?>
-        where T : struct
-    {
-        /// <inheritdoc />
-        public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            if (reader.TokenType == JsonTokenType.Null)
-            {
-                return null;
-            }
-
-            return innerConverter.Read(ref reader, typeToConvert, options);
-        }
-
-        /// <inheritdoc />
-        public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
-        {
-            if (value is null)
-            {
-                writer.WriteNullValue();
-            }
-            else
-            {
-                innerConverter.Write(writer, value.Value, options);
-            }
-        }
     }
 }

--- a/src/main/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj
+++ b/src/main/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Yardarm.Client\Yardarm.Client.csproj" />
+    <ProjectReference Include="..\Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/main/Yardarm.SystemTextJson.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Properties/ClientAssemblyInfo.cs
@@ -2,4 +2,5 @@
 
 #if FORTESTS
 [assembly: InternalsVisibleTo("Yardarm.SystemTextJson.UnitTests")]
+[assembly: InternalsVisibleTo("Yardarm.NodaTime.Client")]
 #endif

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/NullableConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/NullableConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RootNamespace.Serialization.Json;
+
+/// <summary>
+/// Wraps an inner converter for serializing and deserializing nullable value types.
+/// </summary>
+/// <param name="innerConverter">Inner converter for serializing and deserializing when not null.</param>
+/// <remarks>
+/// While System.Text.Json has built-in support for nullable value types, this converter is useful for overriding
+/// the behavior, especially if there is another converter applied that overrides the behavior. This is included
+/// in the client so it may be easily used by other extensions, such as the NodaTime extension. The Yardarm.SystemTextJson
+/// extension doesn't currently use it directly.
+/// </remarks>
+internal sealed class NullableConverter<T>(JsonConverter<T> innerConverter) : JsonConverter<T?>
+    where T : struct
+{
+    /// <inheritdoc />
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return null;
+        }
+
+        return innerConverter.Read(ref reader, typeToConvert, options);
+    }
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, T? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+        }
+        else
+        {
+            innerConverter.Write(writer, value.Value, options);
+        }
+    }
+}

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/NullableConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/NullableConverter.cs
@@ -25,7 +25,7 @@ internal sealed class NullableConverter<T>(JsonConverter<T> innerConverter) : Js
             return null;
         }
 
-        return innerConverter.Read(ref reader, typeToConvert, options);
+        return innerConverter.Read(ref reader, typeof(T), options);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Motivation
----------
Various extensions, including Yardarm.NodaTime, need to register simple custom converters for nullable value types that wrap an inner converter and handle nulls. To prevent code duplication, make this a common internal member available with the Yardarm.SystemTextJson extension.

Modifications
-------------
- Move NodaNullableConverter to NullableConverter in the STJ client
- Add references and InternalsVisibleTo to support testing