### PR TITLE
Make C# LangVersion centrally configured

### DIFF
--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializerContextGenerator.cs
@@ -17,6 +17,7 @@ namespace Yardarm.SystemTextJson.Internal;
 /// </summary>
 internal class JsonSerializerContextGenerator(
     IJsonSerializationNamespace jsonSerializationNamespace,
+    GenerationContext context,
     [FromKeyedServices(JsonSerializerContextGenerator.AttributeEnricherKey)] IEnumerable<IEnricher<AttributeSyntax>> enrichers)
     : ISyntaxTreeGenerator
 {
@@ -56,15 +57,18 @@ internal class JsonSerializerContextGenerator(
             .WithAdditionalAnnotations(GeneratorAnnotation);
 
         return [
-            CSharpSyntaxTree.Create(CompilationUnit(
-            default,
-            default,
-            default,
-            SingletonList<MemberDeclarationSyntax>(NamespaceDeclaration(
-                jsonSerializationNamespace.Name,
-                default,
-                default,
-                SingletonList<MemberDeclarationSyntax>(classDeclaration)))))
+            CSharpSyntaxTree.Create(
+                CompilationUnit(
+                    default,
+                    default,
+                    default,
+                    SingletonList<MemberDeclarationSyntax>(NamespaceDeclaration(
+                        jsonSerializationNamespace.Name,
+                        default,
+                        default,
+                        SingletonList<MemberDeclarationSyntax>(classDeclaration)))),
+                options: context.ParseOptions,
+                encoding: System.Text.Encoding.UTF8)
         ];
     }
 }

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -3,6 +3,7 @@
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
     <File Path="../global.json" />
+    <File Path="../nuget.config" />
     <File Path="Directory.Packages.props" />
   </Folder>
   <Project Path="Yardarm.Benchmarks/Yardarm.Benchmarks.csproj" />

--- a/src/main/Yardarm/Enrichment/Compilation/IncludedFilesGenerator.cs
+++ b/src/main/Yardarm/Enrichment/Compilation/IncludedFilesGenerator.cs
@@ -26,9 +26,7 @@ public sealed class IncludedFilesGenerator(GenerationContext generationContext) 
             {
                 SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(
                     includedFile.GetSourceText(),
-                    CSharpParseOptions.Default
-                        .WithLanguageVersion(LanguageVersion.CSharp14)
-                        .WithPreprocessorSymbols(generationContext.PreprocessorSymbols),
+                    options: generationContext.ParseOptions,
                     path: PathHelpers.Combine(
                         generationContext.Settings.BasePath,
                         includedFile.SourceEmbeddingPath));

--- a/src/main/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
+++ b/src/main/Yardarm/Generation/Internal/AssemblyInfoGenerator.cs
@@ -31,6 +31,7 @@ namespace Yardarm.Generation.Internal
                 SyntaxFactory.CompilationUnit()
                     .Enrich(_enrichers)
                     .NormalizeWhitespace(),
+                options: _context.ParseOptions,
                 path: PathHelpers.Combine(_context.Settings.BasePath, "Properties", "AssemblyInfo.cs"),
                 encoding: Encoding.UTF8);
         }

