### PR TITLE
Add support for NodaTime Offset

### DIFF
--- a/src/main/Yardarm.NodaTime.Client/Serialization/Literals/Converters/NodaLiteralConverters.cs
+++ b/src/main/Yardarm.NodaTime.Client/Serialization/Literals/Converters/NodaLiteralConverters.cs
@@ -29,6 +29,12 @@ internal static class NodaLiteralConverters
         new NodaPatternLiteralConverter<LocalTime>(LocalTimePattern.ExtendedIso);
 
     /// <summary>
+    /// Converter for UTC offsets, using the ISO-8601 offset pattern.
+    /// </summary>
+    public static LiteralConverter<Offset> OffsetConverter => field ??=
+        new NodaPatternLiteralConverter<Offset>(OffsetPattern.CreateWithInvariantCulture("+HH:mm"));
+
+    /// <summary>
     /// Converter for offset date/times.
     /// </summary>
     public static LiteralConverter<OffsetDateTime> OffsetDateTimeConverter => field ??=

--- a/src/main/Yardarm.NodaTime.Client/Serialization/Literals/Converters/NodaLiteralConverters.cs
+++ b/src/main/Yardarm.NodaTime.Client/Serialization/Literals/Converters/NodaLiteralConverters.cs
@@ -32,7 +32,7 @@ internal static class NodaLiteralConverters
     /// Converter for UTC offsets, using the ISO-8601 offset pattern.
     /// </summary>
     public static LiteralConverter<Offset> OffsetConverter => field ??=
-        new NodaPatternLiteralConverter<Offset>(OffsetPattern.CreateWithInvariantCulture("+HH:mm"));
+        new NodaPatternLiteralConverter<Offset>(OffsetPattern.GeneralInvariant);
 
     /// <summary>
     /// Converter for offset date/times.

--- a/src/main/Yardarm.NodaTime.UnitTests/Serialization/Literals/Converters/NodaPatternConverterTests.cs
+++ b/src/main/Yardarm.NodaTime.UnitTests/Serialization/Literals/Converters/NodaPatternConverterTests.cs
@@ -96,6 +96,51 @@ public class NodaPatternConverterTests
     }
 
     [Theory]
+    [InlineData("utc-offset")]
+    public void Serialize_Offset_ReturnsString(string format)
+    {
+        // Act
+
+        string result = NodaLiteralConverters.OffsetConverter.Write(
+            Offset.FromHours(-4),
+            format);
+
+        // Assert
+
+        result.Should().Be("-04:00");
+    }
+
+    [Theory]
+    [InlineData("utc-offset")]
+    public void Serialize_OffsetWithMinutes_ReturnsString(string format)
+    {
+        // Act
+
+        string result = NodaLiteralConverters.OffsetConverter.Write(
+            Offset.FromHoursAndMinutes(5, 30),
+            format);
+
+        // Assert
+
+        result.Should().Be("+05:30");
+    }
+
+    [Theory]
+    [InlineData("utc-offset")]
+    public void Serialize_OffsetZero_ReturnsString(string format)
+    {
+        // Act
+
+        string result = NodaLiteralConverters.OffsetConverter.Write(
+            Offset.Zero,
+            format);
+
+        // Assert
+
+        result.Should().Be("+00:00");
+    }
+
+    [Theory]
     [InlineData("partial-time")]
     public void Serialize_OffsetTime_ReturnsString(string format)
     {
@@ -224,6 +269,51 @@ public class NodaPatternConverterTests
         // Assert
 
         result.Should().Be(new LocalTime(13, 1, 2, 234));
+    }
+
+    [Theory]
+    [InlineData("utc-offset")]
+    public void Deserialize_Offset_ReturnsOffset(string format)
+    {
+        // Act
+
+        var result = NodaLiteralConverters.OffsetConverter.Read(
+            "-04:00",
+            format);
+
+        // Assert
+
+        result.Should().Be(Offset.FromHours(-4));
+    }
+
+    [Theory]
+    [InlineData("utc-offset")]
+    public void Deserialize_OffsetWithMinutes_ReturnsOffset(string format)
+    {
+        // Act
+
+        var result = NodaLiteralConverters.OffsetConverter.Read(
+            "+05:30",
+            format);
+
+        // Assert
+
+        result.Should().Be(Offset.FromHoursAndMinutes(5, 30));
+    }
+
+    [Theory]
+    [InlineData("utc-offset")]
+    public void Deserialize_OffsetZ_ReturnsOffset(string format)
+    {
+        // Act
+
+        var result = NodaLiteralConverters.OffsetConverter.Read(
+            "+00:00",
+            format);
+
+        // Assert
+
+        result.Should().Be(Offset.Zero);
     }
 
     [Theory]

