### PR TITLE
Make extensible enums strongly typed

### DIFF
--- a/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
+++ b/src/main/Yardarm.Client.UnitTests/Serialization/LiteralSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using RootNamespace.Models;
 using RootNamespace.Serialization.Literals;
 using RootNamespace.Serialization.Literals.Converters;
 using Xunit;
@@ -267,6 +268,42 @@ namespace Yardarm.Client.UnitTests.Serialization
             // Assert
 
             result.Should().Be("Ordinal");
+        }
+
+        [Fact]
+        public void Serialize_ExtensibleEnum_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize(ExtensibleEnum.Case1);
+
+            // Assert
+
+            result.Should().Be("Case1");
+        }
+
+        [Fact]
+        public void Serialize_NullableExtensibleEnum_ReturnsString()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize<ExtensibleEnum?>(ExtensibleEnum.Case1);
+
+            // Assert
+
+            result.Should().Be("Case1");
+        }
+
+        [Fact]
+        public void Serialize_NullableExtensibleEnum_ReturnsEmptyStringForNull()
+        {
+            // Act
+
+            string result = LiteralSerializer.Serialize<ExtensibleEnum?>(null);
+
+            // Assert
+
+            result.Should().Be("");
         }
 
         #endregion
@@ -1136,6 +1173,37 @@ namespace Yardarm.Client.UnitTests.Serialization
             result.Should().Be(StringComparison.Ordinal);
         }
 
+        [Fact]
+        public void Deserialize_ExtensibleEnum_ReturnsValue()
+        {
+            // Act
+            ExtensibleEnum result = LiteralSerializer.Deserialize<ExtensibleEnum>("Case1");
+
+            // Assert
+            result.Should().Be(ExtensibleEnum.Case1);
+        }
+
+        [Fact]
+        public void Deserialize_NullableExtensibleEnum_ReturnsValue()
+        {
+            // Act
+            ExtensibleEnum? result = LiteralSerializer.Deserialize<ExtensibleEnum?>("Case1");
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Should().Be(ExtensibleEnum.Case1);
+        }
+
+        [Fact]
+        public void Deserialize_NullableExtensibleEnum_ReturnsNull()
+        {
+            // Act
+            ExtensibleEnum? result = LiteralSerializer.Deserialize<ExtensibleEnum?>(null);
+
+            // Assert
+            result.Should().BeNull();
+        }
+
         #endregion
 
         #region JoinListT
@@ -1165,6 +1233,15 @@ namespace Yardarm.Client.UnitTests.Serialization
 
             public override string Write(IntWrapper value, string format) => checked(_innerConverter.Write(value.Value + 1, format));
             protected override IntWrapper ReadCore(string value, string format) => checked(new IntWrapper(_innerConverter.Read(value, format) - 1));
+        }
+
+        [LiteralConverter(typeof(ExtensibleEnumLiteralConverter<ExtensibleEnum>))]
+        private readonly record struct ExtensibleEnum(string Value) : IExtensibleEnum<ExtensibleEnum>
+        {
+            public static ExtensibleEnum Case1 { get; } = new(nameof(Case1));
+            public static ExtensibleEnum Case2 { get; } = new(nameof(Case2));
+
+            public static ExtensibleEnum Create(string value) => new(value);
         }
     }
 }

--- a/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
@@ -16,6 +16,7 @@ internal static class ExtensibleEnum
     /// Creates a new instance of the extensible enumeration with the specified value.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="value"/> may not be null.</exception>
+    /// <remarks>
     /// For .NET 7 and later, the extensible enumeration type must implement the static abstract method <see cref="IExtensibleEnum{TSelf}.Create(string)"/>.
     /// For runtimes before .NET 7, the extensible enumeration type must have a public constructor that takes a single string parameter.
     /// </remarks>

--- a/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using RootNamespace.Models;
+
+namespace RootNamespace.Internal;
+
+/// <summary>
+/// Tools for working with <see cref="IExtensibleEnum{TSelf}"/>.
+/// </summary>
+internal static class ExtensibleEnum
+{
+    /// <summary>
+    /// Creates a new instance of the extensible enumeration with the specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of the extensible enumeration.</typeparam>
+    /// <param name="value">The value of the extensible enumeration.</param>
+    /// <returns>A new instance of the extensible enumeration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"> may not be null.</exception>'
+    /// <remarks>
+    /// For .NET 7 and later, the extensible enumeration type must implement the static abstract method <see cref="IExtensibleEnum{TSelf}.Create(string)"/>.
+    /// For runtimes before .NET 7, the extensible enumeration type must have a public constructor that takes a single string parameter.
+    /// </remarks>
+    public static T Create<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string value)
+        where T : struct, IExtensibleEnum<T>
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+#if NET7_0_OR_GREATER
+        return T.Create(value);
+#else
+        return FactoryContainer<T>.Factory(value);
+#endif
+    }
+
+#if !NET7_0_OR_GREATER
+
+    // Static abstract interface methods are not supported before .NET 7, so use reflection to get the constructor instead.
+
+    private static class FactoryContainer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
+        where T : struct, IExtensibleEnum<T>
+    {
+        public static readonly Func<string, T> Factory = CreateFactory();
+
+        private static Func<string, T> CreateFactory()
+        {
+            ConstructorInfo? constructor = typeof(T).GetConstructor([typeof(string)]);
+            if (constructor is null)
+            {
+                ThrowHelper.ThrowInvalidOperationException($"Type {typeof(T)} does not have a public constructor that takes a single string parameter.");
+            }
+
+#if NETCOREAPP3_0_OR_GREATER
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+#endif
+                // More performant option that is dynamically compiled to avoid using reflection on each invocation
+                ParameterExpression parameterExpression = Expression.Parameter(typeof(string), "value");
+
+                NewExpression newExpression = Expression.New(
+                    constructor,
+                    parameterExpression);
+
+                return Expression
+                    .Lambda<Func<string, T>>(newExpression, parameterExpression)
+                    .Compile();
+#if NETCOREAPP3_0_OR_GREATER
+            }
+            else
+            {
+                // Fallback for scenarios where JIT is not supported
+                return (value) => (T)constructor.Invoke([value]);
+            }
+#endif
+        }
+    }
+
+#endif
+}