--- a/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
+++ b/src/main/Yardarm/Generation/ResourceSyntaxTreeGenerator.cs
@@ -99,9 +99,7 @@ namespace Yardarm.Generation
             buffer.Dispose();
 
             SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(sourceText,
-                CSharpParseOptions.Default
-                    .WithLanguageVersion(LanguageVersion.CSharp14)
-                    .WithPreprocessorSymbols(GenerationContext.PreprocessorSymbols),
+                options: GenerationContext.ParseOptions,
                 path: PathHelpers.Combine(
                     GenerationContext.Settings.BasePath,
                     "Resources",

--- a/src/main/Yardarm/Generation/TypeGeneratorBase.cs
+++ b/src/main/Yardarm/Generation/TypeGeneratorBase.cs
@@ -45,6 +45,7 @@ namespace Yardarm.Generation
             var compilationUnit = GenerateCompilationUnit(members);
 
             return CSharpSyntaxTree.Create(compilationUnit,
+                options: Context.ParseOptions,
                 path: GetSourceFilePath(),
                 encoding: Encoding.UTF8);
         }

--- a/src/main/Yardarm/GenerationContext.cs
+++ b/src/main/Yardarm/GenerationContext.cs
@@ -55,7 +55,18 @@ namespace Yardarm
         private readonly IOptions<GenerationOptions> _options;
         internal GenerationOptions Options => _options.Value;
 
-        public LanguageVersion LanguageVersion => LanguageVersion.CSharp14;
+        public LanguageVersion LanguageVersion {
+            get;
+            set
+            {
+                if (field != value)
+                {
+                    field = value;
+
+                    _parseOptions = null;
+                }
+            }
+        } = LanguageVersion.CSharp14;
 
         public CSharpParseOptions ParseOptions => _parseOptions ??=
             CSharpParseOptions.Default

--- a/src/main/Yardarm/GenerationContext.cs
+++ b/src/main/Yardarm/GenerationContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
@@ -21,8 +22,8 @@ namespace Yardarm
         private readonly Lazy<INameFormatterSelector> _nameFormatterSelector;
         private readonly Lazy<ITypeGeneratorRegistry> _typeGeneratorRegistry;
 
-        private NuGetFramework _currentTargetFramework = NuGetFramework.UnsupportedFramework;
         private HashSet<string>? _preprocessorSymbols;
+        private CSharpParseOptions? _parseOptions;
 
         public OpenApiDocument Document => _openApiDocument.Value;
         public IOpenApiElementRegistry ElementRegistry => _elementRegistry.Value;
@@ -33,20 +34,33 @@ namespace Yardarm
 
         public NuGetFramework CurrentTargetFramework
         {
-            get => _currentTargetFramework;
+            get;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
-                _currentTargetFramework = value;
-                _preprocessorSymbols = null;
+
+                if (field != value)
+                {
+                    field = value;
+
+                    _preprocessorSymbols = null;
+                    _parseOptions = null;
+                }
             }
-        }
+        } = NuGetFramework.UnsupportedFramework;
 
         public IReadOnlySet<string> PreprocessorSymbols =>
             _preprocessorSymbols ??= GetPreprocessorSymbols(CurrentTargetFramework);
 
         private readonly IOptions<GenerationOptions> _options;
         internal GenerationOptions Options => _options.Value;
+
+        public LanguageVersion LanguageVersion => LanguageVersion.CSharp14;
+
+        public CSharpParseOptions ParseOptions => _parseOptions ??=
+            CSharpParseOptions.Default
+                .WithLanguageVersion(LanguageVersion)
+                .WithPreprocessorSymbols(PreprocessorSymbols);
 
         public GenerationContext(IServiceProvider serviceProvider) : base(serviceProvider)
         {

--- a/src/main/Yardarm/YardarmGenerator.cs
+++ b/src/main/Yardarm/YardarmGenerator.cs
@@ -166,7 +166,8 @@ namespace Yardarm
                     .ToList();
 
                 // Execute the source generators
-                compilation = ExecuteSourceGenerators(compilation,
+                compilation = ExecuteSourceGenerators(context,
+                    compilation,
                     sourceGenerators,
                     out additionalDiagnostics,
                     cancellationToken);
@@ -267,8 +268,8 @@ namespace Yardarm
             }
         }
 
-        private CSharpCompilation ExecuteSourceGenerators(CSharpCompilation compilation, IReadOnlyList<ISourceGenerator>? generators,
-            out ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken = default)
+        private CSharpCompilation ExecuteSourceGenerators(GenerationContext context, CSharpCompilation compilation,
+            IReadOnlyList<ISourceGenerator>? generators, out ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken = default)
         {
             if (generators is null || generators.Count == 0)
             {
@@ -276,7 +277,8 @@ namespace Yardarm
                 return compilation;
             }
 
-            var driver = CSharpGeneratorDriver.Create(generators);
+            var driver = CSharpGeneratorDriver.Create(generators,
+                parseOptions: context.ParseOptions);
 
             driver.RunGeneratorsAndUpdateCompilation(compilation, out var newCompilation, out diagnostics, cancellationToken);
 

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 
   <packageSourceMapping>
@@ -10,5 +11,12 @@
     <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
+
+    <!-- Uncomment below to support prerelease C# packages from dotnet-tools feed -->
+    <!--
+    <packageSource key="dotnet-tools">
+      <package pattern="Microsoft.CodeAnalysis.*" />
+    </packageSource>
+    -->
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Motivation
------------
Enable easier experimentation with preview language versions.

Modifications
---------------
- Make LangVersion a settable property on GenerationContext
- Supply CSharpParseOptions from GenerationContext using that language version on preprocessor directives
- Reuse the CSharpParseOptions at all locations that were building their own parse options, as well as several spots that were using the default parse options
- Provide a spot in nuget.config to configure NuGet to use the preview C# SDK feed