--- a/src/main/Yardarm.NodaTime.UnitTests/Serialization/Literals/Converters/NodaPatternConverterTests.cs
+++ b/src/main/Yardarm.NodaTime.UnitTests/Serialization/Literals/Converters/NodaPatternConverterTests.cs
@@ -107,7 +107,7 @@ public class NodaPatternConverterTests
 
         // Assert
 
-        result.Should().Be("-04:00");
+        result.Should().Be("-04");
     }
 
     [Theory]
@@ -137,7 +137,7 @@ public class NodaPatternConverterTests
 
         // Assert
 
-        result.Should().Be("+00:00");
+        result.Should().Be("+00");
     }
 
     [Theory]
@@ -278,7 +278,7 @@ public class NodaPatternConverterTests
         // Act
 
         var result = NodaLiteralConverters.OffsetConverter.Read(
-            "-04:00",
+            "-04",
             format);
 
         // Assert

--- a/src/main/Yardarm.NodaTime/Helpers/NodaTimeTypes.cs
+++ b/src/main/Yardarm.NodaTime/Helpers/NodaTimeTypes.cs
@@ -24,6 +24,9 @@ internal static class NodaTimeTypes
     public static NameSyntax LocalTime { get; } =
         QualifiedName(NodaTime, IdentifierName("LocalTime"));
 
+    public static NameSyntax Offset { get; } =
+        QualifiedName(NodaTime, IdentifierName("Offset"));
+
     public static NameSyntax OffsetDateTime { get; } =
         QualifiedName(NodaTime, IdentifierName("OffsetDateTime"));
 

--- a/src/main/Yardarm.NodaTime/Internal/DefaultLiteralConverterEnricher.cs
+++ b/src/main/Yardarm.NodaTime/Internal/DefaultLiteralConverterEnricher.cs
@@ -18,6 +18,7 @@ internal sealed class DefaultLiteralConverterEnricher : ReturnValueRegistrationE
             .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("LocalTimeConverter")))
             .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("OffsetDateTimeConverter")))
             .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("OffsetTimeConverter")))
-            .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("PeriodConverter")));
+            .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("PeriodConverter")))
+            .AddLiteralConverter(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, nodaLiteralConverters, IdentifierName("OffsetConverter")));
     }
 }

--- a/src/main/Yardarm.NodaTime/Internal/NodaTimeSchemaGenerator.cs
+++ b/src/main/Yardarm.NodaTime/Internal/NodaTimeSchemaGenerator.cs
@@ -27,6 +27,7 @@ internal sealed class NodaTimeSchemaGenerator(
         "time",
         "full-time",
         "duration",
+        "utc-offset",
     }.ToFrozenSet();
 
     private static YardarmTypeInfo LocalDate => field ??= new YardarmTypeInfo(
@@ -47,6 +48,9 @@ internal sealed class NodaTimeSchemaGenerator(
     private static YardarmTypeInfo Period => field ??= new YardarmTypeInfo(
         NodaTimeTypes.Period, isGenerated: false);
 
+    private static YardarmTypeInfo Offset => field ??= new YardarmTypeInfo(
+        NodaTimeTypes.Offset, isGenerated: false);
+
     protected override YardarmTypeInfo GetTypeInfo()
     {
         YardarmTypeInfo? typeInfo = Element.Element.Format switch
@@ -57,6 +61,7 @@ internal sealed class NodaTimeSchemaGenerator(
             "partial-time" => LocalTime,
             "time" or "full-time" => OffsetTime,
             "duration" => Period,
+            "utc-offset" => Offset,
             _ => null
         };
 


### PR DESCRIPTION
Motivation
----------
Provide a consistent way to serialize and deserialize NodaTime.Offset, for both JSON and literals, using a non-standard `utc-offset` format specifier.

Modifications
-------------
Add schema handling and a literal converter.