### PR TITLE
Newtonsoft.Json support for externally discriminated unions

### DIFF
--- a/src/main/Yardarm.Client/Internal/ExternallyDiscriminatedUnion.extdunions.cs
+++ b/src/main/Yardarm.Client/Internal/ExternallyDiscriminatedUnion.extdunions.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using RootNamespace.Models;
+
+namespace RootNamespace.Internal;
+
+internal static class ExternallyDiscriminatedUnion<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
+    where T : IUnion
+{
+    public sealed class CaseInfo(string caseName, Type caseType, Func<object, T> factory)
+    {
+        public readonly string CaseName = caseName;
+        public readonly Type CaseType = caseType;
+        public readonly Func<object, T> Factory = factory;
+    }
+
+    public static FrozenDictionary<string, CaseInfo> CasesByName { get; }
+    public static FrozenDictionary<Type, CaseInfo> CasesByType { get; }
+    public static Func<object, T>? UnknownCaseFactory { get; }
+
+    static ExternallyDiscriminatedUnion()
+    {
+        var casesByName = new Dictionary<string, CaseInfo>();
+        var casesByType = new Dictionary<Type, CaseInfo>();
+
+        foreach (ConstructorInfo constructor in typeof(T).GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+        {
+            ParameterInfo[] parameters = constructor.GetParameters();
+            if (parameters.Length == 1 && parameters[0] is { ParameterType: Type parameterType })
+            {
+                if (parameterType == typeof(UnknownCase))
+                {
+                    UnknownCaseFactory = CreateCaseFactory(constructor, parameterType);
+                }
+                else
+                {
+                    var attribute = constructor.GetCustomAttribute<UnionCaseNameAttribute>();
+                    if (attribute is null)
+                    {
+                        continue;
+                    }
+
+                    var caseInfo = new CaseInfo(attribute.CaseName, parameterType,
+                        CreateCaseFactory(constructor, parameterType));
+
+                    casesByName[attribute.CaseName] = caseInfo;
+                    casesByType[parameterType] = caseInfo;
+                }
+            }
+        }
+
+        CasesByName = casesByName.ToFrozenDictionary();
+        CasesByType = casesByType.ToFrozenDictionary();
+    }
+
+    private static Func<object, T> CreateCaseFactory(ConstructorInfo constructor, Type parameterType)
+    {
+        ArgumentNullException.ThrowIfNull(constructor);
+        ArgumentNullException.ThrowIfNull(parameterType);
+
+#if NETCOREAPP3_0_OR_GREATER
+        if (RuntimeFeature.IsDynamicCodeCompiled)
+        {
+#endif
+            // More performant option that is dynamically compiled to avoid using reflection on each invocation
+            ParameterExpression parameterExpression = Expression.Parameter(typeof(object), "value");
+
+            NewExpression newExpression = Expression.New(
+                constructor,
+                Expression.Convert(parameterExpression, parameterType));
+
+            return Expression
+                .Lambda<Func<object, T>>(newExpression, parameterExpression)
+                .Compile();
+#if NETCOREAPP3_0_OR_GREATER
+        }
+        else
+        {
+            // Fallback for scenarios where JIT is not supported
+            return (value) => (T)constructor.Invoke([value]);
+        }
+#endif
+    }
+}

--- a/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.Client/Properties/ClientAssemblyInfo.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Yardarm.Client.UnitTests")]
 [assembly: InternalsVisibleTo("Yardarm.MicrosoftExtensionsHttp.Client")]
 [assembly: InternalsVisibleTo("Yardarm.NewtonsoftJson.Client")]
+[assembly: InternalsVisibleTo("Yardarm.NewtonsoftJson.UnitTests")]
 [assembly: InternalsVisibleTo("Yardarm.NodaTime.Client")]
 [assembly: InternalsVisibleTo("Yardarm.SystemTextJson.Client")]
 [assembly: InternalsVisibleTo("Yardarm.SystemTextJson.UnitTests")]

--- a/src/main/Yardarm.NewtonsoftJson.Client/Properties/ClientAssemblyInfo.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Properties/ClientAssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Runtime.CompilerServices;
+
+#if FORTESTS
+[assembly: InternalsVisibleTo("Yardarm.NewtonsoftJson.UnitTests")]
+#endif

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using System.Text.Json.Serialization.Metadata;
+using Newtonsoft.Json;
 using RootNamespace.Internal;
 using RootNamespace.Models;
 
@@ -14,17 +12,22 @@ namespace RootNamespace.Serialization.Json;
 /// Constructors must be annotated with <see cref="UnionCaseNameAttribute"/>.
 /// </summary>
 /// <typeparam name="T">Type of the union.</typeparam>
-internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
-    : JsonConverter<T>
+internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConverter
     where T : IUnion
 {
-    public override bool HandleNull => false;
+    public override bool CanConvert(Type objectType) => objectType == typeof(T);
 
-    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
-        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(serializer);
 
-        if (reader.TokenType != JsonTokenType.StartObject)
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return default;
+        }
+
+        if (reader.TokenType != JsonToken.StartObject)
         {
             JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
         }
@@ -35,21 +38,20 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
             JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
         }
 
