### PR TITLE
Add LiteralConverterAttribute to override conversion behavior

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using FluentAssertions;
 using RootNamespace.Serialization.Literals;
+using RootNamespace.Serialization.Literals.Converters;
 using Xunit;
 
 namespace Yardarm.Client.UnitTests.Serialization
@@ -31,6 +32,18 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be("105");
+        }
+
+        [Fact]
+        public void Serialize_CustomConverter_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize(new IntWrapper(105));
+
+            // Assert
+
+            result.Should().Be("106");
         }
 
         [Fact]
@@ -835,6 +848,18 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void Deserialize_CustomConverter_ReturnsString()
+        {
+            // Act
+
+            IntWrapper result = LiteralSerializer.Deserialize<IntWrapper>("106");
+
+            // Assert
+
+            result.Value.Should().Be(105);
+        }
+
+        [Fact]
         public void Deserialize_Long_ReturnsString()
         {
             // Act
@@ -1081,5 +1106,16 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         #endregion
+
+        [LiteralConverter(typeof(CustomConverter))]
+        private readonly record struct IntWrapper(int Value);
+
+        private sealed class CustomConverter : ValueTypeLiteralConverter<IntWrapper>
+        {
+            private readonly Int32LiteralConverter _innerConverter = new();
+
+            public override string Write(IntWrapper value, string format) => checked(_innerConverter.Write(value.Value + 1, format));
+            protected override IntWrapper ReadCore(string value, string format) => checked(new IntWrapper(_innerConverter.Read(value, format) - 1));
+        }
     }
 }

--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -47,6 +47,30 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
+        public void Serialize_NullableCustomConverter_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize<IntWrapper?>(new IntWrapper(105));
+
+            // Assert
+
+            result.Should().Be("106");
+        }
+
+        [Fact]
+        public void Serialize_NullableCustomConverter_ReturnsEmptyStringForNull()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize<IntWrapper?>(null);
+
+            // Assert
+
+            result.Should().Be("");
+        }
+
+        [Fact]
         public void Serialize_Long_ReturnsString()
         {
             // Act
@@ -848,7 +872,7 @@ namespace Yardarm.Client.UnitTests.Serialization
         }
 
         [Fact]
-        public void Deserialize_CustomConverter_ReturnsString()
+        public void Deserialize_CustomConverter_ReturnsValue()
         {
             // Act
 
@@ -857,6 +881,31 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Value.Should().Be(105);
+        }
+
+        [Fact]
+        public void Deserialize_NullableCustomConverter_ReturnsValue()
+        {
+            // Act
+
+            IntWrapper? result = LiteralSerializer.Deserialize<IntWrapper?>("106");
+
+            // Assert
+
+            result.Should().NotBeNull();
+            result.Value.Value.Should().Be(105);
+        }
+
+        [Fact]
+        public void Deserialize_NullableCustomConverter_ReturnsNull()
+        {
+            // Act
+
+            IntWrapper? result = LiteralSerializer.Deserialize<IntWrapper?>(null);
+
+            // Assert
+
+            result.Should().BeNull();
         }
 
         [Fact]
@@ -1107,7 +1156,7 @@ namespace Yardarm.Client.UnitTests.Serialization
 
         #endregion
 
-        [LiteralConverter(typeof(CustomConverter))]
+        [LiteralConverter(typeof(CustomConverter), typeof(NullableLiteralConverter<IntWrapper>))]
         private readonly record struct IntWrapper(int Value);
 
         private sealed class CustomConverter : ValueTypeLiteralConverter<IntWrapper>

--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -1156,7 +1156,7 @@ namespace Yardarm.Client.UnitTests.Serialization
 
         #endregion
 
-        [LiteralConverter(typeof(CustomConverter), typeof(NullableLiteralConverter<IntWrapper>))]
+        [LiteralConverter(typeof(CustomConverter))]
         private readonly record struct IntWrapper(int Value);
 
         private sealed class CustomConverter : ValueTypeLiteralConverter<IntWrapper>

--- a/src/main/Yardarm.Client/Serialization/Literals/Converters/ValueTypeLiteralConverter.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/Converters/ValueTypeLiteralConverter.cs
@@ -1,9 +1,12 @@
-﻿namespace RootNamespace.Serialization.Literals.Converters;
+﻿using System;
+
+namespace RootNamespace.Serialization.Literals.Converters;
 
 /// <summary>
 /// Base type of literal converters for value types.
 /// </summary>
