### PR TITLE
Avoid repeated OpenAPI reference reflection

### DIFF
--- a/src/main/Core/Yardarm.UnitTests/Spec/OpenApiReferenceHolderAccessorTests.cs
+++ b/src/main/Core/Yardarm.UnitTests/Spec/OpenApiReferenceHolderAccessorTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.OpenApi;
+using Xunit;
+using Yardarm.Spec;
+
+namespace Yardarm.UnitTests.Spec;
+
+public class OpenApiReferenceHolderAccessorTests
+{
+    [Fact]
+    public void GetReference_KnownProxy_ReturnsReference()
+    {
+        var document = new OpenApiDocument();
+        var reference = new OpenApiSchemaReference("schema", document, null!);
+
+        BaseOpenApiReference result = OpenApiReferenceHolderAccessor.GetReference(reference);
+
+        result.Should().BeSameAs(reference.Reference);
+    }
+
+    [Fact]
+    public void GetTarget_KnownProxy_ReturnsResolvedTarget()
+    {
+        var schema = new OpenApiSchema();
+        var document = new OpenApiDocument
+        {
+            Workspace = new OpenApiWorkspace(),
+            Components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>
+                {
+                    ["schema"] = schema
+                }
+            }
+        };
+        document.RegisterComponents();
+        var reference = new OpenApiSchemaReference("schema", document, null!);
+
+        IOpenApiElement result = OpenApiReferenceHolderAccessor.GetTarget(reference);
+
+        result.Should().BeSameAs(schema);
+    }
+
+    [Fact]
+    public void GetReference_UnknownHolder_ReturnsReference()
+    {
+        var holder = new CustomReferenceHolder();
+
+        BaseOpenApiReference result = OpenApiReferenceHolderAccessor.GetReference(holder);
+
+        result.Should().BeSameAs(holder.Reference);
+    }
+
+    [Fact]
+    public void GetTarget_UnknownHolder_ReturnsTarget()
+    {
+        var holder = new CustomReferenceHolder();
+
+        IOpenApiElement result = OpenApiReferenceHolderAccessor.GetTarget(holder);
+
+        result.Should().BeSameAs(holder.Target);
+    }
+
+    [Fact]
+    public void GetReference_InvalidUnknownHolder_ThrowsDescriptiveException()
+    {
+        var holder = new InvalidReferenceHolder();
+
+        Action action = () => OpenApiReferenceHolderAccessor.GetReference(holder);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*InvalidReferenceHolder*Reference*BaseOpenApiReference*");
+    }
+
+    private sealed class CustomReferenceHolder : IOpenApiReferenceHolder
+    {
+        public JsonSchemaReference Reference { get; } = new();
+
+        public IOpenApiSchema Target { get; } = new OpenApiSchema();
+
+        public bool UnresolvedReference => false;
+
+        public void SerializeAsV2(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV3(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV31(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV32(IOpenApiWriter writer)
+        {
+        }
+    }
+
+    private sealed class InvalidReferenceHolder : IOpenApiReferenceHolder
+    {
+        public string Reference => string.Empty;
+
+        public string Target => string.Empty;
+
+        public bool UnresolvedReference => false;
+
+        public void SerializeAsV2(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV3(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV31(IOpenApiWriter writer)
+        {
+        }
+
+        public void SerializeAsV32(IOpenApiWriter writer)
+        {
+        }
+    }
+}

--- a/src/main/Core/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
+++ b/src/main/Core/Yardarm/Generation/Internal/TypeGeneratorRegistry`1.cs
@@ -63,22 +63,15 @@ internal class TypeGeneratorRegistry<TElement> : ITypeGeneratorRegistry<TElement
     private static ITypeGenerator CreateTypeGenerator(ILocatedOpenApiElement<TElement> element, TypeGeneratorRegistry<TElement> registry)
     {
         if (LocatedElementEqualityComparer<TElement>.IsReferenceEqualDefault &&
-            element.Element is IOpenApiReferenceHolder)
+            element.Element is IOpenApiReferenceHolder referenceHolder &&
+            OpenApiReferenceHolderAccessor.GetReference(referenceHolder)?.Id is { } referenceId)
         {
             // When making the new type generator with the factory for a reference, we must ensure
             // that we are using the referenced component path for the ILocatedOpenApiElement.
 
-            var referenceId = element.Element.GetReferenceId();
-            if (referenceId != null)
+            if (OpenApiReferenceHolderAccessor.GetTarget(referenceHolder) is TElement resolvedTarget)
             {
-                // TODO: This is a bit of a hack, but it works for now. We should do this without using reflection.
-
-                // Get the resolved target via the Target property on the reference holder
-                var targetProp = element.Element.GetType().GetProperty("Target");
-                if (targetProp?.GetValue(element.Element) is TElement resolvedTarget)
-                {
-                    element = LocatedOpenApiElement.CreateRoot(resolvedTarget, referenceId);
-                }
+                element = LocatedOpenApiElement.CreateRoot(resolvedTarget, referenceId);
             }
         }
 

--- a/src/main/Core/Yardarm/Spec/OpenApiReferenceExtensions.cs
+++ b/src/main/Core/Yardarm/Spec/OpenApiReferenceExtensions.cs
@@ -25,21 +25,12 @@ public static class OpenApiReferenceExtensions
 
         /// <summary>
         /// Gets the BaseOpenApiReference from an element if it is a reference holder.
-        /// Uses reflection to access the Reference property since the generic interface
-        /// requires knowing the concrete reference type at compile time.
         /// </summary>
         private BaseOpenApiReference? GetBaseReference()
         {
-            if (element is not IOpenApiReferenceHolder)
-            {
-                return null;
-            }
-
-            // TODO: Redesign this to avoid reflection when retrieving the reference.
-            // All reference holders in Microsoft.OpenApi derive from BaseOpenApiReferenceHolder<T,U,V>
-            // which has a public property Reference of type V : BaseOpenApiReference.
-            var refProp = element.GetType().GetProperty("Reference");
-            return refProp?.GetValue(element) as BaseOpenApiReference;
+            return element is IOpenApiReferenceHolder referenceHolder
+                ? OpenApiReferenceHolderAccessor.GetReference(referenceHolder)
+                : null;
         }
     }
 }

--- a/src/main/Core/Yardarm/Spec/OpenApiReferenceHolderAccessor.cs
+++ b/src/main/Core/Yardarm/Spec/OpenApiReferenceHolderAccessor.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.OpenApi;
+using Yardarm.Helpers;
+
+namespace Yardarm.Spec;
+
+internal static class OpenApiReferenceHolderAccessor
+{
+    private static readonly ConcurrentDictionary<Type, FallbackAccessor> s_fallbackAccessors = new();
+
+    public static BaseOpenApiReference? GetReference(IOpenApiReferenceHolder holder)
+    {
+        ArgumentNullException.ThrowIfNull(holder);
+
+        return holder switch
+        {
+            OpenApiCallbackReference reference => reference.Reference,
+            OpenApiExampleReference reference => reference.Reference,
+            OpenApiHeaderReference reference => reference.Reference,
+            OpenApiLinkReference reference => reference.Reference,
+            OpenApiMediaTypeReference reference => reference.Reference,
+            OpenApiParameterReference reference => reference.Reference,
+            OpenApiPathItemReference reference => reference.Reference,
+            OpenApiRequestBodyReference reference => reference.Reference,
+            OpenApiResponseReference reference => reference.Reference,
+            OpenApiSchemaReference reference => reference.Reference,
+            OpenApiSecuritySchemeReference reference => reference.Reference,
+            OpenApiTagReference reference => reference.Reference,
+            _ => s_fallbackAccessors.GetOrAdd(holder.GetType(), CreateFallbackAccessor).GetReference(holder)
+        };
+    }
+
+    public static IOpenApiElement? GetTarget(IOpenApiReferenceHolder holder)
+    {
+        ArgumentNullException.ThrowIfNull(holder);
+
+        return holder switch
+        {
+            OpenApiCallbackReference reference => reference.Target,
+            OpenApiExampleReference reference => reference.Target,
+            OpenApiHeaderReference reference => reference.Target,
+            OpenApiLinkReference reference => reference.Target,
+            OpenApiMediaTypeReference reference => reference.Target,
+            OpenApiParameterReference reference => reference.Target,
+            OpenApiPathItemReference reference => reference.Target,
+            OpenApiRequestBodyReference reference => reference.Target,
+            OpenApiResponseReference reference => reference.Target,
+            OpenApiSchemaReference reference => reference.Target,
+            OpenApiSecuritySchemeReference reference => reference.Target,
+            OpenApiTagReference reference => reference.Target,
+            _ => s_fallbackAccessors.GetOrAdd(holder.GetType(), CreateFallbackAccessor).GetTarget(holder)
+        };
+    }
+
+    private static FallbackAccessor CreateFallbackAccessor(Type holderType) =>
+        new(
+            CreateGetter<BaseOpenApiReference>(holderType, "Reference"),
+            CreateGetter<IOpenApiElement>(holderType, "Target"));
+
+    private static AccessorProperty<T> CreateGetter<T>(Type holderType, string propertyName)
+        where T : class
+    {
+        PropertyInfo? property = holderType.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        if (property?.GetMethod is null || property.GetIndexParameters().Length != 0 ||
+            !typeof(T).IsAssignableFrom(property.PropertyType))
+        {
+            return new AccessorProperty<T>(
+                $"Reference holder type '{holderType.FullName}' must expose a public, non-indexed " +
+                $"{propertyName} property assignable to '{typeof(T).FullName}'.");
+        }
+
+        var holder = Expression.Parameter(typeof(IOpenApiReferenceHolder), "holder");
+        var propertyAccess = Expression.Property(Expression.Convert(holder, holderType), property);
+        var convertedProperty = Expression.Convert(propertyAccess, typeof(T));
+
+        return new AccessorProperty<T>(
+            Expression.Lambda<Func<IOpenApiReferenceHolder, T?>>(convertedProperty, holder).Compile());
+    }
+
+    private sealed class FallbackAccessor(
+        AccessorProperty<BaseOpenApiReference> reference,
+        AccessorProperty<IOpenApiElement> target)
+    {
+        public BaseOpenApiReference? GetReference(IOpenApiReferenceHolder holder) => reference.Get(holder);
+
+        public IOpenApiElement? GetTarget(IOpenApiReferenceHolder holder) => target.Get(holder);
+    }
+
+    private sealed class AccessorProperty<T>
+        where T : class
+    {
+        private readonly Func<IOpenApiReferenceHolder, T?>? _getter;
+        private readonly string? _errorMessage;
+
+        public AccessorProperty(Func<IOpenApiReferenceHolder, T?> getter)
+        {
+            _getter = getter;
+        }
+
+        public AccessorProperty(string errorMessage)
+        {
+            _errorMessage = errorMessage;
+        }
+
+        public T? Get(IOpenApiReferenceHolder holder)
+        {
+            if (_getter is not null)
+            {
+                return _getter(holder);
+            }
+
+            ThrowHelpers.ThrowInvalidOperationException(_errorMessage);
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Microsoft.OpenApi 3.9.0 exposes reference metadata and resolved targets through generic interfaces, causing Yardarm to use uncached reflection for both values.

Modifications
-------------
- Added a centralized accessor with direct handling for the 12 built-in reference proxy types.
- Added cached, validated reflection accessors for third-party reference-holder implementations.
- Updated reference extensions and type generation to use the shared accessor.
- Added focused coverage for known proxies, custom holders, and malformed holders.

Results
-------
- Built-in OpenAPI reference proxies no longer use reflection for reference or target access.