--- a/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Internal/ExtensibleEnum.cs
@@ -15,11 +15,7 @@ internal static class ExtensibleEnum
     /// <summary>
     /// Creates a new instance of the extensible enumeration with the specified value.
     /// </summary>
-    /// <typeparam name="T">The type of the extensible enumeration.</typeparam>
-    /// <param name="value">The value of the extensible enumeration.</param>
-    /// <returns>A new instance of the extensible enumeration.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="value"> may not be null.</exception>'
-    /// <remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> may not be null.</exception>
     /// For .NET 7 and later, the extensible enumeration type must implement the static abstract method <see cref="IExtensibleEnum{TSelf}.Create(string)"/>.
     /// For runtimes before .NET 7, the extensible enumeration type must have a public constructor that takes a single string parameter.
     /// </remarks>

--- a/src/main/Yardarm.Client/Internal/IsExternalInit.netstandard.cs
+++ b/src/main/Yardarm.Client/Internal/IsExternalInit.netstandard.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    static class IsExternalInit
+    {
+    }
+}

--- a/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
@@ -16,9 +16,6 @@ internal interface IExtensibleEnum<TSelf> : IEquatable<TSelf>
     /// <summary>
     /// Creates a new instance of the extensible enumeration with the specified value.
     /// </summary>
-    /// <param name="value">The value of the extensible enumeration.</param>
-    /// <returns>A new instance of the extensible enumeration.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="value"> may not be null.</exception>
-    public static abstract TSelf Create(string value);
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> may not be null.</exception>
 #endif
 }

--- a/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace RootNamespace.Models;
+
+/// <summary>
+/// String-based enumeration that is extensible and may contain any string value, not just well-known values.
+/// </summary>
+internal interface IExtensibleEnum<TSelf> : IEquatable<TSelf>
+{
+    /// <summary>
+    /// Gets the value of the extensible enumeration.
+    /// </summary>
+    public string Value { get; }
+
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// Creates a new instance of the extensible enumeration with the specified value.
+    /// </summary>
+    /// <param name="value">The value of the extensible enumeration.</param>
+    /// <returns>A new instance of the extensible enumeration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value"> may not be null.</exception>
+    public static abstract TSelf Create(string value);
+#endif
+}

--- a/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
+++ b/src/main/Yardarm.Client/Models/IExtensibleEnum.cs
@@ -17,5 +17,6 @@ internal interface IExtensibleEnum<TSelf> : IEquatable<TSelf>
     /// Creates a new instance of the extensible enumeration with the specified value.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="value"/> may not be null.</exception>
+    public static abstract TSelf Create(string value);
 #endif
 }

--- a/src/main/Yardarm.Client/Serialization/Literals/Converters/ExtensibleEnumLiteralConverter.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/Converters/ExtensibleEnumLiteralConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using RootNamespace.Internal;
+using RootNamespace.Models;
+
+namespace RootNamespace.Serialization.Literals.Converters;
+
+internal sealed class ExtensibleEnumLiteralConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>
+    : ValueTypeLiteralConverter<T>
+    where T : struct, IExtensibleEnum<T>
+{
+    protected override T ReadCore(string value, string? format) => ExtensibleEnum.Create<T>(value);
+
+    public override string Write(T value, string? format) => value.Value;
+
+#if NET6_0_OR_GREATER
+
+    public override bool TryWrite(T value, ReadOnlySpan<char> format, Span<char> destination, out int charsWritten)
+    {
+        string stringValue = value.Value ?? "";
+
+        if (stringValue.TryCopyTo(destination))
+        {
+            charsWritten = stringValue.Length;
+            return true;
+        }
+
+        charsWritten = 0;
+        return false;
+    }
+
+#endif
+}

