### PR TITLE
Track unknown case values after deserialization

### DIFF
--- a/src/main/Core/Yardarm.Client/Models/UnknownCase.extdunions.cs
+++ b/src/main/Core/Yardarm.Client/Models/UnknownCase.extdunions.cs
@@ -1,20 +1,17 @@
-﻿namespace RootNamespace.Models
+﻿namespace RootNamespace.Models;
+
+/// <summary>
+/// May be added to a union type to allow deserialization of unknown union cases to a placeholder type, rather than throwing an exception.
+/// </summary>
+/// <param name="CaseName">The name of the unknown case.</param>
+/// <param name="Value">The value of the unknown case.</param>
+/// <remarks>
+/// <para>
+/// The <paramref name="CaseName"/> and <paramref name="Value"/> properties are optional, and may be null if the unknown case does not have a name or value.
+/// The type of the <paramref name="Value"/> property depends on the deserializer used.
+/// </para>
+/// </remarks>
+public sealed record UnknownCase(string? CaseName, object? Value)
 {
-    /// <summary>
-    /// May be added to a union type to allow deserialization of unknown union cases to a placeholder type, rather than throwing an exception.
-    /// </summary>
-    public sealed class UnknownCase
-    {
-        /// <summary>
-        /// Singleton instance of <see cref="UnknownCase"/>. This is the only instance of this type, and is used to indicate that a union case is unknown.
-        /// </summary>
-        public static UnknownCase Value { get; } = new();
-
-        // Prevent construction outside of this class, so that the only instance is the singleton Value property.
-        private UnknownCase()
-        {
-        }
-
-        public override string ToString() => nameof(UnknownCase);
-    }
+    public UnknownCase() : this(null, null) { }
 }

--- a/src/main/NewtonsoftJson/Yardarm.NewtonsoftJson.Client.UnitTests/JsonExternallyDiscriminatedUnionConverterTests.cs
+++ b/src/main/NewtonsoftJson/Yardarm.NewtonsoftJson.Client.UnitTests/JsonExternallyDiscriminatedUnionConverterTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using RootNamespace.Internal;
 using RootNamespace.Models;
 using RootNamespace.Serialization.Json;
@@ -205,27 +206,51 @@ public class JsonExternallyDiscriminatedUnionConverterTests
         Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<TestUnion>(json, s_settings));
     }
 
