### PR TITLE
Move to .NET 10 for the SDK task

### DIFF
--- a/src/Client.Packages.props
+++ b/src/Client.Packages.props
@@ -1,0 +1,23 @@
+<Project>
+  <!--
+    Package versions in this file should match the behaviors in the various dependency generators
+    (e.g. JsonDependencyGenerator and StandardDependencyGenerator). They are used for local test builds
+    of the client projects and the Yardarm.SDK.Test project.
+  -->
+
+  <PropertyGroup>
+    <ClientSystemPackageVersion>10.0.10</ClientSystemPackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('Client.UnitTests')) Or $(MSBuildProjectFile.Contains('Sdk.Test'))">
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="System.Net.Http.Json" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(ClientSystemPackageVersion)" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+  </ItemGroup>
+</Project>

--- a/src/main/Client.Packages.props
+++ b/src/main/Client.Packages.props
@@ -2,7 +2,7 @@
   <!--
     Package versions in this file should match the behaviors in the various dependency generators
     (e.g. JsonDependencyGenerator and StandardDependencyGenerator). They are used for local test builds
-    of the client projects and the Yardarm.SDK.Test project.
+    of the client projects and the Yardarm.Sdk.Test project.
   -->
 
   <PropertyGroup>

--- a/src/main/Client.Packages.props
+++ b/src/main/Client.Packages.props
@@ -9,7 +9,7 @@
     <ClientSystemPackageVersion>10.0.10</ClientSystemPackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('Client.UnitTests')) Or $(MSBuildProjectFile.Contains('Sdk.Test'))">
+  <ItemGroup>
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(ClientSystemPackageVersion)" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/main/Core/Yardarm.CommandLine/Interop/DtoSerializerContext.cs
+++ b/src/main/Core/Yardarm.CommandLine/Interop/DtoSerializerContext.cs
@@ -1,6 +1,4 @@
-﻿#if NET6_0_OR_GREATER
-
-using System;
+﻿using System;
 using System.Text.Json.Serialization;
 
 #nullable enable
@@ -13,5 +11,3 @@ namespace Yardarm.CommandLine.Interop
     {
     }
 }
-
-#endif

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -29,5 +29,6 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)../Client.Packages.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Client.Packages.props"
+          Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('Client.UnitTests'))"/>
 </Project>

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -3,9 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
     <YardarmSystemPackageVersion>10.0.10</YardarmSystemPackageVersion>
-
-    <!-- This version should be kept in sync with the versions added by the various dependency generators -->
-    <ClientSystemPackageVersion>10.0.10</ClientSystemPackageVersion>
   </PropertyGroup>
 
   <!-- Yardarm Dependencies-->
@@ -24,17 +21,6 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
 
-  <!-- Client Dependencies -->
-  <ItemGroup Condition="$(MSBuildProjectFile.Contains('Client')) Or $(MSBuildProjectFile.Contains('UnitTests'))">
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(ClientSystemPackageVersion)" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.4.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="$(ClientSystemPackageVersion)" />
-    <PackageVersion Include="System.Net.Http.Json" Version="$(ClientSystemPackageVersion)" />
-    <PackageVersion Include="System.Text.Json" Version="$(ClientSystemPackageVersion)" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-  </ItemGroup>
-
   <!-- Test Dependencies -->
   <ItemGroup Condition="$(MSBuildProjectFile.Contains('UnitTests'))">
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
@@ -42,4 +28,6 @@
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)../Client.Packages.props" />
 </Project>

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -9,11 +9,11 @@
   </Folder>
   <Folder Name="/Global/">
     <File Path="../../Dockerfile" />
-    <File Path="../Client.Packages.props" />
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
     <File Path="../global.json" />
     <File Path="../nuget.config" />
+    <File Path="Client.Packages.props" />
     <File Path="Directory.Packages.props" />
   </Folder>
   <Folder Name="/MicrosoftExtensionsHttp/">