--- a/src/main/Yardarm.Client/Serialization/Literals/Converters/ExtensibleEnumLiteralConverter.cs
+++ b/src/main/Yardarm.Client/Serialization/Literals/Converters/ExtensibleEnumLiteralConverter.cs
@@ -11,7 +11,7 @@ internal sealed class ExtensibleEnumLiteralConverter<[DynamicallyAccessedMembers
 {
     protected override T ReadCore(string value, string? format) => ExtensibleEnum.Create<T>(value);
 
-    public override string Write(T value, string? format) => value.Value;
+    public override string Write(T value, string? format) => value.Value ?? "";
 
 #if NET6_0_OR_GREATER
 

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Newtonsoft.Json;
+using RootNamespace.Internal;
+using RootNamespace.Models;
+
+namespace RootNamespace.Serialization.Json;
+
+internal sealed class JsonExtensibleEnumConverter<T> : JsonConverter
+    where T : struct, IExtensibleEnum<T>
+{
+    public override bool CanConvert(Type objectType) => objectType == typeof(T);
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        if (reader.TokenType == JsonToken.Null)
+        {
+            return null;
+        }
+
+        if (reader.TokenType == JsonToken.String)
+        {
+            return ExtensibleEnum.Create<T>((string)reader.Value!);
+        }
+
+        throw new JsonSerializationException($"Unable to convert JSON to {typeof(T).FullName}.");
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (value is null)
+        {
+            writer.WriteNull();
+        }
+        else if (value is T typedValue)
+        {
+            writer.WriteValue(typedValue.Value);
+        }
+        else
+        {
+            throw new JsonSerializationException($"{value.GetType().FullName} is not of type {typeof(T).FullName}.");
+        }
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
@@ -8,7 +8,7 @@ namespace RootNamespace.Serialization.Json;
 internal sealed class JsonExtensibleEnumConverter<T> : JsonConverter
     where T : struct, IExtensibleEnum<T>
 {
-    public override bool CanConvert(Type objectType) => objectType == typeof(T);
+    public override bool CanConvert(Type objectType) => objectType == typeof(T) || objectType == typeof(T?);
 
     public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {

--- a/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
@@ -15,7 +15,7 @@ namespace RootNamespace.Serialization.Json;
 internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConverter
     where T : IUnion
 {
-    public override bool CanConvert(Type objectType) => objectType == typeof(T);
+    public override bool CanConvert(Type objectType) => objectType == typeof(T) || objectType == typeof(T?);
 
     public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {

--- a/src/main/Yardarm.NewtonsoftJson.UnitTests/Client/JsonExtensibleEnumConverterTests.cs
+++ b/src/main/Yardarm.NewtonsoftJson.UnitTests/Client/JsonExtensibleEnumConverterTests.cs
@@ -1,0 +1,86 @@
+﻿using FluentAssertions;
+using Newtonsoft.Json;
+using RootNamespace.Models;
+using RootNamespace.Serialization.Json;
+using Xunit;
+
+namespace Yardarm.NewtonsoftJson.UnitTests.Client;
+
+public class JsonExtensibleEnumConverterTests
+{
+    [Fact]
+    public void Serialize_ExtensibleEnum_ReturnsString()
+    {
+        // Act
+
+        string result = JsonConvert.SerializeObject(ExtensibleEnum.Case1);
+
+        // Assert
+
+        result.Should().Be("\"Case1\"");
+    }
+
+    [Fact]
+    public void Serialize_NullableExtensibleEnum_ReturnsString()
+    {
+        // Act
+
+        string result = JsonConvert.SerializeObject(ExtensibleEnum.Case1, typeof(ExtensibleEnum?), settings: null);
+
+        // Assert
+
+        result.Should().Be("\"Case1\"");
+    }
+
+    [Fact]
+    public void Serialize_NullableExtensibleEnum_ReturnsNull()
+    {
+        // Act
+
+        string result = JsonConvert.SerializeObject(null, typeof(ExtensibleEnum?), settings: null);
+
+        // Assert
+
+        result.Should().Be("null");
+    }
+
+    [Fact]
+    public void Deserialize_ExtensibleEnum_ReturnsValue()
+    {
+        // Act
+        ExtensibleEnum result = JsonConvert.DeserializeObject<ExtensibleEnum>("\"Case1\"");
+
+        // Assert
+        result.Should().Be(ExtensibleEnum.Case1);
+    }
+
+    [Fact]
+    public void Deserialize_NullableExtensibleEnum_ReturnsValue()
+    {
+        // Act
+        ExtensibleEnum? result = JsonConvert.DeserializeObject<ExtensibleEnum?>("\"Case1\"");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(ExtensibleEnum.Case1);
+    }
+
+    [Fact]
+    public void Deserialize_NullableExtensibleEnum_ReturnsNull()
+    {
+        // Act
+        ExtensibleEnum? result = JsonConvert.DeserializeObject<ExtensibleEnum?>("null");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [JsonConverter(typeof(JsonExtensibleEnumConverter<ExtensibleEnum>))]
+    private readonly record struct ExtensibleEnum(string Value) : IExtensibleEnum<ExtensibleEnum>
+    {
+        public static ExtensibleEnum Case1 { get; } = new(nameof(Case1));
+        public static ExtensibleEnum Case2 { get; } = new(nameof(Case2));
+
+        public static ExtensibleEnum Create(string value) => new(value);
+    }
+}

--- a/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/IJsonSerializationNamespace.cs
@@ -13,5 +13,7 @@ public interface IJsonSerializationNamespace
 
     TypeSyntax AdditionalPropertiesDictionary(TypeSyntax valueType);
 
+    TypeSyntax JsonExtensibleEnumConverterName(TypeSyntax enumType);
+
     TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType);
 }

--- a/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.NewtonsoftJson/Internal/JsonSerializationNamespace.cs
@@ -50,6 +50,10 @@ internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationN
                 Identifier("AdditionalPropertiesDictionary"),
                 TypeArgumentList(SingletonSeparatedList(valueType))));
 
+    public TypeSyntax JsonExtensibleEnumConverterName(TypeSyntax enumType) =>
+        QualifiedName(Name, GenericName(Identifier("JsonExtensibleEnumConverter"),
+            TypeArgumentList(SingletonSeparatedList(enumType))));
+
     public TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType) =>
         QualifiedName(Name, GenericName(Identifier("JsonExternallyDiscriminatedUnionConverter"),
             TypeArgumentList(SingletonSeparatedList(schemaType))));

--- a/src/main/Yardarm.NewtonsoftJson/JsonExtensibleEnumEnricher.cs
+++ b/src/main/Yardarm.NewtonsoftJson/JsonExtensibleEnumEnricher.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.NewtonsoftJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.NewtonsoftJson;
+
+public class JsonExtensibleEnumEnricher(
+    IJsonSerializationNamespace jsonNamespace)
+    : IOpenApiSyntaxNodeEnricher<RecordDeclarationSyntax, OpenApiSchema>
+{
+    public RecordDeclarationSyntax Enrich(RecordDeclarationSyntax target, OpenApiEnrichmentContext<OpenApiSchema> context)
+        => target.IsExtensibleEnumeration()
+            ? EnrichEnum(target)
+            : target;
+
+    private RecordDeclarationSyntax EnrichEnum(RecordDeclarationSyntax target)
+        => target
+            .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                Attribute(
+                    NewtonsoftJsonTypes.JsonConverterAttributeName,
+                    AttributeArgumentList(SingletonSeparatedList(
+                        AttributeArgument(TypeOfExpression(
+                            jsonNamespace.JsonExtensibleEnumConverterName(IdentifierName(target.Identifier)))))))))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+}

--- a/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
+++ b/src/main/Yardarm.NewtonsoftJson/NewtonsoftJsonExtension.cs
@@ -23,6 +23,7 @@ namespace Yardarm.NewtonsoftJson
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatorEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
                 .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatedUnionEnricher>()
+                .AddOpenApiSyntaxNodeEnricher<JsonExtensibleEnumEnricher>()
                 .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
                 .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>();
 

--- a/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
+++ b/src/main/Yardarm.SystemTextJson.Client/Serialization/Json/JsonExtensibleEnumConverter.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using RootNamespace.Internal;
+using RootNamespace.Models;
+
+namespace RootNamespace.Serialization.Json;
+
+internal sealed class JsonExtensibleEnumConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T> : JsonConverter<T>
+    where T : struct, IExtensibleEnum<T>
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            string? value = reader.GetString();
+            if (value is not null)
+            {
+                return ExtensibleEnum.Create<T>(value);
+            }
+        }
+
+        throw new JsonException($"Unable to convert JSON to {typeof(T).FullName}.");
+    }
+
+    public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.PropertyName)
+        {
+            string? value = reader.GetString();
+            if (value is not null)
+            {
+                return ExtensibleEnum.Create<T>(value);
+            }
+        }
+
+        throw new JsonException($"Unable to convert JSON property name to {typeof(T).FullName}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(value.Value);
+    }
+
+    public override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WritePropertyName(value.Value);
+    }
+}

