### PR TITLE
Shrink SDK package payload

### DIFF
--- a/docs/generating/yardarm-sdk.md
+++ b/docs/generating/yardarm-sdk.md
@@ -16,6 +16,11 @@ managed much like any other C# project.
 - Reference the project as a `PackageReference` from other .NET projects
 - `dotnet restore`, `dotnet build`, and `dotnet pack` support
 
+## Requirements
+
+Yardarm SDK runs its bundled command-line generator with the installed .NET runtime. It supports
+Windows, Linux, and macOS on x64 and ARM64 when a compatible .NET runtime is available.
+
 ## Example Project
 
 Create the below as a `.csproj` file and include a `.yaml` or `.json` OpenAPI specification

--- a/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
+++ b/src/sdk/Yardarm.Sdk.Test/Yardarm.Sdk.Test.csproj
@@ -6,8 +6,7 @@
     <KeyFile>..\..\Yardarm.snk</KeyFile>
 
     <!-- Override these for local testing, get directly from build output -->
-    <YardarmToolPath Condition=" $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_linux-x64\</YardarmToolPath>
-    <YardarmToolPath Condition=" !$([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_win-x64\</YardarmToolPath>
+    <YardarmToolPath>$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.CommandLine\$(Configuration.ToLower())_any\</YardarmToolPath>
     <YardarmTaskBasePath>$(MSBuildThisFileDirectory)..\..\artifacts\bin\Yardarm.Sdk\$(Configuration.ToLower())\</YardarmTaskBasePath>
 
     <JsonMode>System.Text.Json</JsonMode>

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.props
@@ -6,8 +6,7 @@
 
     <UsingYardarmSdk>true</UsingYardarmSdk>
 
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' And $([MSBuild]::IsOSPlatform('Linux')) ">$(MSBuildThisFileDirectory)..\tools\net10.0\linux-x64\yardarm\</YardarmToolPath>
-    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\net10.0\win-x64\yardarm\</YardarmToolPath>
+    <YardarmToolPath Condition=" '$(YardarmToolPath)' == '' ">$(MSBuildThisFileDirectory)..\tools\net10.0\any\yardarm\</YardarmToolPath>
     <YardarmTaskBasePath Condition=" '$(YardarmTaskBasePath)' == '' ">$(MSBuildThisFileDirectory)..\tasks\net10.0\</YardarmTaskBasePath>
   </PropertyGroup>
 

--- a/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
+++ b/src/sdk/Yardarm.Sdk/Sdk/Sdk.targets
@@ -141,7 +141,7 @@
           DependsOnTargets="CollectYardarmExtensions;_ResolveYardarmProperties"
           Returns="@(PackageReference);@(PackageDownload)">
     <YardarmCollectDependencies
-      ToolPath="$(YardarmToolPath)"
+      YardarmToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
       RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"
@@ -203,7 +203,7 @@
     </PropertyGroup>
 
     <YardarmGenerate
-      ToolPath="$(YardarmToolPath)"
+      YardarmToolPath="$(YardarmToolPath)"
       AssemblyName="$(AssemblyName)"
       RootNamespace="$(RootNamespace)"
       TargetFramework="$(TargetFramework)"

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -74,8 +74,7 @@
     Only do this once as part of the outer multi-targeting run.
   -->
   <ItemGroup>
-    <YardarmCommandLineRuntimeIdentifier Include="win-x64" />
-    <YardarmCommandLineRuntimeIdentifier Include="linux-x64" />
+    <YardarmCommandLineRuntimeIdentifier Include="any" />
   </ItemGroup>
 
   <Target Name="DefineYardarmCommandLineRids">
@@ -90,9 +89,10 @@
   <Target Name="BuildYardarmCommandLine"
           DependsOnTargets="DefineYardarmCommandLineRids">
     <!--
-      Ensure that the CommandLine build has been run for both RuntimeIdentifier values
+      Build the portable command-line payload used only by the SDK package. The command-line
+      project's own multi-RID tool package remains unchanged.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False" Targets="Restore;Publish" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=false" Targets="Restore;Publish" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
     </MSBuild>
   </Target>
 