--- a/src/main/Yardarm.slnx
+++ b/src/main/Yardarm.slnx
@@ -9,6 +9,7 @@
   </Folder>
   <Folder Name="/Global/">
     <File Path="../../Dockerfile" />
+    <File Path="../Client.Packages.props" />
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
     <File Path="../global.json" />
@@ -20,18 +21,18 @@
     <Project Path="MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp/Yardarm.MicrosoftExtensionsHttp.csproj" />
   </Folder>
   <Folder Name="/NewtonsoftJson/">
-    <Project Path="NewtonsoftJson/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj" />
     <Project Path="NewtonsoftJson/Yardarm.NewtonsoftJson.Client.UnitTests/Yardarm.NewtonsoftJson.Client.UnitTests.csproj" />
+    <Project Path="NewtonsoftJson/Yardarm.NewtonsoftJson.Client/Yardarm.NewtonsoftJson.Client.csproj" />
     <Project Path="NewtonsoftJson/Yardarm.NewtonsoftJson/Yardarm.NewtonsoftJson.csproj" />
   </Folder>
   <Folder Name="/NodaTime/">
-    <Project Path="NodaTime/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj" />
     <Project Path="NodaTime/Yardarm.NodaTime.Client.UnitTests/Yardarm.NodaTime.Client.UnitTests.csproj" />
+    <Project Path="NodaTime/Yardarm.NodaTime.Client/Yardarm.NodaTime.Client.csproj" />
     <Project Path="NodaTime/Yardarm.NodaTime/Yardarm.NodaTime.csproj" />
   </Folder>
   <Folder Name="/SystemTextJson/">
-    <Project Path="SystemTextJson/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj" />
     <Project Path="SystemTextJson/Yardarm.SystemTextJson.Client.UnitTests/Yardarm.SystemTextJson.Client.UnitTests.csproj" />
+    <Project Path="SystemTextJson/Yardarm.SystemTextJson.Client/Yardarm.SystemTextJson.Client.csproj" />
     <Project Path="SystemTextJson/Yardarm.SystemTextJson/Yardarm.SystemTextJson.csproj" />
   </Folder>
 </Solution>

--- a/src/sdk/Directory.Packages.props
+++ b/src/sdk/Directory.Packages.props
@@ -7,8 +7,4 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.3.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.3.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.Build.CopyOnWrite" Version="1.0.322" />
-  </ItemGroup>
 </Project>

--- a/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
+++ b/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
@@ -1,37 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildThisFileDirectory)../Directory.Packages.props" />
-
-  <!--
-    Package versions in this file should match the behaviors in the various dependency generators
-    (e.g. JsonDependencyGenerator and StandardDependencyGenerator).
-  -->
-
-  <ItemGroup>
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NodaTime.Serialization.JsonNet" Version="3.2.0" />
-    <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'netstandard2.1'))">
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
-    <PackageVersion Include="System.Net.Http.Json" Version="9.0.0" />
-  </ItemGroup>
+  <Import Project="$(MSBuildThisFileDirectory)../../Client.Packages.props" />
 </Project>

--- a/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
+++ b/src/sdk/Yardarm.Sdk.Test/Directory.Packages.props
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildThisFileDirectory)../Directory.Packages.props" />
-  <Import Project="$(MSBuildThisFileDirectory)../../Client.Packages.props" />
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)../../main/Client.Packages.props" />
 </Project>

--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -8,8 +8,6 @@
     <!-- Override these for local testing, get directly from build output -->
     <YardarmToolPath Condition=" $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_linux-x64\</YardarmToolPath>
     <YardarmToolPath Condition=" !$([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_win-x64\</YardarmToolPath>
-
-    <!-- Below uses a trailing underscore instead of a slash due to the artifacts directory layout -->
     <YardarmTaskBasePath>$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.Sdk\$(Configuration.ToLower())\</YardarmTaskBasePath>
 
     <JsonMode>System.Text.Json</JsonMode>