--- a/src/main/Yardarm.SystemTextJson.UnitTests/Client/JsonExtensibleEnumConverterTests.cs
+++ b/src/main/Yardarm.SystemTextJson.UnitTests/Client/JsonExtensibleEnumConverterTests.cs
@@ -1,0 +1,87 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using RootNamespace.Models;
+using RootNamespace.Serialization.Json;
+using Xunit;
+
+namespace Yardarm.SystemTextJson.UnitTests.Client;
+
+public class JsonExtensibleEnumConverterTests
+{
+    [Fact]
+    public void Serialize_ExtensibleEnum_ReturnsString()
+    {
+        // Act
+
+        string result = JsonSerializer.Serialize(ExtensibleEnum.Case1);
+
+        // Assert
+
+        result.Should().Be("\"Case1\"");
+    }
+
+    [Fact]
+    public void Serialize_NullableExtensibleEnum_ReturnsString()
+    {
+        // Act
+
+        string result = JsonSerializer.Serialize<ExtensibleEnum?>(ExtensibleEnum.Case1);
+
+        // Assert
+
+        result.Should().Be("\"Case1\"");
+    }
+
+    [Fact]
+    public void Serialize_NullableExtensibleEnum_ReturnsNull()
+    {
+        // Act
+
+        string result = JsonSerializer.Serialize<ExtensibleEnum?>(null);
+
+        // Assert
+
+        result.Should().Be("null");
+    }
+
+    [Fact]
+    public void Deserialize_ExtensibleEnum_ReturnsValue()
+    {
+        // Act
+        ExtensibleEnum result = JsonSerializer.Deserialize<ExtensibleEnum>("\"Case1\"");
+
+        // Assert
+        result.Should().Be(ExtensibleEnum.Case1);
+    }
+
+    [Fact]
+    public void Deserialize_NullableExtensibleEnum_ReturnsValue()
+    {
+        // Act
+        ExtensibleEnum? result = JsonSerializer.Deserialize<ExtensibleEnum?>("\"Case1\"");
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().Be(ExtensibleEnum.Case1);
+    }
+
+    [Fact]
+    public void Deserialize_NullableExtensibleEnum_ReturnsNull()
+    {
+        // Act
+        ExtensibleEnum? result = JsonSerializer.Deserialize<ExtensibleEnum?>("null");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [JsonConverter(typeof(JsonExtensibleEnumConverter<ExtensibleEnum>))]
+    private readonly record struct ExtensibleEnum(string Value) : IExtensibleEnum<ExtensibleEnum>
+    {
+        public static ExtensibleEnum Case1 { get; } = new(nameof(Case1));
+        public static ExtensibleEnum Case2 { get; } = new(nameof(Case2));
+
+        public static ExtensibleEnum Create(string value) => new(value);
+    }
+}

--- a/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/IJsonSerializationNamespace.cs
@@ -15,5 +15,7 @@ public interface IJsonSerializationNamespace
 
     TypeSyntax JsonDiscriminatedObjectConverterName(TypeSyntax schemaType);
 
+    TypeSyntax JsonExtensibleEnumConverterName(TypeSyntax enumType);
+
     TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType);
 }

