### PR TITLE
Use BaseNamespaceDeclarationSyntax for namespace enrichment

### DIFF
--- a/src/main/Core/Yardarm/Enrichment/Responses/ResponseTypeCastExtensionEnricher.cs
+++ b/src/main/Core/Yardarm/Enrichment/Responses/ResponseTypeCastExtensionEnricher.cs
@@ -27,7 +27,7 @@ namespace Yardarm.Enrichment.Responses
         public CompilationUnitSyntax Enrich(CompilationUnitSyntax target,
             OpenApiEnrichmentContext<OpenApiResponses> context)
         {
-            NamespaceDeclarationSyntax? ns = target.ChildNodes().OfType<NamespaceDeclarationSyntax>().FirstOrDefault();
+            BaseNamespaceDeclarationSyntax? ns = target.ChildNodes().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
             if (ns == null)
             {
                 return target;


### PR DESCRIPTION
Motivation
----------
Since we've switch to using file-scoped namespaces in 0.8.0 the ResponseTypeCastExtensionEnricher is not performing any enrichments.

Modifications
-------------
Use BaseNamespaceDeclarationSyntax so it works against either namespace declaration pattern.