### PR TITLE
Upgrade to .NET 10 libraries

### DIFF
--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -9,25 +9,25 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.29" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.29" />
     <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.9" />
+    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Client Dependencies -->
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('UnitTests'))">
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageVersion Include="System.Net.Http.Json" Version="9.0.17" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.17" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
+    <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 

--- a/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
+++ b/src/main/Yardarm.SystemTextJson/JsonDependencyGenerator.cs
@@ -10,22 +10,19 @@ public class JsonDependencyGenerator : IDependencyGenerator
 {
     public IEnumerable<LibraryDependency> GetDependencies(NuGetFramework targetFramework)
     {
-        if (targetFramework.Version.Major < 9)
+        if (targetFramework.Version.Major < 10)
         {
-            // Upgrade System.Text.Json to at least 9.0 if we're targeting downlevel frameworks
+            // Upgrade System.Text.Json to at least 10.0 if we're targeting downlevel frameworks
             yield return new LibraryDependency
             {
                 LibraryRange = new LibraryRange
                 {
                     Name = "System.Text.Json",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("9.0.17")
+                    VersionRange = VersionRange.Parse("10.0.10")
                 }
             };
-        }
 
-        if (targetFramework.Version.Major < 10)
-        {
             // System.Net.Http.Json is in-box in .NET 10 and later
             yield return new LibraryDependency
             {
@@ -33,7 +30,7 @@ public class JsonDependencyGenerator : IDependencyGenerator
                 {
                     Name = "System.Net.Http.Json",
                     TypeConstraint = LibraryDependencyTarget.Package,
-                    VersionRange = VersionRange.Parse("9.0.17")
+                    VersionRange = VersionRange.Parse("10.0.10")
                 }
             };
         }

--- a/src/main/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
+++ b/src/main/Yardarm/Packaging/Internal/StandardDependencyGenerator.cs
@@ -54,7 +54,7 @@ namespace Yardarm.Packaging.Internal
                     {
                         Name = "System.Collections.Immutable",
                         TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("8.0.0")
+                        VersionRange = VersionRange.Parse("10.0.10")
                     }
                 };
 
@@ -68,16 +68,17 @@ namespace Yardarm.Packaging.Internal
                     }
                 };
             }
-            else if (targetFramework.Version.Major < 8)
+            else if (targetFramework.Version.Major < 10)
             {
-                // .NET < 8 also requires System.Collections.Immutable for FrozenDictionary
+                // .NET < 8 also requires System.Collections.Immutable for FrozenDictionary,
+                // but upgrade to the .NET 10 version for .NET 8 and 9 for consistency
                 yield return new LibraryDependency
                 {
                     LibraryRange = new LibraryRange
                     {
                         Name = "System.Collections.Immutable",
                         TypeConstraint = LibraryDependencyTarget.Package,
-                        VersionRange = VersionRange.Parse("8.0.0")
+                        VersionRange = VersionRange.Parse("10.0.10")
                     }
                 };
             }


### PR DESCRIPTION
Motivation
----------
.NET 10 has been out long enough to stabilize, use .NET 10 libraries, especially System.Text.Json, so we can get improvements and new features.

Modifications
-------------
- Update package versions used internally
- Update package versions applied to generated SDKs