--- a/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
+++ b/src/main/Yardarm.SystemTextJson/Internal/JsonSerializationNamespace.cs
@@ -56,6 +56,10 @@ internal class JsonSerializationNamespace : IKnownNamespace, IJsonSerializationN
         QualifiedName(Name, GenericName(Identifier("JsonDiscriminatedObjectConverter"),
             TypeArgumentList(SingletonSeparatedList(schemaType))));
 
+    public TypeSyntax JsonExtensibleEnumConverterName(TypeSyntax enumType) =>
+        QualifiedName(Name, GenericName(Identifier("JsonExtensibleEnumConverter"),
+            TypeArgumentList(SingletonSeparatedList(enumType))));
+
     public TypeSyntax JsonExternallyDiscriminatedUnionConverterName(TypeSyntax schemaType) =>
         QualifiedName(Name, GenericName(Identifier("JsonExternallyDiscriminatedUnionConverter"),
             TypeArgumentList(SingletonSeparatedList(schemaType))));

--- a/src/main/Yardarm.SystemTextJson/JsonExtensibleEnumEnricher.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonExtensibleEnumEnricher.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.OpenApi.Models;
+using Yardarm.Enrichment;
+using Yardarm.Generation;
+using Yardarm.SystemTextJson.Helpers;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Yardarm.SystemTextJson;
+
+public class JsonExtensibleEnumEnricher(
+    IJsonSerializationNamespace jsonNamespace)
+    : IOpenApiSyntaxNodeEnricher<RecordDeclarationSyntax, OpenApiSchema>
+{
+    public RecordDeclarationSyntax Enrich(RecordDeclarationSyntax target, OpenApiEnrichmentContext<OpenApiSchema> context)
+        => target.IsExtensibleEnumeration()
+            ? EnrichEnum(target)
+            : target;
+
+    private RecordDeclarationSyntax EnrichEnum(RecordDeclarationSyntax target)
+        => target
+            .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                Attribute(
+                    SystemTextJsonTypes.Serialization.JsonConverterAttributeName,
+                    AttributeArgumentList(SingletonSeparatedList(
+                        AttributeArgument(TypeOfExpression(
+                            jsonNamespace.JsonExtensibleEnumConverterName(IdentifierName(target.Identifier)))))))))
+                .WithTrailingTrivia(ElasticCarriageReturnLineFeed));
+}

--- a/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
+++ b/src/main/Yardarm.SystemTextJson/SystemTextJsonExtension.cs
@@ -27,6 +27,7 @@ public class SystemTextJsonExtension : YardarmExtension
             .AddOpenApiSyntaxNodeEnricher<JsonOptionalPropertyEnricher>()
             .AddOpenApiSyntaxNodeEnricher<JsonDateOnlyPropertyEnricher>()
             .AddOpenApiSyntaxNodeEnricher<JsonDiscriminatedUnionEnricher>()
+            .AddOpenApiSyntaxNodeEnricher<JsonExtensibleEnumEnricher>()
             .AddSingleton<IDependencyGenerator, JsonDependencyGenerator>()
             .AddSingleton<ISyntaxTreeGenerator, ClientGenerator>()
             .AddSingleton<ISyntaxTreeGenerator, DiscriminatorConverterGenerator>()

--- a/src/main/Yardarm/Generation/Schema/DefaultSchemaGeneratorFactory.cs
+++ b/src/main/Yardarm/Generation/Schema/DefaultSchemaGeneratorFactory.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
-using Yardarm.Internal;
 using Yardarm.Spec;
 
 namespace Yardarm.Generation.Schema;
