### PR TITLE
Target the .NET 10 SDK for the tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY ./src ./
 RUN dotnet publish --no-restore -c Release -r $(cat /tmp/arch) -p:PublishReadyToRun=true -p:VERSION=${VERSION} -o /publish ./main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
 
 # No --platform here so we get the base image for the target platform
-FROM mcr.microsoft.com/dotnet/runtime:8.0
+FROM mcr.microsoft.com/dotnet/runtime:10.0
 ARG VERSION
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,8 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0
 ARG VERSION
 WORKDIR /app
 
-COPY --from=build /publish/ ./
-RUN groupadd -g 1000 -r yardarm && useradd --no-log-init -u 1000 -r -g yardarm yardarm && \
-    mkdir -p /home/yardarm && \
-    chown yardarm:yardarm /home/yardarm && \
-    ln -s /app/Yardarm.CommandLine /app/yardarm
-ENV HOME=/home/yardarm PATH=/app:${PATH}
-USER 1000
+COPY --from=build --chown=$APP_UID:$APP_UID /publish/ ./
+RUN ln -s /app/Yardarm.CommandLine /app/yardarm
+ENV PATH=/app:${PATH}
+USER $APP_UID
 CMD ["yardarm"]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,6 +11,10 @@
 
     <UseArtifactsOutput>true</UseArtifactsOutput>
 
+    <YardarmTargetFramework>net10.0</YardarmTargetFramework>
+    <ClientTargetFrameworks>netstandard2.0;net8.0;net10.0</ClientTargetFrameworks>
+    <ClientUnitTestTargetFrameworks>net8.0;net10.0</ClientUnitTestTargetFrameworks>
+
     <!--
       The .Client projects still target .NET 6 to ensure compatibility when generating .NET 6 targets,
       despite the fact that .NET 6 is out of support. Support will be dropped from Yardarm at a later date.

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -55,4 +55,9 @@
     <None Include="**/*.net9.0.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(IsClientProject)' == 'true' And !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <Compile Remove="**/*.net10.0.cs" />
+    <None Include="**/*.net10.0.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -1,6 +1,11 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+    <YardarmSystemPackageVersion>10.0.10</YardarmSystemPackageVersion>
+
+    <!-- This version should be kept in sync with the versions added by the various dependency generators -->
+    <ClientSystemPackageVersion>10.0.10</ClientSystemPackageVersion>
   </PropertyGroup>
 
   <!-- Yardarm Dependencies-->
@@ -9,32 +14,31 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(YardarmSystemPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(YardarmSystemPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="$(YardarmSystemPackageVersion)" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.29" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.29" />
     <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="System.Linq.AsyncEnumerable" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Client Dependencies -->
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('UnitTests'))">
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(ClientSystemPackageVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.10" />
-    <PackageVersion Include="System.Net.Http.Json" Version="10.0.10" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="System.Net.Http.Json" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(ClientSystemPackageVersion)" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 
   <!-- Test Dependencies -->
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>

--- a/src/main/Yardarm.Benchmarks/Yardarm.Benchmarks.csproj
+++ b/src/main/Yardarm.Benchmarks/Yardarm.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/main/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
+++ b/src/main/Yardarm.Client.UnitTests/Yardarm.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientUnitTestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/main/Yardarm.Client/Yardarm.Client.csproj
+++ b/src/main/Yardarm.Client/Yardarm.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>

--- a/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -7,7 +7,7 @@
     <!--
       If .NET target runtime isn't installed, allow the command line tool to run on newer frameworks.
       This may not always work, but provides better compatibility. This option still prefers
-      to use the .NET target runtime as specified in YardarmTargetFrameworks above, and only uses a newer
+      to use the .NET target runtime as specified in TargetFramework above, and only uses a newer
       runtime if the target runtime isn't available.
     -->
     <RollForward>Major</RollForward>

--- a/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <!--
-      If .NET 8 isn't installed, allow the command line tool to run on newer frameworks.
+      If .NET target runtime isn't installed, allow the command line tool to run on newer frameworks.
       This may not always work, but provides better compatibility. This option still prefers
-      to use the .NET 8 runtime as specified in TargetFramework above, and only uses a newer
-      runtime if .NET 8 isn't available.
+      to use the .NET target runtime as specified in YardarmTargetFrameworks above, and only uses a newer
+      runtime if the target runtime isn't available.
     -->
     <RollForward>Major</RollForward>
 

--- a/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp.Client/Yardarm.MicrosoftExtensionsHttp.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>

--- a/src/main/Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj
+++ b/src/main/Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <Nullable>enable</Nullable>
 

--- a/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>

--- a/src/main/Yardarm.NewtonsoftJson.UnitTests/Yardarm.NewtonsoftJson.UnitTests.csproj
+++ b/src/main/Yardarm.NewtonsoftJson.UnitTests/Yardarm.NewtonsoftJson.UnitTests.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientUnitTestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Yardarm.NewtonsoftJson\Yardarm.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\Yardarm.NewtonsoftJson.Client\Yardarm.NewtonsoftJson.Client.csproj" />
   </ItemGroup>
 

--- a/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
+++ b/src/main/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <Nullable>enable</Nullable>
 

--- a/src/main/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj
+++ b/src/main/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>

--- a/src/main/Yardarm.NodaTime.UnitTests/Yardarm.NodaTime.UnitTests.csproj
+++ b/src/main/Yardarm.NodaTime.UnitTests/Yardarm.NodaTime.UnitTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientUnitTestTargetFrameworks)</TargetFrameworks>
+
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Yardarm.NodaTime\Yardarm.NodaTime.csproj" />
     <ProjectReference Include="..\Yardarm.NodaTime.Client\Yardarm.NodaTime.Client.csproj" />
   </ItemGroup>
 

--- a/src/main/Yardarm.NodaTime/Yardarm.NodaTime.csproj
+++ b/src/main/Yardarm.NodaTime/Yardarm.NodaTime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <Nullable>enable</Nullable>
 

--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientTargetFrameworks)</TargetFrameworks>
     <OutputType>Library</OutputType>
 
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
+      </PropertyGroup>
 
   <PropertyGroup>
     <EnableTrimAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</EnableTrimAnalyzer>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