@@ -103,7 +103,7 @@
       the cost of actually copying the files to a publish directory, instead it collects the returned items
       and we can load them directly into the NuGet package.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=false" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
       <Output TaskParameter="TargetOutputs" ItemName="_YardarmCommandLineFiles" />
     </MSBuild>
 
@@ -111,28 +111,9 @@
       Filter the files being published to just the files needed by Yardarm, ignoring .xml and .pdb files, etc.
     -->
     <ItemGroup>
-      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine.exe' " />
-      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(Extension)' == '.dll' " />
-      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine.deps.json' " />
-      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine.runtimeconfig.json' " />
-
-      <_YardarmCommandLineLinuxExecutable Include="@(_YardarmCommandLineFiles-&gt;ClearMetadata())" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine' " RuntimeIdentifier="%(_YardarmCommandLineFiles.RuntimeIdentifier)" />
-    </ItemGroup>
-
-    <!--
-      PackagePath for specifying a destination will only assume that its value is a file name if it has an extension and that extension
-      matches the original file's extension. Otherwise, it assumes that PackagePath is a destination directory. Therefore, the plain
-      "Yardarm.CommandLine" from Linux will get put in a subdirectory (it's original name is "apphost"). Therefore, we must copy it
-      to a temporary directory with a matching name and no TargetPath metadata.
-    -->
-    <ItemGroup>
-      <_CopiedYardarmCommandLineLinuxExecutable Include="@(_YardarmCommandLineLinuxExecutable->'$(BaseIntermediateOutputPath)pubtemp\%(RuntimeIdentifier)\Yardarm.CommandLine')" />
-    </ItemGroup>
-    <Copy SourceFiles="@(_YardarmCommandLineLinuxExecutable)" DestinationFiles="@(_CopiedYardarmCommandLineLinuxExecutable)" SkipUnchangedFiles="true">
-    </Copy>
-    <ItemGroup>
-      <_FilteredYardarmCommandLineFiles Include="@(_CopiedYardarmCommandLineLinuxExecutable)" />
-      <FileWrites Include="@(_CopiedYardarmCommandLineLinuxExecutable)" />
+      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(Extension)' == '.dll' " RuntimeIdentifier="any" />
+      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine.deps.json' " RuntimeIdentifier="any" />
+      <_FilteredYardarmCommandLineFiles Include="@(_YardarmCommandLineFiles)" Condition=" '%(TargetPath)' == 'Yardarm.CommandLine.runtimeconfig.json' " RuntimeIdentifier="any" />
     </ItemGroup>
 
     <!--

--- a/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
+++ b/src/sdk/Yardarm.Sdk/Yardarm.Sdk.csproj
@@ -73,37 +73,23 @@
     Publish and collect the Yardarm command-line application to include as a tool.
     Only do this once as part of the outer multi-targeting run.
   -->
-  <ItemGroup>
-    <YardarmCommandLineRuntimeIdentifier Include="any" />
-  </ItemGroup>
-
-  <Target Name="DefineYardarmCommandLineRids">
-    <ItemGroup>
-      <_YardarmCommandLine Include="..\..\main\Core\Yardarm.CommandLine\Yardarm.CommandLine.csproj">
-        <AdditionalProperties>RuntimeIdentifier=%(YardarmCommandLineRuntimeIdentifier.Identity)</AdditionalProperties>
-        <RuntimeIdentifier>%(YardarmCommandLineRuntimeIdentifier.Identity)</RuntimeIdentifier>
-      </_YardarmCommandLine>
-    </ItemGroup>
-  </Target>
-
-  <Target Name="BuildYardarmCommandLine"
-          DependsOnTargets="DefineYardarmCommandLineRids">
+  <Target Name="BuildYardarmCommandLine">
     <!--
       Build the portable command-line payload used only by the SDK package. The command-line
       project's own multi-RID tool package remains unchanged.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=false" Targets="Restore;Publish" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="..\..\main\Core\Yardarm.CommandLine\Yardarm.CommandLine.csproj" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);RuntimeIdentifier=any;SelfContained=False;PublishReadyToRun=false" Targets="Restore;Publish" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
     </MSBuild>
   </Target>
 
   <Target Name="CollectYardarmCommandLine"
-          DependsOnTargets="DefineYardarmCommandLineRids;BuildYardarmCommandLine">
+          DependsOnTargets="BuildYardarmCommandLine">
     <!--
       Collect the files to be published. By using ComputeFilesToPublish and PublishItemsOutputGroup we skip
       the cost of actually copying the files to a publish directory, instead it collects the returned items
       and we can load them directly into the NuGet package.
     -->
-    <MSBuild Projects="@(_YardarmCommandLine)" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);SelfContained=False;PublishReadyToRun=false" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
+    <MSBuild Projects="..\..\main\Core\Yardarm.CommandLine\Yardarm.CommandLine.csproj" Properties="Configuration=$(Configuration);TargetFramework=$(YardarmTargetFramework);RuntimeIdentifier=any;SelfContained=False;PublishReadyToRun=false" Targets="PublishItemsOutputGroup" BuildInParallel="$(BuildInParallel)" SkipNonexistentProjects="false" ContinueOnError="false">
       <Output TaskParameter="TargetOutputs" ItemName="_YardarmCommandLineFiles" />
     </MSBuild>
 