-        T? result = default;
-        bool foundResult = false;
+        object? result = null;
         string? firstPropertyName = null;
 
-        while (reader.TokenType != JsonTokenType.EndObject)
+        while (reader.TokenType != JsonToken.EndObject)
         {
-            if (reader.TokenType != JsonTokenType.PropertyName)
+            if (reader.TokenType != JsonToken.PropertyName)
             {
                 JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
             }
 
-            string? propertyName = reader.GetString();
+            string? propertyName = (string?)reader.Value;
             firstPropertyName ??= propertyName;
 
-            if (!foundResult
+            if (result is null
                 && propertyName is not null
                 && ExternallyDiscriminatedUnion<T>.CasesByName.TryGetValue(propertyName, out var caseInfo))
             {
@@ -59,8 +61,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
                     JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
                 }
 
-                JsonTypeInfo typeInfo = options.GetTypeInfo(caseInfo.CaseType);
-                object? value = JsonSerializer.Deserialize(ref reader, typeInfo);
+                object? value = serializer.Deserialize(reader, caseInfo.CaseType);
                 if (value is null)
                 {
                     // Null is not a valid union case
@@ -68,7 +69,6 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
                 }
 
                 result = caseInfo.Factory(value);
-                foundResult = true;
 
                 // Advance past the value token
                 if (!reader.Read())
@@ -89,15 +89,27 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
             }
         }
 
-        return foundResult ? result : CreateUnknownCase(firstPropertyName);
+        return result ?? CreateUnknownCase(firstPropertyName);
     }
 
-    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         ArgumentNullException.ThrowIfNull(writer);
-        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(serializer);
 