-internal abstract class ValueTypeLiteralConverter<T> : LiteralConverter<T> where T : struct
+internal abstract class ValueTypeLiteralConverter<T> : LiteralConverter<T>, IValueTypeLiteralConverter
+    where T : struct
 {
     public sealed override T Read(string? value, string? format)
     {
@@ -16,4 +19,22 @@ internal abstract class ValueTypeLiteralConverter<T> : LiteralConverter<T> where
     }
 
     protected abstract T ReadCore(string value, string? format);
+
+    /// <summary>
+    /// Creates a literal converter for the nullable version of <typeparamref name="T"/>.
+    /// </summary>
+    /// <returns>A new literal converter for the nullable version of <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is already a nullable type.</exception>
+    public virtual LiteralConverter<T?> CreateNullableConverter()
+    {
+        if (Nullable.GetUnderlyingType(typeof(T)) is not null)
+        {
+            ThrowHelper.ThrowInvalidOperationException($"Type '{typeof(T).FullName}' is already a nullable type.");
+        }
+
+        return new NullableLiteralConverter<T>(this);
+    }
+
+    /// <inheritdoc />
+    LiteralConverter IValueTypeLiteralConverter.CreateNullableConverter() => CreateNullableConverter();
 }

--- a/src/main/Yardarm.Client/Serialization/Literals/IValueTypeLiteralConverter.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/IValueTypeLiteralConverter.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace RootNamespace.Serialization.Literals;
+
+/// <summary>
+/// Interface for literal converters for value types that can create a converter for the nullable version of the type.
+/// </summary>
+internal interface IValueTypeLiteralConverter
+{
+    /// <summary>
+    /// Creates a literal converter for the nullable version of this value type.
+    /// </summary>
+    /// <returns>A new literal converter for the nullable version of this type.</returns>
+    /// <exception cref="InvalidOperationException">The type is already a nullable type.</exception>
+    LiteralConverter CreateNullableConverter();
+}

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
@@ -3,25 +3,34 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace RootNamespace.Serialization.Literals;
 
+/// <summary>
+/// Specifies a literal converter to use for a type when serializing and deserializing literals.
+/// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
 internal class LiteralConverterAttribute : Attribute
 {
+    /// <summary>
+    /// Gets the type of the literal converter to use for the type this attribute is applied to.
+    /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type ConverterType { get; }
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
-    public Type? NullableConverterType { get; }
-
-    public LiteralConverterAttribute(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? nullableConverterType = null)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LiteralConverterAttribute"/> class with the specified converter type.
+    /// </summary>
+    /// <param name="converterType">The type of the literal converter to use. The type must be a <see cref="LiteralConverter"/> for the type this attribute is applied to and have a public parameterless constructor.</param>
+    public LiteralConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType)
     {
         ArgumentNullException.ThrowIfNull(converterType);
 
         ConverterType = converterType;
-        NullableConverterType = nullableConverterType;
     }
 
+    /// <summary>
+    /// Create a new instance of the <see cref="LiteralConverter"/> specified by <see cref="ConverterType"/>.
+    /// </summary>
+    /// <returns>A new instance of the specified <see cref="LiteralConverter"/>.</returns>
+    /// <example cref="InvalidOperationException">The specified <see cref="ConverterType"/> is not a valid <see cref="LiteralConverter"/>.</example>
     public LiteralConverter CreateConverter()
     {
         object? obj = Activator.CreateInstance(ConverterType);
@@ -32,24 +41,6 @@ internal class LiteralConverterAttribute : Attribute
         }
 
         ThrowHelper.ThrowInvalidOperationException($"Type '{ConverterType.FullName}' is not a valid LiteralConverter.");
-        return null!;
-    }
-
-    public LiteralConverter? CreateNullableConverter()
-    {
-        if (NullableConverterType is not Type nullableConverterType)
-        {
-            return null;
-        }
-
-        object? obj = Activator.CreateInstance(nullableConverterType, [CreateConverter()]);
-
-        if (obj is LiteralConverter converter)
-        {
-            return converter;
-        }
-
-        ThrowHelper.ThrowInvalidOperationException($"Type '{nullableConverterType.FullName}' is not a valid LiteralConverter.");
         return null!;
     }
 }

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace RootNamespace.Serialization.Literals;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
+public sealed class LiteralConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type) : Attribute
+{
+    public Type Type => type;
+
+    public LiteralConverter CreateConverter() => (LiteralConverter)Activator.CreateInstance(type)!;
+}

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
@@ -4,20 +4,52 @@ using System.Diagnostics.CodeAnalysis;
 namespace RootNamespace.Serialization.Literals;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, Inherited = false, AllowMultiple = false)]
