### PR TITLE
Enable C# language preview features during generated client compilation

### DIFF
--- a/src/main/Core/Yardarm/GenerationContext.cs
+++ b/src/main/Core/Yardarm/GenerationContext.cs
@@ -66,7 +66,7 @@ namespace Yardarm
                     _parseOptions = null;
                 }
             }
-        } = LanguageVersion.CSharp14;
+        } = LanguageVersion.Preview; // Change once we have access to C# 15
 
         public CSharpParseOptions ParseOptions => _parseOptions ??=
             CSharpParseOptions.Default

--- a/src/main/Directory.Packages.props
+++ b/src/main/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 
+    <RoslynVersion>5.6.0</RoslynVersion>
     <YardarmSystemPackageVersion>10.0.10</YardarmSystemPackageVersion>
   </PropertyGroup>
 
@@ -9,8 +10,8 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(YardarmSystemPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(YardarmSystemPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(YardarmSystemPackageVersion)" />


### PR DESCRIPTION
Motivation
----------
System.Text.Json source generators expect to be able to use union type conversion features when serializing properties that are unions. We get compilation failures if a union type is used as a property on an object without the union C# feature enabled.

Modifications
-------------
- Enable C# 15 preview features for now
- Make changing the Roslyn version easier in the future with a single version property