### PR TITLE
Include YardarmSdkVersion property in the package

### DIFF
--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -11,6 +11,10 @@
     <YardarmTaskBasePath Condition=" '$(YardarmTaskBasePath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\net10.0\</YardarmTaskBasePath>
   </PropertyGroup>
 
+  <!-- Include the SdkVersion.props file if it exists. This is generated dynamically at pack time. -->
+  <Import Project="$(MSBuildThisFileDirectory)SdkVersion.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)SdkVersion.props')" />
+
   <Import Project="$(CustomBeforeYardarmProps)" Condition=" '$(CustomBeforeYardarmProps)' != '' And Exists('$(CustomBeforeYardarmProps)') " />
 
   <PropertyGroup>

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -18,6 +18,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
 
     <NoWarn>$(NoWarn);NU5100;NU5128;NU5129</NoWarn>
+
+    <GeneratedSdkVersionProps>$(BaseIntermediateOutputPath)SdkVersion.props</GeneratedSdkVersionProps>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,6 +40,34 @@
     <!-- Make sure VS considers any change to any of the targets as requiring a new build/pack -->
     <UpToDateCheckInput Include="@(Content)" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <GenerateNuspecDependsOn>
+      CollectYardarmCommandLine;
+      GenerateSdkVersionProps;
+      $(GenerateNuspecDependsOn)
+    </GenerateNuspecDependsOn>
+  </PropertyGroup>
+
+  <!-- Generate a SdkVersion.props file that contains the current version of the Yardarm.Sdk package. -->
+  <Target Name="GenerateSdkVersionProps">
+    <PropertyGroup>
+      <_SdkVersionPropsContent>
+&lt;Project&gt;
+  &lt;PropertyGroup&gt;
+    &lt;YardarmSdkVersion&gt;$(PackageVersion)&lt;/YardarmSdkVersion&gt;
+  &lt;/PropertyGroup&gt;
+&lt;/Project&gt;
+      </_SdkVersionPropsContent>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(GeneratedSdkVersionProps)" Overwrite="true" WriteOnlyWhenDifferent="true" Lines="$(_SdkVersionPropsContent)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(GeneratedSdkVersionProps)" />
+      <_PackageFiles Include="$(GeneratedSdkVersionProps)" Pack="true" PackagePath="Sdk/SdkVersion.props" />
+    </ItemGroup>
+  </Target>
 
   <!--
     Publish and collect the Yardarm command-line application to include as a tool.
@@ -66,12 +96,6 @@
     </MSBuild>
   </Target>
 
-  <PropertyGroup>
-    <GenerateNuspecDependsOn>
-      CollectYardarmCommandLine;
-      $(GenerateNuspecDependsOn)
-    </GenerateNuspecDependsOn>
-  </PropertyGroup>
   <Target Name="CollectYardarmCommandLine"
           DependsOnTargets="DefineYardarmCommandLineRids;BuildYardarmCommandLine">
     <!--


### PR DESCRIPTION
Motivation
----------
This makes it easier for SDK-style package generators to consume extensions with versions that match the SDK version.

Modifications
-------------
Dynamically generate a props file with the package version that sets the YardarmSdkVersion property and include it in the Yardarm.Sdk package.