-public sealed class LiteralConverterAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type type) : Attribute
+internal class LiteralConverterAttribute : Attribute
 {
-    public Type Type => type;
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public Type ConverterType { get; }
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public Type? NullableConverterType { get; }
+
+    public LiteralConverterAttribute(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type converterType,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type? nullableConverterType = null)
+    {
+        ArgumentNullException.ThrowIfNull(converterType);
+
+        ConverterType = converterType;
+        NullableConverterType = nullableConverterType;
+    }
 
     public LiteralConverter CreateConverter()
     {
-        object? obj = Activator.CreateInstance(type);
+        object? obj = Activator.CreateInstance(ConverterType);
 
         if (obj is LiteralConverter converter)
         {
             return converter;
         }
 
-        ThrowHelper.ThrowInvalidOperationException($"Type '{type.FullName}' is not a valid LiteralConverter.");
+        ThrowHelper.ThrowInvalidOperationException($"Type '{ConverterType.FullName}' is not a valid LiteralConverter.");
+        return null!;
+    }
+
+    public LiteralConverter? CreateNullableConverter()
+    {
+        if (NullableConverterType is not Type nullableConverterType)
+        {
+            return null;
+        }
+
+        object? obj = Activator.CreateInstance(nullableConverterType, [CreateConverter()]);
+
+        if (obj is LiteralConverter converter)
+        {
+            return converter;
+        }
+
+        ThrowHelper.ThrowInvalidOperationException($"Type '{nullableConverterType.FullName}' is not a valid LiteralConverter.");
         return null!;
     }
 }

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterAttribute.cs
@@ -8,5 +8,16 @@ public sealed class LiteralConverterAttribute([DynamicallyAccessedMembers(Dynami
 {
     public Type Type => type;
 
-    public LiteralConverter CreateConverter() => (LiteralConverter)Activator.CreateInstance(type)!;
+    public LiteralConverter CreateConverter()
+    {
+        object? obj = Activator.CreateInstance(type);
+
+        if (obj is LiteralConverter converter)
+        {
+            return converter;
+        }
+
+        ThrowHelper.ThrowInvalidOperationException($"Type '{type.FullName}' is not a valid LiteralConverter.");
+        return null!;
+    }
 }

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -90,9 +90,22 @@ public sealed class LiteralConverterRegistry
     /// <returns>True if the converter was found, otherwise false.</returns>
     public bool TryGet<T>([NotNullWhen(true)] out LiteralConverter<T>? converter)
     {
-        converter = DynamicConverters.GetOrAdd(typeof(T), CreateConverter) as LiteralConverter<T>;
+        converter = null;
 
-        return converter is not null;
+        LiteralConverter? result = DynamicConverters.GetOrAdd(typeof(T), CreateConverter);
+        if (result is null)
+        {
+            return false;
+        }
+
+        if (result is LiteralConverter<T> typedResult)
+        {
+            converter = typedResult;
+            return true;
+        }
+
+        ThrowHelper.ThrowInvalidOperationException($"Registered converter for type '{typeof(T).FullName}' is not of the expected type '{typeof(LiteralConverter<T>).FullName}'.");
+        return false;
     }
 
     private LiteralConverter? CreateConverter(Type type)

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -99,14 +99,16 @@ public sealed class LiteralConverterRegistry
 
     private LiteralConverter? CreateConverter(Type type)
     {
-        // First, check for an attribute
-        if (type.GetCustomAttribute<LiteralConverterAttribute>() is LiteralConverterAttribute attribute)
+        LiteralConverter? converter = Nullable.GetUnderlyingType(type) is Type underlyingType
+            ? underlyingType.GetCustomAttribute<LiteralConverterAttribute>()?.CreateNullableConverter()
+            : type.GetCustomAttribute<LiteralConverterAttribute>()?.CreateConverter();
+        if (converter is not null)
         {
-            return attribute.CreateConverter();
+            return converter;
         }
 
         // Next, check our standard converters
-        if (_converters.TryGetValue(type, out LiteralConverter? converter))
+        if (_converters.TryGetValue(type, out converter))
         {
             return converter;
         }

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -1,8 +1,9 @@
 ﻿using System;
-using System.Collections.Frozen;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using RootNamespace.Serialization.Literals.Converters;
@@ -48,19 +49,19 @@ public sealed class LiteralConverterRegistry
 
     // A LiteralConverterRegistry is generally initialized once and then read many times, so using a FrozenDictionary
     // for reads becomes worthwhile for the slightly faster read performance.
-    private FrozenDictionary<Type, LiteralConverter>? _frozenConverters;
-    private FrozenDictionary<Type, LiteralConverter> FrozenConverters
+    private ConcurrentDictionary<Type, LiteralConverter?>? _dynamicConverters;
+    private ConcurrentDictionary<Type, LiteralConverter?> DynamicConverters
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            FrozenDictionary<Type, LiteralConverter>? converters = _frozenConverters;
+            ConcurrentDictionary<Type, LiteralConverter?>? converters = _dynamicConverters;
             if (converters is not null)
             {
                 return converters;
             }
 
-            return Interlocked.CompareExchange(ref _frozenConverters, _converters.ToFrozenDictionary(), null) ?? _frozenConverters;
+            return Interlocked.CompareExchange(ref _dynamicConverters, [], null) ?? _dynamicConverters;
         }
     }
 
@@ -89,14 +90,27 @@ public sealed class LiteralConverterRegistry
     /// <returns>True if the converter was found, otherwise false.</returns>
     public bool TryGet<T>([NotNullWhen(true)] out LiteralConverter<T>? converter)
     {
-        if (FrozenConverters.TryGetValue(typeof(T), out LiteralConverter? baseConverter))
+        converter = DynamicConverters.GetOrAdd(typeof(T), CreateConverter) as LiteralConverter<T>;
+
+        return converter is not null;
+    }
+
+    private LiteralConverter? CreateConverter(Type type)
+    {
+        // First, check for an attribute
+        if (type.GetCustomAttribute<LiteralConverterAttribute>() is LiteralConverterAttribute attribute)
         {
-            converter = (LiteralConverter<T>)baseConverter;
-            return true;
+            return attribute.CreateConverter();
         }
 
-        converter = null;
-        return false;
+        // Next, check our standard converters
+        if (_converters.TryGetValue(type, out LiteralConverter? converter))
+        {
+            return converter;
+        }
+
+        // No converter found
+        return null;
     }
 
     /// <summary>
@@ -122,7 +136,7 @@ public sealed class LiteralConverterRegistry
             _converters[typeof(T?)] = nullableConverter;
         }
 
-        _frozenConverters = null; // Clear the frozen dictionary to force a rebuild
+        Volatile.Write(ref _dynamicConverters, null); // Clear the frozen dictionary to force a rebuild
         return this;
     }
 