-    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" />
+    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
+++ b/src/main/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj
@@ -6,7 +6,7 @@
 
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
-      </PropertyGroup>
+  </PropertyGroup>
 
   <PropertyGroup>
     <EnableTrimAnalyzer Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</EnableTrimAnalyzer>

--- a/src/main/Yardarm.SystemTextJson.UnitTests/Yardarm.SystemTextJson.UnitTests.csproj
+++ b/src/main/Yardarm.SystemTextJson.UnitTests/Yardarm.SystemTextJson.UnitTests.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>$(ClientUnitTestTargetFrameworks)</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Yardarm.SystemTextJson\Yardarm.SystemTextJson.csproj" />
     <ProjectReference Include="..\Yardarm.SystemTextJson.Client\Yardarm.SystemTextJson.Client.csproj" />
   </ItemGroup>
 

--- a/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
+++ b/src/main/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <Nullable>enable</Nullable>
 

--- a/src/main/Yardarm.UnitTests/Yardarm.UnitTests.csproj
+++ b/src/main/Yardarm.UnitTests/Yardarm.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/Solution Items/">
+    <File Path="../../Dockerfile" />
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
     <File Path="../global.json" />

--- a/src/main/Yardarm/Yardarm.csproj
+++ b/src/main/Yardarm/Yardarm.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>$(YardarmTargetFramework)</TargetFrameworks>
 
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -20,7 +20,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="NuGet.Commands" />
-    <PackageReference Include="System.Linq.AsyncEnumerable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -2,7 +2,7 @@
   <Import Project="../Yardarm.Sdk/Sdk/Sdk.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
     <KeyFile>..\..\Yardarm.snk</KeyFile>
 
     <!-- Override these for local testing, get directly from build output -->

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -66,7 +66,7 @@
     <!--
       Ensure that the CommandLine build has been run for both RuntimeIdentifier values
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=net8.0;SelfContained=False;PublishReadyToRun=true" Targets="Restore;Publish" BuildInParallel="false" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=true" Targets="Restore;Publish" BuildInParallel="false" SkipNonexistentProjects="false" ContinueOnError="false">
     </MSBuild>
   </Target>
 
@@ -83,7 +83,7 @@
       the cost of actually copying the files to a publish directory, instead it collects the returned items
       and we can load them directly into the NuGet package.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=net8.0;SelfContained=False;PublishReadyToRun=true" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=true" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
       <Output TaskParameter="TargetOutputs" ItemName="_YardarmCommandLineFiles" />
     </MSBuild>
 
@@ -119,7 +119,7 @@
       Convert the collected _FilteredYardarmCommandLineFiles into _PackageFiles items marked for pack in the appropriate directories.
     -->
     <ItemGroup>
-      <_PackageFiles Include="@(_FilteredYardarmCommandLineFiles)" BuildAction="None" Pack="true" PackagePath="tools\net8.0\%(_FilteredYardarmCommandLineFiles.RuntimeIdentifier)\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
+      <_PackageFiles Include="@(_FilteredYardarmCommandLineFiles)" BuildAction="None" Pack="true" PackagePath="tools\$(YardarmTargetFramework)\%(_FilteredYardarmCommandLineFiles.RuntimeIdentifier)\yardarm\%(_FilteredYardarmCommandLineFiles.TargetPath)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Motivation
----------
.NET 10 SDK has been out for a while now, and the .NET 8 SDK will be EOL soon. At this point, most users will have the .NET 10 SDK installed.

Modifications
-------------
- Target Yardarm at .NET 10, including removing the unnecessary reference to System.Linq.AsyncEnumerable
- Remove .NET 6 targets for testing, it has been EOL for a while
- Move target runtimes to shared properties for easy reuse
- Switch the Docker image from a custom `yardarm` user 1000 to the built-in `app` user, user 1000 is used by Ubuntu in the  .NET 10 base image
- Make a couple of package reference tweaks