@@ -13,6 +12,9 @@ public class DefaultSchemaGeneratorFactory(GenerationContext context) : ITypeGen
 {
     private ObjectFactory<ExternallyDiscriminatedUnionSchemaGenerator> ExternallyDiscriminatedUnionFactory => field ??=
         ActivatorUtilities.CreateFactory<ExternallyDiscriminatedUnionSchemaGenerator>([ typeof(ILocatedOpenApiElement<OpenApiSchema>), typeof(GenerationContext), typeof(ITypeGenerator) ]);
+
+    private ObjectFactory<ExtensibleEnumSchemaGenerator> ExtensibleEnumFactory => field ??=
+        ActivatorUtilities.CreateFactory<ExtensibleEnumSchemaGenerator>([typeof(ILocatedOpenApiElement<OpenApiSchema>), typeof(ITypeGenerator), typeof(List<string>)]);
 
     public virtual ITypeGenerator Create(ILocatedOpenApiElement<OpenApiSchema> element, ITypeGenerator? parent)
     {
@@ -70,7 +72,7 @@ public class DefaultSchemaGeneratorFactory(GenerationContext context) : ITypeGen
 
             if (values.Count > 0)
             {
-                return new ExtensibleEnumSchemaGenerator(element, context, parent, values);
+                return ExtensibleEnumFactory.Invoke(context.GenerationServices, [element, parent, values]);
             }
         }
 

--- a/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
@@ -9,9 +9,9 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Yardarm.Generation.Schema;
 
 /// <summary>
-/// Generates a static class containing string constants for an OpenAPI schema that has the "x-extensible-enum" extension.
-/// Generates well-known values as constants in a static class which is located and named using the
-/// usual schema class naming techniques. The properties referencing this schema will be generated as a string.
+/// Generates a readonly record struct that can contain any non-null string for an OpenAPI schema that has the "x-extensible-enum" extension.
+/// Generates well-known values as static readonly properties. The generated type implements IExtensibleEnum{TSelf}" and
+/// provides implicit conversions to and from string.
 /// </summary>
 internal class ExtensibleEnumSchemaGenerator(
     GenerationContext context,

--- a/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
@@ -15,16 +14,14 @@ namespace Yardarm.Generation.Schema;
 /// usual schema class naming techniques. The properties referencing this schema will be generated as a string.
 /// </summary>
 internal class ExtensibleEnumSchemaGenerator(
-    ILocatedOpenApiElement<OpenApiSchema> schemaElement,
     GenerationContext context,
+    IRootNamespace rootNamespace,
+    ILocatedOpenApiElement<OpenApiSchema> schemaElement,
     ITypeGenerator? parent,
     List<string> wellKnownValues)
     : SchemaGeneratorBase(schemaElement, context, parent)
 {
     protected override NameKind NameKind => NameKind.Class;
-
-    protected override YardarmTypeInfo CreateTypeInfo() => new(
-        PredefinedType(Token(SyntaxKind.StringKeyword)), isGenerated: false);
 
     public override IEnumerable<MemberDeclarationSyntax> Generate()
     {
@@ -37,17 +34,51 @@ internal class ExtensibleEnumSchemaGenerator(
 
         string className = classNameAndNamespace.Right.Identifier.Text;
 
-        yield return ClassDeclaration(
-            attributeLists: default,
-            modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)),
+        QualifiedNameSyntax literalsNamespace =
+            QualifiedName(QualifiedName(rootNamespace.Name, IdentifierName("Serialization")), IdentifierName("Literals"));
+
+        NameSyntax interfaceName = QualifiedName(QualifiedName(rootNamespace.Name, IdentifierName("Models")),
+            GenericName(
+                Identifier("IExtensibleEnum"),
+                TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName(className)))));
+
+        NameSyntax converterName = QualifiedName(QualifiedName(literalsNamespace, IdentifierName("Converters")),
+            GenericName(
+                Identifier("ExtensibleEnumLiteralConverter"),
+                TypeArgumentList(SingletonSeparatedList<TypeSyntax>(IdentifierName(className)))));
+
+        yield return RecordDeclaration(
+            kind: SyntaxKind.RecordStructDeclaration,
+            attributeLists: SingletonList(AttributeList(SingletonSeparatedList(
+                Attribute(
+                    QualifiedName(literalsNamespace, IdentifierName("LiteralConverter")),
+                    AttributeArgumentList(SingletonSeparatedList(AttributeArgument(TypeOfExpression(converterName)))))))),
+            modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.ReadOnlyKeyword)),
+            keyword: Token(SyntaxKind.RecordKeyword),
+            classOrStructKeyword: Token(SyntaxKind.StructKeyword),
             identifier: Identifier(className),
             typeParameterList: null,
-            baseList: null,
+            parameterList: ParameterList(SingletonSeparatedList(
+                Parameter(
+                    attributeLists: default,
+                    modifiers: default,
+                    type: PredefinedType(Token(SyntaxKind.StringKeyword)),
+                    identifier: Identifier("Value"),
+                    @default: null))),
+            baseList: BaseList(SingletonSeparatedList<BaseTypeSyntax>(SimpleBaseType(interfaceName))),
             constraintClauses: default,
-            members: List(GetConstantDeclarations()));
+            openBraceToken: Token(SyntaxKind.OpenBraceToken),
+            members: List([
+                ..GetConstantDeclarations(className),
+                ..GetHelperMethods(className, interfaceName)
+            ]),
+            closeBraceToken: Token(SyntaxKind.CloseBraceToken),
+            semicolonToken: default)
+            .AddGeneratorAnnotation(this)
+            .AddElementAnnotation(Element, Context.ElementRegistry);
     }
 