--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -10,8 +10,7 @@
     <YardarmToolPath Condition=" !$([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_win-x64\</YardarmToolPath>
 
     <!-- Below uses a trailing underscore instead of a slash due to the artifacts directory layout -->
-    <YardarmTaskBasePath Condition=" '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.Sdk\$(Configuration.ToLower())_</YardarmTaskBasePath>
-    <YardarmTaskBasePath Condition=" '$(MSBuildRuntimeType)' != 'Core' ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.Sdk\$(Configuration.ToLower())_</YardarmTaskBasePath>
+    <YardarmTaskBasePath>$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.Sdk\$(Configuration.ToLower())\</YardarmTaskBasePath>
 
     <JsonMode>System.Text.Json</JsonMode>
     <DateTimeMode>Legacy</DateTimeMode>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -6,9 +6,9 @@
 
     <UsingYardarmSdk>true</UsingYardarmSdk>
 
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' And $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\tools\net8.0\linux-x64\yardarm\</YardarmToolPath>
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\net8.0\win-x64\yardarm\</YardarmToolPath>
-    <YardarmTaskBasePath Condition=" '$(YardarmTaskBasePath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\</YardarmTaskBasePath>
+    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' And $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\tools\net10.0\linux-x64\yardarm\</YardarmToolPath>
+    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\net10.0\win-x64\yardarm\</YardarmToolPath>
+    <YardarmTaskBasePath Condition=" '$(YardarmTaskBasePath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\net10.0\</YardarmTaskBasePath>
   </PropertyGroup>
 
   <Import Project="$(CustomBeforeYardarmProps)" Condition=" '$(CustomBeforeYardarmProps)' != '' And Exists('$(CustomBeforeYardarmProps)') " />

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -16,13 +16,32 @@
     Add Yardarm tasks.
   -->
   <PropertyGroup>
-    <YardarmTaskAssembly Condition=" '$(YardarmTaskAssembly)' == '' And '$(MSBuildRuntimeType)' == 'Core' ">$(YardarmTaskBasePath)netcoreapp3.1\Yardarm.Build.Tasks.dll</YardarmTaskAssembly>
-    <YardarmTaskAssembly Condition=" '$(YardarmTaskAssembly)' == '' And '$(MSBuildRuntimeType)' != 'Core' ">$(YardarmTaskBasePath)net472\Yardarm.Build.Tasks.dll</YardarmTaskAssembly>
+    <YardarmTaskAssembly Condition=" '$(YardarmTaskAssembly)' == '' ">$(YardarmTaskBasePath)Yardarm.Build.Tasks.dll</YardarmTaskAssembly>
   </PropertyGroup>
+
   <UsingTask TaskName="Yardarm.Build.Tasks.YardarmGenerate"
-             AssemblyFile="$(YardarmTaskAssembly)" />
+             AssemblyFile="$(YardarmTaskAssembly)"
+             Runtime="NET"
+             Architecture="CurrentArchitecture"
+             Condition=" '$(MSBuildRuntimeType)' == 'Core' " />
+  <UsingTask TaskName="Yardarm.Build.Tasks.YardarmGenerate"
+             AssemblyFile="$(YardarmTaskAssembly)"
+             Runtime="NET"
+             Architecture="*"
+             TaskFactory="TaskHostFactory"
+             Condition=" '$(MSBuildRuntimeType)' == 'Full' "/>
+
   <UsingTask TaskName="Yardarm.Build.Tasks.YardarmCollectDependencies"
-             AssemblyFile="$(YardarmTaskAssembly)" />
+             AssemblyFile="$(YardarmTaskAssembly)"
+             Runtime="NET"
+             Architecture="CurrentArchitecture"
+             Condition=" '$(MSBuildRuntimeType)' == 'Core' " />
+  <UsingTask TaskName="Yardarm.Build.Tasks.YardarmCollectDependencies"
+             AssemblyFile="$(YardarmTaskAssembly)"
+             Runtime="NET"
+             Architecture="*"
+             TaskFactory="TaskHostFactory"
+             Condition=" '$(MSBuildRuntimeType)' == 'Full' "/>
 
   <PropertyGroup>
     <!-- This property must be overridden to remove a few targets that compile assemblies -->

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
 
     <AssemblyName>Yardarm.Build.Tasks</AssemblyName>
     <RootNamespace>Yardarm.Build.Tasks</RootNamespace>