@@ -140,7 +154,7 @@ public sealed class LiteralConverterRegistry
 
         _converters[typeof(T)] = converter;
 
-        _frozenConverters = null; // Clear the frozen dictionary to force a rebuild
+        Volatile.Write(ref _dynamicConverters, null); // Clear the frozen dictionary to force a rebuild
         return this;
     }
 

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -47,8 +47,8 @@ public sealed class LiteralConverterRegistry
 
     private readonly Dictionary<Type, LiteralConverter> _converters = [];
 
-    // A LiteralConverterRegistry is generally initialized once and then read many times, so using a FrozenDictionary
-    // for reads becomes worthwhile for the slightly faster read performance.
+// A LiteralConverterRegistry is generally initialized once and then read many times, so caching converters
+// (including ones discovered via LiteralConverterAttribute) improves performance for repeated lookups.
     private ConcurrentDictionary<Type, LiteralConverter?>? _dynamicConverters;
     private ConcurrentDictionary<Type, LiteralConverter?> DynamicConverters
     {

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -47,23 +47,9 @@ public sealed class LiteralConverterRegistry
 
     private readonly Dictionary<Type, LiteralConverter> _converters = [];
 
-// A LiteralConverterRegistry is generally initialized once and then read many times, so caching converters
-// (including ones discovered via LiteralConverterAttribute) improves performance for repeated lookups.
-    private ConcurrentDictionary<Type, LiteralConverter?>? _dynamicConverters;
-    private ConcurrentDictionary<Type, LiteralConverter?> DynamicConverters
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
-        {
-            ConcurrentDictionary<Type, LiteralConverter?>? converters = _dynamicConverters;
-            if (converters is not null)
-            {
-                return converters;
-            }
-
-            return Interlocked.CompareExchange(ref _dynamicConverters, [], null) ?? _dynamicConverters;
-        }
-    }
+    // A LiteralConverterRegistry is generally initialized once and then read many times, so caching converters
+    // (including ones discovered via LiteralConverterAttribute) improves performance for repeated lookups.
+    private readonly ConcurrentDictionary<Type, LiteralConverter?> _dynamicConverters = [];
 
     /// <summary>
     /// Gets a registered converter for the specified type.