-    private IEnumerable<MemberDeclarationSyntax> GetConstantDeclarations()
+    private IEnumerable<MemberDeclarationSyntax> GetConstantDeclarations(string className)
     {
         var nameFormatter = Context.NameFormatterSelector.GetFormatter(NameKind.EnumMember);
 
@@ -55,16 +86,102 @@ internal class ExtensibleEnumSchemaGenerator(
         {
             yield return FieldDeclaration(
                 attributeLists: default,
-                modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.ConstKeyword)),
+                modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword), Token(SyntaxKind.ReadOnlyKeyword)),
                 declaration: VariableDeclaration(
-                    PredefinedType(Token(SyntaxKind.StringKeyword)),
-                    SeparatedList(
-                    [
+                    IdentifierName(className),
+                    SingletonSeparatedList(
                         VariableDeclarator(
                             Identifier(nameFormatter.Format(value)),
                             argumentList: null,
-                            initializer: EqualsValueClause(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value))))
-                    ])));
+                            initializer: EqualsValueClause(ImplicitObjectCreationExpression(
+                                argumentList: ArgumentList(SingletonSeparatedList(
+                                    Argument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(value))))),
+                                initializer: null))))));
+        }
+    }
+
+    private IEnumerable<MemberDeclarationSyntax> GetHelperMethods(string className, NameSyntax interfaceName)
+    {
+        // Override ToString() to return the Value property
+        yield return MethodDeclaration(
+            attributeLists: default,
+            modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.OverrideKeyword)),
+            returnType: PredefinedType(Token(SyntaxKind.StringKeyword)),
+            explicitInterfaceSpecifier: default,
+            identifier: Identifier("ToString"),
+            typeParameterList: default,
+            parameterList: ParameterList(),
+            constraintClauses: default,
+            body: null,
+            expressionBody: ArrowExpressionClause(IdentifierName("Value")),
+            semicolonToken: Token(SyntaxKind.SemicolonToken));
+
+        // Implicit conversion to string
+        yield return ConversionOperatorDeclaration(
+            attributeLists: default,
+            modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)),
+            implicitOrExplicitKeyword: Token(SyntaxKind.ImplicitKeyword),
+            operatorKeyword: Token(SyntaxKind.OperatorKeyword),
+            type: PredefinedType(Token(SyntaxKind.StringKeyword)),
+            parameterList: ParameterList(SingletonSeparatedList(
+                Parameter(
+                    attributeLists: default,
+                    modifiers: default,
+                    type: IdentifierName(className),
+                    identifier: Identifier("value"),
+                    @default: null))),
+            body: null,
+            expressionBody: ArrowExpressionClause(MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                IdentifierName("value"),
+                IdentifierName("Value"))),
+            semicolonToken: Token(SyntaxKind.SemicolonToken));
+
+        // Implicit conversion from string
+        yield return ConversionOperatorDeclaration(
+            attributeLists: default,
+            modifiers: TokenList(Token(SyntaxKind.PublicKeyword), Token(SyntaxKind.StaticKeyword)),
+            implicitOrExplicitKeyword: Token(SyntaxKind.ImplicitKeyword),
+            operatorKeyword: Token(SyntaxKind.OperatorKeyword),
+            type: IdentifierName(className),
+            parameterList: ParameterList(SingletonSeparatedList(
+                Parameter(
+                    attributeLists: default,
+                    modifiers: default,
+                    type: PredefinedType(Token(SyntaxKind.StringKeyword)),
+                    identifier: Identifier("value"),
+                    @default: null))),
+            body: null,
+            expressionBody: ArrowExpressionClause(ImplicitObjectCreationExpression(
+                argumentList: ArgumentList(SingletonSeparatedList(
+                    Argument(IdentifierName("value")))),
+                initializer: null)),
+            semicolonToken: Token(SyntaxKind.SemicolonToken));
+
+        // Static create method to satisfy the IExtensibleEnum<T> interface requirement
+        if (Context.CurrentTargetFramework.Version.Major >= 7)
+        {
+            yield return MethodDeclaration(
+                attributeLists: default,
+                modifiers: TokenList(Token(SyntaxKind.StaticKeyword)),
+                returnType: IdentifierName(className),
+                explicitInterfaceSpecifier: ExplicitInterfaceSpecifier(interfaceName),
+                identifier: Identifier("Create"),
+                typeParameterList: default,
+                parameterList: ParameterList(SingletonSeparatedList(
+                    Parameter(
+                        attributeLists: default,
+                        modifiers: default,
+                        type: PredefinedType(Token(SyntaxKind.StringKeyword)),
+                        identifier: Identifier("value"),
+                        @default: null))),
+                constraintClauses: default,
+                body: null,
+                expressionBody: ArrowExpressionClause(ImplicitObjectCreationExpression(
+                    argumentList: ArgumentList(SingletonSeparatedList(
+                        Argument(IdentifierName("value")))),
+                    initializer: null)),
+                semicolonToken: Token(SyntaxKind.SemicolonToken));
         }
     }
 }