-    [Theory]
-    [InlineData("""
+    [Fact]
+    public void Deserialize_HasUnknownCase_WithCaseNameAndValue_Returned()
+    {
+        // Arrange
+
+        const string json = """
         {
             "caseC": {
                 "value": "unknown"
             }
         }
-        """)]
-    [InlineData("""
-        {
-        }
-        """)]
-    public void Deserialize_HasUnknownCase_Returned(string json)
-    {
+        """;
+
         // Act
 
         var result = JsonConvert.DeserializeObject<TestUnionWithUnknown>(json, s_settings);
 
         // Assert
 
-        Assert.IsType<UnknownCase>(result.Value);
+        var unknownCase = Assert.IsType<UnknownCase>(result.Value);
+        Assert.Equal("caseC", unknownCase.CaseName);
+
+        var value = Assert.IsType<JObject>(unknownCase.Value);
+        Assert.Equal("unknown", value["value"]?.Value<string>());
+    }
+
+    [Fact]
+    public void Deserialize_HasUnknownCase_EmptyObject_Returned()
+    {
+        // Arrange
+
+        const string json = """
+        {
+        }
+        """;
+
+        // Act
+
+        var result = JsonConvert.DeserializeObject<TestUnionWithUnknown>(json, s_settings);
+
+        // Assert
+
+        var unknownCase = Assert.IsType<UnknownCase>(result.Value);
+        Assert.Null(unknownCase.CaseName);
+        Assert.Null(unknownCase.Value);
     }
 
     [Fact]
@@ -345,7 +370,7 @@ public class JsonExternallyDiscriminatedUnionConverterTests
     {
         // Arrange
 
-        var union = new TestUnionWithUnknown(UnknownCase.Value);
+        var union = new TestUnionWithUnknown(new UnknownCase());
 
         // Act
 
@@ -354,6 +379,60 @@ public class JsonExternallyDiscriminatedUnionConverterTests
         // Assert
 
         Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public void Serialize_UnknownCase_WithCaseNameAndJObject()
+    {
+        // Arrange
+
+        var payload = JObject.Parse("""
+        {
+            "value": "unknown",
+            "metadata": {
+                "source": "api"
+            }
+        }
+        """);
+
+        var union = new TestUnionWithUnknown(new UnknownCase("caseC", payload));
+
+        // Act
+
+        string result = JsonConvert.SerializeObject(union, s_settings);
+
+        // Assert
+
+        Assert.Equal("{\"caseC\":{\"value\":\"unknown\",\"metadata\":{\"source\":\"api\"}}}", result);
+    }
+
+    [Fact]
+    public void RoundTrip_UnknownCase_WithCaseNameAndJObject()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseC": {
+                "value": "unknown",
+                "metadata": {
+                    "source": "api"
+                }
+            }
+        }
+        """;
+
+        // Act
+
+        var deserialized = JsonConvert.DeserializeObject<TestUnionWithUnknown>(json, s_settings);
+        string serialized = JsonConvert.SerializeObject(deserialized, s_settings);
+
+        // Assert
+
+        var unknownCase = Assert.IsType<UnknownCase>(deserialized.Value);
+        Assert.Equal("caseC", unknownCase.CaseName);
+        Assert.IsType<JObject>(unknownCase.Value);
+        Assert.Equal("{\"caseC\":{\"value\":\"unknown\",\"metadata\":{\"source\":\"api\"}}}", serialized);
     }
 
     [Fact]

--- a/src/main/NewtonsoftJson/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
+++ b/src/main/NewtonsoftJson/Yardarm.NewtonsoftJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using RootNamespace.Internal;
 using RootNamespace.Models;
 
@@ -40,6 +41,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
 
         object? result = null;
         string? firstPropertyName = null;
+        JToken? firstPropertyValue = null;
 
         while (reader.TokenType != JsonToken.EndObject)
         {
@@ -78,8 +80,22 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
             }
             else
             {
-                // Skip the property if it is an unknown case or we have already found a matching case
-                reader.Skip();
+                // Advance to the value token
+                if (!reader.Read())
+                {
+                    JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
+                }
+
+                if (firstPropertyValue is null)
+                {
+                    // Parse and save the first property's content in case we need it for the unknown case
+                    firstPropertyValue = JToken.ReadFrom(reader);
+                }
+                else
+                {
+                    // Skip the property if we have already found a matching case
+                    reader.Skip();
+                }
 
                 // Read to the next property or EndObject token
                 if (!reader.Read())
@@ -89,7 +105,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
             }
         }
 
-        return result ?? CreateUnknownCase(firstPropertyName);
+        return result ?? CreateUnknownCase(firstPropertyName, firstPropertyValue);
     }
 
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
@@ -114,9 +130,23 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
         {
             writer.WriteStartObject();
 
-            if (innerValue is UnknownCase)
+            if (innerValue is UnknownCase unknownCase)
             {
-                // Support round-trip serialization of the unknown case by serializing it as an empty object
+                // Support round-trip serialization of the unknown case.
+                if (unknownCase.CaseName is not null)
+                {
+                    writer.WritePropertyName(unknownCase.CaseName);
+
+                    if (unknownCase.Value is JToken unknownValue)
+                    {
+                        unknownValue.WriteTo(writer);
+                    }
+                    else
+                    {
+                        writer.WriteNull();
+                    }
+                }
+
                 writer.WriteEndObject();
                 return;
             }
@@ -144,14 +174,14 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<T> : JsonConvert
         JsonDiscriminatedUnionConverter.ThrowUnknownUnionCaseType(typeof(T), innerValue?.GetType());
     }
 
-    private static T CreateUnknownCase(string? caseName = null)
+    private static T CreateUnknownCase(string? caseName = null, object? value = null)
     {
         if (ExternallyDiscriminatedUnion<T>.UnknownCaseFactory is null)
         {
             JsonDiscriminatedUnionConverter.ThrowUnknownUnionCase(typeof(T), caseName);
         }
 
-        return ExternallyDiscriminatedUnion<T>.UnknownCaseFactory(UnknownCase.Value);
+        return ExternallyDiscriminatedUnion<T>.UnknownCaseFactory(new UnknownCase(caseName, value));
     }
 }
 

--- a/src/main/SystemTextJson/Yardarm.SystemTextJson.Client.UnitTests/JsonExternallyDiscriminatedUnionConverterTests.cs
+++ b/src/main/SystemTextJson/Yardarm.SystemTextJson.Client.UnitTests/JsonExternallyDiscriminatedUnionConverterTests.cs
@@ -205,27 +205,52 @@ public class JsonExternallyDiscriminatedUnionConverterTests
         Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<TestUnion>(json, s_options));
     }
 
-    [Theory]
-    [InlineData("""
+    [Fact]
+    public void Deserialize_HasUnknownCase_WithCaseNameAndValue_Returned()
+    {
+        // Arrange
+
+        const string json = """
         {
             "caseC": {
                 "value": "unknown"
             }
         }
-        """)]
-    [InlineData("""
-        {
-        }
-        """)]
-    public void Deserialize_HasUnknownCase_Returned(string json)
-    {
+        """;
+
         // Act
 
         var result = JsonSerializer.Deserialize<TestUnionWithUnknown>(json, s_options);
 
         // Assert
 
-        Assert.IsType<UnknownCase>(result.Value);
+        var unknownCase = Assert.IsType<UnknownCase>(result.Value);
+        Assert.Equal("caseC", unknownCase.CaseName);
+
+        var value = Assert.IsType<JsonElement>(unknownCase.Value);
+        Assert.Equal(JsonValueKind.Object, value.ValueKind);
+        Assert.Equal("unknown", value.GetProperty("value").GetString());
+    }
+
+    [Fact]
+    public void Deserialize_HasUnknownCase_EmptyObject_Returned()
+    {
+        // Arrange
+
+        const string json = """
+        {
+        }
+        """;
+
+        // Act
+
+        var result = JsonSerializer.Deserialize<TestUnionWithUnknown>(json, s_options);
+
+        // Assert
+
+        var unknownCase = Assert.IsType<UnknownCase>(result.Value);
+        Assert.Null(unknownCase.CaseName);
+        Assert.Null(unknownCase.Value);
     }
 
     [Fact]
@@ -343,7 +368,7 @@ public class JsonExternallyDiscriminatedUnionConverterTests
     {
         // Arrange
 
-        var union = new TestUnionWithUnknown(UnknownCase.Value);
+        var union = new TestUnionWithUnknown(new UnknownCase());
 
         // Act
 
@@ -352,6 +377,60 @@ public class JsonExternallyDiscriminatedUnionConverterTests
         // Assert
 
         Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public void Serialize_UnknownCase_WithCaseNameAndJsonElement()
+    {
+        // Arrange
+
+        using var payloadDocument = JsonDocument.Parse("""
+        {
+            "value": "unknown",
+            "metadata": {
+                "source": "api"
+            }
+        }
+        """);
+
+        var union = new TestUnionWithUnknown(new UnknownCase("caseC", payloadDocument.RootElement.Clone()));
+
+        // Act
+
+        string result = JsonSerializer.Serialize(union, s_options);
+
+        // Assert
+
+        Assert.Equal("{\"caseC\":{\"value\":\"unknown\",\"metadata\":{\"source\":\"api\"}}}", result);
+    }
+
+    [Fact]
+    public void RoundTrip_UnknownCase_WithCaseNameAndJsonElement()
+    {
+        // Arrange
+
+        const string json = """
+        {
+            "caseC": {
+                "value": "unknown",
+                "metadata": {
+                    "source": "api"
+                }
+            }
+        }
+        """;
+
+        // Act
+
+        var deserialized = JsonSerializer.Deserialize<TestUnionWithUnknown>(json, s_options);
+        string serialized = JsonSerializer.Serialize(deserialized, s_options);
+
+        // Assert
+
+        var unknownCase = Assert.IsType<UnknownCase>(deserialized.Value);
+        Assert.Equal("caseC", unknownCase.CaseName);
+        Assert.IsType<JsonElement>(unknownCase.Value);
+        Assert.Equal("{\"caseC\":{\"value\":\"unknown\",\"metadata\":{\"source\":\"api\"}}}", serialized);
     }
 
     [Fact]

--- a/src/main/SystemTextJson/Yardarm.SystemTextJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
+++ b/src/main/SystemTextJson/Yardarm.SystemTextJson.Client/Serialization/Json/JsonExternallyDiscriminatedUnionConverter.extdunions.cs
@@ -38,6 +38,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
         T? result = default;
         bool foundResult = false;
         string? firstPropertyName = null;
+        JsonElement? firstPropertyValue = null;
 
         while (reader.TokenType != JsonTokenType.EndObject)
         {
@@ -78,8 +79,22 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
             }
             else
             {
-                // Skip the property if it is an unknown case or we have already found a matching case
-                reader.Skip();
+                // Advance to the value token
+                if (!reader.Read())
+                {
+                    JsonDiscriminatedUnionConverter.ThrowInvalidUnionJson(typeof(T));
+                }
+
+                if (firstPropertyValue is null)
+                {
+                    // Parse and save the first matching property's content in case we need it for the unknown case
+                    firstPropertyValue = JsonElement.ParseValue(ref reader);
+                }
+                else
+                {
+                    // Skip the property if we have already found a matching case
+                    reader.Skip();
+                }
 
                 // Read to the next property or EndObject token
                 if (!reader.Read())
@@ -89,7 +104,7 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
             }
         }
 
-        return foundResult ? result : CreateUnknownCase(firstPropertyName);
+        return foundResult ? result : CreateUnknownCase(firstPropertyName, firstPropertyValue);
     }
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
@@ -102,9 +117,24 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
         {
             writer.WriteStartObject();
 
-            if (innerValue is UnknownCase)
+            if (innerValue is UnknownCase unknownCase)
             {
-                // Support round-trip serialization of the unknown case by serializing it as an empty object
+                // Support round-trip serialization of the unknown case
+
+                if (unknownCase.CaseName is not null)
+                {
+                    writer.WritePropertyName(unknownCase.CaseName);
+
+                    if (unknownCase.Value is JsonElement unknownValue)
+                    {
+                        unknownValue.WriteTo(writer);
+                    }
+                    else
+                    {
+                        writer.WriteNullValue();
+                    }
+                }
+
                 writer.WriteEndObject();
                 return;
             }
@@ -133,14 +163,14 @@ internal sealed class JsonExternallyDiscriminatedUnionConverter<[DynamicallyAcce
         JsonDiscriminatedUnionConverter.ThrowUnknownUnionCaseType(typeof(T), innerValue?.GetType());
     }
 
-    private static T CreateUnknownCase(string? caseName = null)
+    private static T CreateUnknownCase(string? caseName = null, object? value = null)
     {
         if (ExternallyDiscriminatedUnion<T>.UnknownCaseFactory is null)
         {
             JsonDiscriminatedUnionConverter.ThrowUnknownUnionCase(typeof(T), caseName);
         }
 
-        return ExternallyDiscriminatedUnion<T>.UnknownCaseFactory(UnknownCase.Value);
+        return ExternallyDiscriminatedUnion<T>.UnknownCaseFactory(new UnknownCase(caseName, value));
     }
 }
 


### PR DESCRIPTION
Motivation
----------
Allow clients to see information about the unknown case that can't be deserialized.

Modifications
-------------
- Add an optional case name and value to UnknownCase, dropping the singleton
- Deserialize the first property into the UnknownCase, when present and no later property matches a case, for both Newtonsoft and STJ
- Also support serializing contents, when present, for round-trip consistency
- Add/adjust unit tests