@@ -92,7 +78,7 @@ public sealed class LiteralConverterRegistry
     {
         converter = null;
 
-        LiteralConverter? result = DynamicConverters.GetOrAdd(typeof(T), CreateConverter);
+        LiteralConverter? result = _dynamicConverters.GetOrAdd(typeof(T), CreateConverter);
         if (result is null)
         {
             return false;
@@ -149,7 +135,7 @@ public sealed class LiteralConverterRegistry
             _converters[typeof(T?)] = nullableConverter;
         }
 
-        Volatile.Write(ref _dynamicConverters, null); // Clear the dynamic cache to force a rebuild
+        _dynamicConverters.Clear(); // Clear the dynamic cache to force a rebuild
         return this;
     }
 
@@ -167,7 +153,7 @@ public sealed class LiteralConverterRegistry
 
         _converters[typeof(T)] = converter;
 
-        Volatile.Write(ref _dynamicConverters, null); // Clear the frozen dictionary to force a rebuild
+        _dynamicConverters.Clear(); // Clear the cache dictionary to force a rebuild
         return this;
     }
 

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -136,7 +136,7 @@ public sealed class LiteralConverterRegistry
             _converters[typeof(T?)] = nullableConverter;
         }
 
-        Volatile.Write(ref _dynamicConverters, null); // Clear the frozen dictionary to force a rebuild
+        Volatile.Write(ref _dynamicConverters, null); // Clear the dynamic cache to force a rebuild
         return this;
     }
 

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -99,16 +99,26 @@ public sealed class LiteralConverterRegistry
 
     private LiteralConverter? CreateConverter(Type type)
     {
-        LiteralConverter? converter = Nullable.GetUnderlyingType(type) is Type underlyingType
-            ? underlyingType.GetCustomAttribute<LiteralConverterAttribute>()?.CreateNullableConverter()
-            : type.GetCustomAttribute<LiteralConverterAttribute>()?.CreateConverter();
-        if (converter is not null)
+        if (Nullable.GetUnderlyingType(type) is Type underlyingType)
         {
-            return converter;
+            LiteralConverter? innerConverter = _dynamicConverters.GetOrAdd(underlyingType, CreateConverterDelegate);
+
+            if (innerConverter is IValueTypeLiteralConverter valueTypeInnerConverter)
+            {
+                return valueTypeInnerConverter.CreateNullableConverter();
+            }
+        }
+        else
+        {
+            LiteralConverter? attributeConverter = type.GetCustomAttribute<LiteralConverterAttribute>()?.CreateConverter();
+            if (attributeConverter is not null)
+            {
+                return attributeConverter;
+            }
         }
 
         // Next, check our standard converters
-        if (_converters.TryGetValue(type, out converter))
+        if (_converters.TryGetValue(type, out LiteralConverter? converter))
         {
             return converter;
         }

--- a/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/LiteralConverterRegistry.cs
@@ -78,7 +78,7 @@ public sealed class LiteralConverterRegistry
     {
         converter = null;
 
-        LiteralConverter? result = _dynamicConverters.GetOrAdd(typeof(T), CreateConverter);
+        LiteralConverter? result = _dynamicConverters.GetOrAdd(typeof(T), CreateConverterDelegate);
         if (result is null)
         {
             return false;
@@ -93,6 +93,9 @@ public sealed class LiteralConverterRegistry
         ThrowHelper.ThrowInvalidOperationException($"Registered converter for type '{typeof(T).FullName}' is not of the expected type '{typeof(LiteralConverter<T>).FullName}'.");
         return false;
     }
+
+    // Cache the delegate for reuse
+    private Func<Type, LiteralConverter?> CreateConverterDelegate => field ??= CreateConverter;
 
     private LiteralConverter? CreateConverter(Type type)
     {

--- a/src/main/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/main/Yardarm.Client/Yardarm.Client.csproj
@@ -6,6 +6,7 @@
 
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Motivation
----------
The currently approach for registering converters works well for simple cases. But for trimming scenarios, applying a strongly-typed generic converter for a special schema via attribute is preferable. There is no way to globally register a literal converter currently that can apply to more than one type, and trying to make that possible would break trimming and AOT compatibility.

Modifications
-------------
- Add LiteralConverterAttribute
- Dynamically create the LiteralConverter<T> for a given type, preferring the registered LiteralConverterAttribute over any globally registered converters
- Cache the converters in a concurrent dictionary for reuse