--- a/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.OpenApi.Models;
+using Yardarm.Helpers;
 using Yardarm.Names;
 using Yardarm.Spec;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -151,11 +152,14 @@ internal class ExtensibleEnumSchemaGenerator(
                     type: PredefinedType(Token(SyntaxKind.StringKeyword)),
                     identifier: Identifier("value"),
                     @default: null))),
-            body: null,
-            expressionBody: ArrowExpressionClause(ImplicitObjectCreationExpression(
-                argumentList: ArgumentList(SingletonSeparatedList(
-                    Argument(IdentifierName("value")))),
-                initializer: null)),
+            body: Block(List([
+                MethodHelpers.ThrowIfArgumentNull("value"),
+                ReturnStatement(ImplicitObjectCreationExpression(
+                    argumentList: ArgumentList(SingletonSeparatedList(
+                        Argument(IdentifierName("value")))),
+                    initializer: null))
+            ])),
+            expressionBody: null,
             semicolonToken: Token(SyntaxKind.SemicolonToken));
 
         // Static create method to satisfy the IExtensibleEnum<T> interface requirement
@@ -176,11 +180,14 @@ internal class ExtensibleEnumSchemaGenerator(
                         identifier: Identifier("value"),
                         @default: null))),
                 constraintClauses: default,
-                body: null,
-                expressionBody: ArrowExpressionClause(ImplicitObjectCreationExpression(
+                body: Block(List([
+                MethodHelpers.ThrowIfArgumentNull("value"),
+                ReturnStatement(ImplicitObjectCreationExpression(
                     argumentList: ArgumentList(SingletonSeparatedList(
                         Argument(IdentifierName("value")))),
-                    initializer: null)),
+                    initializer: null))
+                ])),
+                expressionBody: null,
                 semicolonToken: Token(SyntaxKind.SemicolonToken));
         }
     }

--- a/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
+++ b/src/main/Yardarm/Generation/Schema/ExtensibleEnumSchemaGenerator.cs
@@ -160,7 +160,7 @@ internal class ExtensibleEnumSchemaGenerator(
                     initializer: null))
             ])),
             expressionBody: null,
-            semicolonToken: Token(SyntaxKind.SemicolonToken));
+            semicolonToken: default);
 
         // Static create method to satisfy the IExtensibleEnum<T> interface requirement
         if (Context.CurrentTargetFramework.Version.Major >= 7)
@@ -188,7 +188,7 @@ internal class ExtensibleEnumSchemaGenerator(
                     initializer: null))
                 ])),
                 expressionBody: null,
-                semicolonToken: Token(SyntaxKind.SemicolonToken));
+                semicolonToken: default);
         }
     }
 }

--- a/src/main/Yardarm/Generation/SyntaxNodeExtensions.cs
+++ b/src/main/Yardarm/Generation/SyntaxNodeExtensions.cs
@@ -100,9 +100,7 @@ public static class SyntaxNodeExtensions
         /// </summary>
         /// <returns><c>true</c> if the <see cref="SyntaxNode"/> is an extensible enumeration, otherwise <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="node"/> may not be <c>null</c>.</exception>
-        /// <remarks>
-        /// An extensible enumeration a strongly-typed string value that can accept any string, not just well-known values.
-        /// </remarks>
+        /// An extensible enumeration is a strongly-typed string value that can accept any string, not just well-known values.
         public bool IsExtensibleEnumeration()
         {
             ArgumentNullException.ThrowIfNull(node);

--- a/src/main/Yardarm/Generation/SyntaxNodeExtensions.cs
+++ b/src/main/Yardarm/Generation/SyntaxNodeExtensions.cs
@@ -94,5 +94,20 @@ public static class SyntaxNodeExtensions
 
             return node.GetGeneratorAnnotation() == typeof(ExternallyDiscriminatedUnionSchemaGenerator);
         }
+
+        /// <summary>
+        /// Returns <c>true</c> if the <see cref="SyntaxNode"/> is an extensible enumeration, otherwise <c>false</c>.
+        /// </summary>
+        /// <returns><c>true</c> if the <see cref="SyntaxNode"/> is an extensible enumeration, otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="node"/> may not be <c>null</c>.</exception>
+        /// <remarks>
+        /// An extensible enumeration a strongly-typed string value that can accept any string, not just well-known values.
+        /// </remarks>
+        public bool IsExtensibleEnumeration()
+        {
+            ArgumentNullException.ThrowIfNull(node);
+
+            return node.GetGeneratorAnnotation() == typeof(ExtensibleEnumSchemaGenerator);
+        }
     }
 }


### PR DESCRIPTION
Motivation
----------
This provides a clearer indication to the consumer of what well known values are available, making the values much more discoverable using Intellisense. It also allows the values to be passed by the consumer between methods in a strongly typed manner, making it more consistent with how traditional enumerations behave.

Modifications
-------------
Generate a `record struct` for each extensible enumeration that contains the string value. Include static read-only properties on the record that return the well known values. Include implicit conversions to and from `string` for ease of use.

Add `IsExternalInit` for download support of read-only records.

Add and internal `ExtensibleEnum` static class and `IExtensibleEnum<TSelf>` interface to the client to support serialization and deserialization.

Create converters supporting serialization and deserialization for literals, System.Text.Json, and Newtonsoft.Json, with related tests. Use attributes to attach the converters to the type.