--- a/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmCommonTask.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.IO;
+using System.Text;
 using Microsoft.Build.Framework;
 
 namespace Yardarm.Build.Tasks
@@ -17,6 +18,9 @@ namespace Yardarm.Build.Tasks
         public string? TargetFramework { get; set; }
 
         public string? BaseIntermediateOutputPath { get; set; }
+
+        [Required]
+        public string? YardarmToolPath { get; set; }
 
         public string? AdditionalProperties { get; set; }
 
@@ -42,12 +46,21 @@ namespace Yardarm.Build.Tasks
                 return false;
             }
 
+            if (string.IsNullOrWhiteSpace(YardarmToolPath))
+            {
+                Log.LogError("YardarmToolPath is required.");
+                return false;
+            }
+
             return true;
         }
 
         protected override string GenerateCommandLineCommands()
         {
-            var builder = new StringBuilder(Verb);
+            var builder = new StringBuilder();
+            builder.AppendQuoted(Path.Combine(YardarmToolPath!, "Yardarm.CommandLine.dll"));
+            builder.Append(' ');
+            builder.Append(Verb);
             builder.AppendFormat(" -n {0}", AssemblyName);
             builder.AppendFormat(" --root-namespace {0}", RootNamespace);
             builder.AppendFormat(" -f {0}", TargetFramework);

--- a/src/sdk/Yardarm.Sdk/YardarmTask.cs
+++ b/src/sdk/Yardarm.Sdk/YardarmTask.cs
@@ -12,8 +12,7 @@ namespace Yardarm.Build.Tasks
 
         protected override string GenerateFullPathToTool() => ToolName;
 
-        protected override string ToolName =>
-            (int) Environment.OSVersion.Platform > 3 ? "Yardarm.CommandLine" : "Yardarm.CommandLine.exe";
+        protected override string ToolName => "dotnet";
 
 
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)


### PR DESCRIPTION
Motivation
----------
The SDK package embedded separate ReadyToRun command-line payloads for each supported runtime, increasing package size and limiting supported platforms.

Modifications
-------------
- Package one framework-dependent `any` command-line payload and launch it through `dotnet`.
- Preserve the existing `Yardarm.CommandLine` project and its NuGet packaging unchanged.
- Point SDK defaults and the generation fixture at the portable payload, and document runtime/platform requirements.

Results
-------
- The generated SDK package is 10.9 MB and supports Windows, Linux, and macOS on x64 and ARM64.