### PR TITLE
Build the dotnet tool multi-arch and ReadyToRun

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
           tag-prefix: release/
 
   build:
-    runs-on: ubuntu-latest
+    # Yardarm.CommandLine must be built on Windows to support building ReadyToRun images for multiple platforms
+    runs-on: windows-latest
     needs: version
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY ["src/main/*.props", "src/main/*.targets", "./main/"]
 RUN dotnet restore -r $(cat /tmp/arch) -p:PublishReadyToRun=true ./main/Core/Yardarm.CommandLine/Yardarm.CommandLine.csproj
 
 COPY ./src ./
-RUN dotnet publish --no-restore -c Release -r $(cat /tmp/arch) -p:PublishReadyToRun=true -p:VERSION=${VERSION} -o /app ./main/Core/Yardarm.CommandLine/Yardarm.CommandLine.csproj && \
+RUN dotnet publish --no-restore -c Release -r $(cat /tmp/arch) -p:VERSION=${VERSION} -o /app ./main/Core/Yardarm.CommandLine/Yardarm.CommandLine.csproj && \
     ln -s /app/Yardarm.CommandLine /app/yardarm
 
 # No --platform here so we get the base image for the target platform

--- a/src/main/Core/Yardarm.CommandLine/Yardarm.CommandLine.csproj
+++ b/src/main/Core/Yardarm.CommandLine/Yardarm.CommandLine.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>$(YardarmTargetFramework)</TargetFramework>
 
     <!--
+      Publish for several specific runtime identifiers, but also publish "any" for use with any other runtime.
+    -->
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64;any</RuntimeIdentifiers>
+    <PublishReadyToRun>true</PublishReadyToRun>
+
+    <!--
       If .NET target runtime isn't installed, allow the command line tool to run on newer frameworks.
       This may not always work, but provides better compatibility. This option still prefers
       to use the .NET target runtime as specified in TargetFramework above, and only uses a newer
@@ -19,8 +25,6 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Description>Command-line tool to generate C# SDKs directly from OpenAPI 3 specifications using the Roslyn compiler.</Description>
 
     <PackAsTool>true</PackAsTool>

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -66,7 +66,7 @@
     <!--
       Ensure that the CommandLine build has been run for both RuntimeIdentifier values
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=true" Targets="Restore;Publish" BuildInParallel="false" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False" Targets="Restore;Publish" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
     </MSBuild>
   </Target>
 
@@ -83,7 +83,7 @@
       the cost of actually copying the files to a publish directory, instead it collects the returned items
       and we can load them directly into the NuGet package.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=true" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
       <Output TaskParameter="TargetOutputs" ItemName="_YardarmCommandLineFiles" />
     </MSBuild>
 


### PR DESCRIPTION
Motivation
----------
The .NET 10 SDK supports multi-architecture dotnet tools. To improve startup performance, publish the Yardarm .NET tool under several common architectures as ReadyToRun.

Modifications
-------------
- Add RIDs to the Yardarm.CommandLine project
- Set PublishReadyToRun directly in the Yardarm.CommandLine project rather than in the Dockerfile or SDK build
- Don't generate symbols, this is incompatible with tool multi-arch builds and not very useful anyway
- Enable parallel build when referenced from the SDK