@@ -29,10 +29,6 @@
     <Compile Include="..\..\main\Core\Yardarm.CommandLine\Interop\*.cs">
       <LinkBase>Interop</LinkBase>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-    <Reference Include="System.Runtime.Serialization" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Yardarm.CommandLine.Interop;
-
-#if NETCOREAPP
-using System.Text.Json;
-#else
-using System.IO;
-using System.Runtime.Serialization.Json;
-#endif
 
 namespace Yardarm.Build.Tasks;
 
@@ -18,17 +12,10 @@ public class YardarmCollectDependencies : YardarmCommonTask
 {
     private const string AddItemPrefix = "AddItem: ";
 
-#if NETCOREAPP
     private static readonly JsonSerializerOptions s_serializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
-#else
-    private static readonly DataContractJsonSerializer s_serializer = new(typeof(AddItemDto), new DataContractJsonSerializerSettings
-    {
-        UseSimpleDictionaryFormat = true
-    });
-#endif
 
     protected override string Verb => "collect-dependencies";
 
@@ -63,14 +50,7 @@ public class YardarmCollectDependencies : YardarmCommonTask
         {
             singleLine = singleLine.Substring(AddItemPrefix.Length);
 
-#if NETCOREAPP
             var item = JsonSerializer.Deserialize<AddItemDto>(singleLine, s_serializerOptions)!;
-#else
-            // Since we need to be compatible with net472 and don't want to take dependencies, we must engage in this ugliness
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(singleLine));
-            var item = (AddItemDto) s_serializer.ReadObject(stream);
-#endif
-
             if (!string.IsNullOrWhiteSpace(item.Identity))
             {
                 var taskItem = new TaskItem(item.Identity);

--- a/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCollectDependencies.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/sdk/Yardarm.Sdk/YardarmTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmTask.cs
@@ -5,22 +5,20 @@ using Microsoft.Build.Utilities;
 
 namespace Yardarm.Build.Tasks
 {
-    public abstract class YardarmTask : ToolTask
+    public abstract partial class YardarmTask : ToolTask
     {
-        private static readonly Regex s_errorRegex = new Regex(@"^\[(\w+)\] (.+)");
+        [GeneratedRegex(@"^\[(\w+)\] (.+)")]
+        private static partial Regex ErrorRegex { get; }
 
         protected override string GenerateFullPathToTool() => ToolName;
 
         protected override string ToolName =>
-#if NETCOREAPP
-            (int) Environment.OSVersion.Platform > 3 ? "Yardarm.CommandLine" :
-#endif
-            "Yardarm.CommandLine.exe";
+            (int) Environment.OSVersion.Platform > 3 ? "Yardarm.CommandLine" : "Yardarm.CommandLine.exe";
 
 
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
         {
-            var match = s_errorRegex.Match(singleLine);
+            var match = ErrorRegex.Match(singleLine);
 
             if (match.Success)
             {


### PR DESCRIPTION
Motivation
----------
.NET 10 SDK and VS2026 and MSBuild 18 now allow the use of .NET 10 tasks, even for builds from the CLR4 variant of MSBuild.

Modifications
-------------
- Update Yardarm.Sdk to target .NET 10 only, dropping .NET 4.7.2 and updating from netcoreapp3.1
- Register the tasks to run with TaskHostFactory when executing from a CLR4 variant of MSBuild
- Move client dependendency versioning to a separate props file so we can have consistent versions with the Yardarm.Sdk.Test project
- Cleanup conditional compilation