### PR TITLE
Use NuGet OIDC and other GHA improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       is-release: ${{ steps.version.outputs.is-release }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -33,12 +33,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x
@@ -73,11 +74,17 @@ jobs:
       working-directory: ./src/main
       run: dotnet pack --configuration Release -p:Version=${{ needs.version.outputs.version }}
       # Note: SDK is packed by build above, doesn't need to be packed here
+    - name: NuGet Login
+      if: ${{ needs.version.outputs.is-release == 'true' }}
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Push to NuGet.org
       if: ${{ needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
-        dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push **/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Push to GitHub Packages
       if: ${{ startsWith(github.ref, 'refs/pull/') || needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
@@ -91,12 +98,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x
@@ -122,11 +130,17 @@ jobs:
       run: ./scripts/generate-sdk.sh
 
     # Note: SDK is packed by build above, doesn't need to be packed here
+    - name: NuGet Login
+      if: ${{ needs.version.outputs.is-release == 'true' }}
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Push to NuGet.org
       if: ${{ needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
       run: |
-        dotnet nuget push **/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        dotnet nuget push **/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Push to GitHub Packages
       if: ${{ startsWith(github.ref, 'refs/pull/') || needs.version.outputs.is-release == 'true' }}
       working-directory: ./src/artifacts/package
@@ -149,6 +163,7 @@ jobs:
           type=ref,event=branch
           type=ref,event=pr
           type=semver,pattern={{version}},value=${{ needs.version.outputs.version }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ needs.version.outputs.version }}
           type=sha
 
     - name: Set up QEMU
@@ -156,7 +171,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
-    - name: Login to DockerHub
+    - name: Login to GitHub Container Registry
       uses: docker/login-action@v4
       with:
         registry: ghcr.io

--- a/.github/workflows/cleanup-packages.yml
+++ b/.github/workflows/cleanup-packages.yml
@@ -18,34 +18,40 @@ jobs:
         package-name: Yardarm
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
     - uses: actions/delete-package-versions@v5
       with:
         package-name: Yardarm.NewtonsoftJson
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
     - uses: actions/delete-package-versions@v5
       with:
         package-name: Yardarm.SystemTextJson
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
     - uses: actions/delete-package-versions@v5
       with:
         package-name: Yardarm.MicrosoftExtensionsHttp
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
+    - uses: actions/delete-package-versions@v5
+      with:
+        package-name: Yardarm.NodaTime
+        package-type: nuget
+        min-versions-to-keep: 30
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
     - uses: actions/delete-package-versions@v5
       with:
         package-name: Yardarm.CommandLine
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$
     - uses: actions/delete-package-versions@v5
       with:
         package-name: Yardarm.Sdk
         package-type: nuget
         min-versions-to-keep: 30
-        ignore-versions: ^(?!.*PullRequest).*$
+        ignore-versions: ^(?!.*alpha|.*PullRequest).*$


### PR DESCRIPTION
Motivation
----------
Security and modernization.

Modifications
-------------
- Use OIDC for NuGet push
- Upgrade GitHub Actions versions
- Include `Major.Minor` version tag on Docker
- Include `alpha` NuGet package tags in package cleanup since we changed version numbering for PRs recently
- Include NodaTime packages in cleanup