-        object? innerValue = value.Value;
+        if (value is null)
+        {
+            writer.WriteNull();
+            return;
+        }
+
+        if (value is not T union)
+        {
+            ThrowHelper.ThrowInvalidOperationException("Cannot serialize value of type '{value.GetType()}' as union type '{typeof(T)}'.");
+            return;
+        }
+
+        object? innerValue = union.Value;
         if (innerValue is not null)
         {
             writer.WriteStartObject();
@@ -116,8 +128,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
                 {
                     writer.WritePropertyName(caseInfo.CaseName);
 
-                    JsonTypeInfo typeInfo = options.GetTypeInfo(caseInfo.CaseType);
-                    JsonSerializer.Serialize(writer, innerValue, typeInfo);
+                    serializer.Serialize(writer, innerValue, caseInfo.CaseType);
 
                     writer.WriteEndObject();
                     return;
@@ -148,17 +159,17 @@ internal static class JsonDiscriminatedUnionConverter
 {
     [DoesNotReturn]
     public static void ThrowInvalidUnionJson(Type unionType)
-        => throw new JsonException($"Invalid JSON for union type '{unionType.FullName}'.");
+        => throw new JsonSerializationException($"Invalid JSON for union type '{unionType.FullName}'.");
 
     [DoesNotReturn]
     public static void ThrowUnknownUnionCaseType(Type unionType, Type? caseType)
-        => throw new JsonException(caseType is not null
+        => throw new JsonSerializationException(caseType is not null
             ? $"Union type '{unionType.FullName}' does not have a case with type '{caseType.FullName}'."
             : $"Union type '{unionType.FullName}' may not contain a null value.");
 
     [DoesNotReturn]
     public static void ThrowUnknownUnionCase(Type unionType, string? caseName)
-        => throw new JsonException(caseName is not null
+        => throw new JsonSerializationException(caseName is not null
             ? $"Union type '{unionType.FullName}' does not have a case '{caseName}'."
             : $"Union type '{unionType.FullName}' does not have an unknown case.");
 }

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
@@ -105,7 +105,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
 
         if (value is not T union)
         {
-            ThrowHelper.ThrowInvalidOperationException("Cannot serialize value of type '{value.GetType()}' as union type '{typeof(T)}'.");
+            ThrowHelper.ThrowInvalidOperationException($"Cannot serialize value of type '{value.GetType().FullName}' as union type '{typeof(T).FullName}'.");
             return;
         }
 

--- a/src/main/Yardarm.NewtonsoftJson.UnitTests/Client/JsonExternallyDiscriminatedUnionConverterTests.cs
+++ b/src/main/Yardarm.NewtonsoftJson.UnitTests/Client/JsonExternallyDiscriminatedUnionConverterTests.cs
@@ -1,0 +1,449 @@
+﻿using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+using RootNamespace.Internal;
+using RootNamespace.Models;
+using RootNamespace.Serialization.Json;
+using Xunit;
+
+#nullable enable
+
+namespace Yardarm.NewtonsoftJson.UnitTests.Client;
+
+public class JsonExternallyDiscriminatedUnionConverterTests
+{
+    private static readonly JsonSerializerSettings s_settings = new()
+    {
+        ContractResolver = new Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver(),
+    };
+
+    #region Deserialize
+
+    [Fact]
+    public void Deserialize_CaseA()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseA": {
+                "name": "Test"
+            }
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnion>(json, s_settings);
+
+        // Assert
+
+        var value = Assert.IsType<CaseA>(result.Value);
+        Assert.Equal("Test", value.Name);
+    }
+
+    [Fact]
+    public void Deserialize_CaseB()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseB": {
+                "type": "caseB",
+                "id": 123
+            }
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnion>(json, s_settings);
+
+        // Assert
+
+        var value = Assert.IsType<CaseB>(result.Value);
+        Assert.Equal(123, value.Id);
+    }
+
+    [Fact]
+    public void Deserialize_CaseBChild()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseB": {
+                "type": "caseBChild",
+                "id": 123,
+                "name": "Test"
+            }
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnion>(json, s_settings);
+
+        // Assert
+
+        var value = Assert.IsType<CaseBChild>(result.Value);
+        Assert.Equal(123, value.Id);
+        Assert.Equal("Test", value.Name);
+    }
+
+    [Theory]
+    [InlineData("""
+        {
+            "caseA": {
+                "name": "Test"
+            },
+            "ignored": true,
+            "metadata": {
+                "source": "api"
+            }
+        }
+        """)]
+    [InlineData("""
+        {
+            "ignored": true,
+            "caseA": {
+                "name": "Test"
+            },
+            "metadata": {
+                "source": "api"
+            }
+        }
+        """)]
+    [InlineData("""
+        {
+            "ignored": true,
+            "metadata": {
+                "source": "api"
+            },
+            "caseA": {
+                "name": "Test"
+            }
+        }
+        """)]
+    public void Deserialize_CaseA_WithAdditionalProperties_IgnoresExtras(string json)
+    {
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnion>(json, s_settings);
+
+        // Assert
+
+        var value = Assert.IsType<CaseA>(result.Value);
+        Assert.Equal("Test", value.Name);
+    }
+
+    [Fact]
+    public void Deserialize_CaseA_InOuterDto()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "union": {
+                "caseA": {
+                    "name": "Test"
+                }
+            },
+            "otherValue": "foobar"
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<OuterDto>(json, s_settings);
+
+        // Assert
+
+        Assert.NotNull(result);
+        var value = Assert.IsType<CaseA>(result.Union.Value);
+        Assert.Equal("Test", value.Name);
+        Assert.Equal("foobar", result.OtherValue);
+    }
+
+    [Fact]
+    public void Deserialize_EmptyObject_InOuterDtoWithUnknownCase_Returned()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "union": {
+            },
+            "otherValue": "foobar"
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<OuterWithUnknownDto>(json, s_settings);
+
+        // Assert
+
+        Assert.NotNull(result);
+        Assert.IsType<UnknownCase>(result.Union.Value);
+        Assert.Equal("foobar", result.OtherValue);
+    }
+
+    [Theory]
+    [InlineData("""
+        {
+            "caseC": {
+                "value": "unknown"
+            }
+        }
+        """)]
+    [InlineData("{}")]
+    public void Deserialize_NoUnknownCase_Throws(string json)
+    {
+        // Act/Assert
+
+        Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<TestUnion>(json, s_settings));
+    }
+
+    [Theory]
+    [InlineData("""
+        {
+            "caseC": {
+                "value": "unknown"
+            }
+        }
+        """)]
+    [InlineData("""
+        {
+        }
+        """)]
+    public void Deserialize_HasUnknownCase_Returned(string json)
+    {
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnionWithUnknown>(json, s_settings);
+
+        // Assert
+
+        Assert.IsType<UnknownCase>(result.Value);
+    }
+
+    [Fact]
+    public void Deserialize_NullUnion_ReturnsNull()
+    {
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnion?>("null", s_settings);
+
+        // Assert
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Deserialize_NullInnerValue_Throws()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseA": null
+        }
+        """;
+
+        // Act
+
+        var ex = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<TestUnion>(json, s_settings));
+
+        // Assert
+
+        Assert.Contains("Invalid JSON for union type", ex.Message);
+    }
+
+    #endregion
+
+    #region Serialize
+
+    [Fact]
+    public void Serialize_CaseA()
+    {
+        // Arrange
+
+        var union = new TestUnion(new CaseA()
+        {
+            Name = "Test"
+        });
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("{\"caseA\":{\"name\":\"Test\"}}", result);
+    }
+
+    [Fact]
+    public void Serialize_CaseB()
+    {
+        // Arrange
+
+        var union = new TestUnion(new CaseB()
+        {
+            Id = 123,
+            Type = "caseBChild"
+        });
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("{\"caseB\":{\"type\":\"caseBChild\",\"id\":123}}", result);
+    }
+
+    [Fact]
+    public void Serialize_CaseBChild()
+    {
+        // Arrange
+
+        var union = new TestUnion(new CaseBChild()
+        {
+            Id = 123,
+            Name = "Test",
+            Type = "caseBChild"
+        });
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("{\"caseB\":{\"name\":\"Test\",\"type\":\"caseBChild\",\"id\":123}}", result);
+    }
+
+    [Fact]
+    public void Serialize_NullUnion_WritesNull()
+    {
+        // Arrange
+
+        TestUnion? union = null;
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("null", result);
+    }
+
+    [Fact]
+    public void Serialize_UnknownCase()
+    {
+        // Arrange
+
+        var union = new TestUnionWithUnknown(UnknownCase.Value);
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public void Serialize_Default_Throws()
+    {
+        // Act
+
+        var ex = Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(default(TestUnion), s_settings));
+
+        // Assert
+
+        Assert.Contains("may not contain a null value", ex.Message);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private class CaseA
+    {
+        public string? Name { get; set; }
+    }
+
+
+    [JsonConverter(typeof(DiscriminatorConverter),
+        [
+            "type",
+            typeof(ICaseB),
+            new object[] {
+                "caseB", typeof(CaseB),
+                "caseBChild", typeof(CaseBChild)
+            }
+        ])]
+    private class CaseB : ICaseB
+    {
+        public string? Type { get; set; }
+        public int Id { get; set; }
+    }
+
+    private interface ICaseB
+    {
+        public int Id { get; set; }
+    }
+
+    private class CaseBChild : CaseB
+    {
+        public string? Name { get; set; }
+    }
+
+    [Union]
+    [JsonConverter(typeof(JsonExternallyDiscriminatedUnionConverter<TestUnion>))]
+    private readonly struct TestUnion : IUnion
+    {
+        public object? Value { get; }
+
+        [UnionCaseName("caseA")]
+        public TestUnion(CaseA value) => Value = value;
+
+        [UnionCaseName("caseB")]
+        public TestUnion(CaseB value) => Value = value;
+    }
+
+    [Union]
+    [JsonConverter(typeof(JsonExternallyDiscriminatedUnionConverter<TestUnionWithUnknown>))]
+    private readonly struct TestUnionWithUnknown : IUnion
+    {
+        public object? Value { get; }
+
+        [UnionCaseName("caseA")]
+        public TestUnionWithUnknown(CaseA value) => Value = value;
+
+        [UnionCaseName("caseB")]
+        public TestUnionWithUnknown(CaseB value) => Value = value;
+
+        public TestUnionWithUnknown(UnknownCase value) => Value = value;
+    }
+
+    private sealed class OuterDto
+    {
+        public TestUnion Union { get; set; }
+
+        public string? OtherValue { get; set; }
+    }
+
+    private sealed class OuterWithUnknownDto
+    {
+        public TestUnionWithUnknown Union { get; set; }
+
+        public string? OtherValue { get; set; }
+    }
+
+    #endregion
+}

--- a/src/main/Yardarm.NewtonsoftJson.UnitTests/Yardarm.NewtonsoftJson.UnitTests.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.UnitTests/Yardarm.NewtonsoftJson.UnitTests.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Yardarm.NewtonsoftJson\Yardarm.NewtonsoftJson.csproj" />
+    <ProjectReference Include="..\Yardarm.NewtonsoftJson.Client\Yardarm.NewtonsoftJson.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
@@ -1,16 +1,17 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace Yardarm.NewtonsoftJson
-{
-    public interface IJsonSerializationNamespace
-    {
-        NameSyntax Name { get; }
-        NameSyntax DiscriminatorConverter { get; }
-        NameSyntax DynamicAdditionalPropertiesDictionary { get; }
-        NameSyntax JsonTypeSerializer { get; }
-        NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
-        public NameSyntax OpenApiDateConverter { get; }
+namespace Yardarm.NewtonsoftJson;
 
-        TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType);
-    }
+public interface IJsonSerializationNamespace
+{
+    NameSyntax Name { get; }
+    NameSyntax DiscriminatorConverter { get; }
+    NameSyntax DynamicAdditionalPropertiesDictionary { get; }
+    NameSyntax JsonTypeSerializer { get; }
+    NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
+    public NameSyntax OpenApiDateConverter { get; }
+
+    TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType);
+
+    TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType);
 }

--- a/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
@@ -3,52 +3,54 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Yardarm.Names;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-namespace Yardarm.NewtonsoftJson.Internal
+namespace Yardarm.NewtonsoftJson.Internal;
+
+internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationNamespace
 {
-    internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationNamespace
+    public NameSyntax Name { get; }
+    public NameSyntax DiscriminatorConverter { get; }
+    public NameSyntax DynamicAdditionalPropertiesDictionary { get; }
+    public NameSyntax JsonTypeSerializer { get; }
+    public NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
+    public NameSyntax OpenApiDateConverter { get; }
+
+    public JsonSerializationNamespace(ISerializationNamespace serializationNamespace)
     {
-        public NameSyntax Name { get; }
-        public NameSyntax DiscriminatorConverter { get; }
-        public NameSyntax DynamicAdditionalPropertiesDictionary { get; }
-        public NameSyntax JsonTypeSerializer { get; }
-        public NameSyntax NullableDynamicAdditionalPropertiesDictionary { get; }
-        public NameSyntax OpenApiDateConverter { get; }
+        ArgumentNullException.ThrowIfNull(serializationNamespace);
 
-        public JsonSerializationNamespace(ISerializationNamespace serializationNamespace)
-        {
-            ArgumentNullException.ThrowIfNull(serializationNamespace);
+        Name = QualifiedName(
+            serializationNamespace.Name,
+            IdentifierName("Json"));
 
-            Name = QualifiedName(
-                serializationNamespace.Name,
-                IdentifierName("Json"));
+        DiscriminatorConverter = QualifiedName(
+            Name,
+            IdentifierName("DiscriminatorConverter"));
 
-            DiscriminatorConverter = QualifiedName(
-                Name,
-                IdentifierName("DiscriminatorConverter"));
+        DynamicAdditionalPropertiesDictionary = QualifiedName(
+            Name,
+            IdentifierName("DynamicAdditionalPropertiesDictionary"));
 
-            DynamicAdditionalPropertiesDictionary = QualifiedName(
-                Name,
-                IdentifierName("DynamicAdditionalPropertiesDictionary"));
+        JsonTypeSerializer = QualifiedName(
+            Name,
+            IdentifierName("JsonTypeSerializer"));
 
-            JsonTypeSerializer = QualifiedName(
-                Name,
-                IdentifierName("JsonTypeSerializer"));
+        NullableDynamicAdditionalPropertiesDictionary = QualifiedName(
+            Name,
+            IdentifierName("NullableDynamicAdditionalPropertiesDictionary"));
 
-            NullableDynamicAdditionalPropertiesDictionary = QualifiedName(
-                Name,
-                IdentifierName("NullableDynamicAdditionalPropertiesDictionary"));
-
-            OpenApiDateConverter = QualifiedName(
-                Name,
-                IdentifierName("OpenApiDateConverter"));
-        }
-
-        public TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType) =>
-            QualifiedName(
-                Name,
-                GenericName(
-                    Identifier("AdditionalPropertiesDictionary"),
-                    TypeArgumentList(SingletonSeparatedList(valueType))));
-
+        OpenApiDateConverter = QualifiedName(
+            Name,
+            IdentifierName("OpenApiDateConverter"));
     }
+
+    public TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType) =>
+        QualifiedName(
+            Name,
+            GenericName(
+                Identifier("AdditionalPropertiesDictionary"),
+                TypeArgumentList(SingletonSeparatedList(valueType))));
+
+    public TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType) =>
+        QualifiedName(Name, GenericName(Identifier("JsonExternallyDiscriminatedUnionConverter"),
+            TypeArgumentList(SingletonSeparatedList(schemaType))));
 }

--- a/src/main/Yardarm.NewtonsoftJson/JsonDiscriminatedUnionEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonDiscriminatedUnionEnricher.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.NewtonsoftJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.NewtonsoftJson;
+
+public sealed class JsonDiscriminatedUnionEnricher(
+    IJsonSerializationNamespace jsonSerializationNamespace)
+    : IOpenApiSyntaxNodeEnricher<StructDeclarationSyntax, OpenApiSchema>
+{
+    public StructDeclarationSyntax Enrich(StructDeclarationSyntax target,
+        OpenApiEnrichmentContext<OpenApiSchema> context) =>
+        target.IsExternallyDiscriminatedUnion()
+            ? AddJsonConverter(target)
+            : target;
+
+    private StructDeclarationSyntax AddJsonConverter(StructDeclarationSyntax target)
+    {
+        TypeSyntax converterType = jsonSerializationNamespace.JsonExternallyDiscriminatedUnionConverterName(IdentifierName(target.Identifier));
+
+        return target.AddAttributeLists(
+            AttributeList(SingletonSeparatedList(Attribute(NewtonsoftJsonTypes.JsonConverterAttributeName,
+                AttributeArgumentList(
+                    SingletonSeparatedList(AttributeArgument(TypeOfExpression(converterType)))))))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -22,6 +22,7 @@ namespace Yardarm.NewtonsoftJson
                 .AddOpenApiSyntaxNodeEnricher<JsonEnumEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatedUnionEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
 

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -13,6 +13,7 @@
   <Project Path="Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj" />
   <Project Path="Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj" />
   <Project Path="Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj" />
+  <Project Path="Yardarm.NewtonsoftJson.UnitTests/Yardarm.NewtonsoftJson.UnitTests.csproj" />
   <Project Path="Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj" />
   <Project Path="Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj" />
   <Project Path="Yardarm.NodaTime.UnitTests/Yardarm.NodaTime.UnitTests.csproj" />


### PR DESCRIPTION
Motivation
----------
Mirror our deserialization support for externally discriminated unions for STJ in Newtonsoft.

Modifications
-------------
- Move some common static information to Yardarm.Client in `ExternallyDiscriminatedUnion<T>`
- Cleanup STJ read handling, which had some dead code and didn't give the property name in the exception when it doesn't match
- Implement the JsonConverter in Yardarm.NewtonsoftJson.Client
- Add Newtonsoft unit tests to cover the converter
- Add the JsonConverter attribute to the schema type